### PR TITLE
feat: add rename/delete team options with extracted dialog components

### DIFF
--- a/apps/frontend/src/app/integrations/page.tsx
+++ b/apps/frontend/src/app/integrations/page.tsx
@@ -3,6 +3,15 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
   Dialog,
@@ -22,7 +31,9 @@ import {
   EyeOff,
   AlertTriangle,
   ExternalLink,
+  Info,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { SiGithub, SiJira, SiLinear, SiClickup, SiAsana } from '@icons-pack/react-simple-icons';
 import Image from 'next/image';
 import { IntegrationsSkeleton } from '@/components/ui/skeleton-helpers';
@@ -124,7 +135,6 @@ export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [successMsg, setSuccessMsg] = useState('');
 
   // Org + teams for mappings
   const [orgId, setOrgId] = useState<string | null>(null);
@@ -154,13 +164,7 @@ export default function IntegrationsPage() {
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [savingMapping, setSavingMapping] = useState(false);
 
-  const inputClass =
-    'flex h-10 w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--input-bg)] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/30 transition-all';
-
-  const showSuccess = (msg: string) => {
-    setSuccessMsg(msg);
-    setTimeout(() => setSuccessMsg(''), 3000);
-  };
+  const [connectError, setConnectError] = useState('');
 
   const loadData = useCallback(async () => {
     try {
@@ -191,7 +195,7 @@ export default function IntegrationsPage() {
     if (!connectProvider || !connectToken.trim()) return;
     const meta = getProviderMeta(connectProvider);
     setConnecting(true);
-    setError('');
+    setConnectError('');
     try {
       await createIntegration({
         provider: connectProvider,
@@ -203,10 +207,11 @@ export default function IntegrationsPage() {
       setConnectToken('');
       setConnectWorkspace('');
       setShowToken(false);
+      setConnectError('');
       await loadData();
-      showSuccess(`${meta?.name ?? connectProvider} connected successfully.`);
+      toast.success(`${meta?.name ?? connectProvider} connected successfully.`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to connect integration');
+      setConnectError(err instanceof Error ? err.message : 'Failed to connect integration');
     } finally {
       setConnecting(false);
     }
@@ -223,7 +228,7 @@ export default function IntegrationsPage() {
       setDisconnectProvider(null);
       setIntegrations((prev) => prev.filter((i) => i.provider !== disconnectProvider));
       if (expandedProvider === disconnectProvider) setExpandedProvider(null);
-      showSuccess(`${meta?.name ?? disconnectProvider} disconnected.`);
+      toast.success(`${meta?.name ?? disconnectProvider} disconnected.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to disconnect integration');
     } finally {
@@ -284,7 +289,7 @@ export default function IntegrationsPage() {
       const mappings = await getProjectMappings(addMappingProvider);
       setMappingsMap((prev) => ({ ...prev, [addMappingProvider]: mappings }));
       setAddMappingProvider(null);
-      showSuccess('Project mapping added.');
+      toast.success('Project mapping added.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create mapping');
     } finally {
@@ -301,7 +306,7 @@ export default function IntegrationsPage() {
         ...prev,
         [provider]: (prev[provider] ?? []).filter((m) => m.id !== mappingId),
       }));
-      showSuccess('Mapping removed.');
+      toast.success('Mapping removed.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to remove mapping');
     }
@@ -329,12 +334,6 @@ export default function IntegrationsPage() {
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400">
           {error}
-        </div>
-      )}
-
-      {successMsg && (
-        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-400">
-          {successMsg}
         </div>
       )}
 
@@ -535,48 +534,67 @@ export default function IntegrationsPage() {
       )}
 
       {/* Connect Dialog */}
-      <Dialog open={!!connectProvider} onOpenChange={(open) => { if (!open) setConnectProvider(null); }}>
+      <Dialog open={!!connectProvider} onOpenChange={(open) => {
+        if (!open) {
+          setConnectProvider(null);
+          setConnectError('');
+        }
+      }}>
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              Connect {connectProvider ? getProviderMeta(connectProvider)?.name : ''}
-            </DialogTitle>
-            <DialogDescription>
-              Provide your API credentials to connect this integration.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            {connectProvider && (() => {
-              const meta = getProviderMeta(connectProvider);
-              if (!meta) return null;
-              return (
-                <>
+          {connectProvider && (() => {
+            const meta = getProviderMeta(connectProvider);
+            if (!meta) return null;
+            return (
+              <>
+                <DialogHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center justify-center rounded-lg border bg-muted p-2">
+                      <ProviderIcon providerId={connectProvider} size={24} />
+                    </div>
+                    <div>
+                      <DialogTitle>Connect {meta.name}</DialogTitle>
+                      <DialogDescription>
+                        Provide your API credentials to connect this integration.
+                      </DialogDescription>
+                    </div>
+                  </div>
+                </DialogHeader>
+                <div className="flex flex-col gap-4 py-4">
                   {/* Help text */}
-                  <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 text-sm text-blue-300">
-                    <p>{meta.helpText}</p>
-                    <a
-                      href={meta.helpUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300 mt-1 underline underline-offset-2"
-                    >
-                      Open settings
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
+                  <div className="flex gap-3 rounded-lg border bg-muted/50 p-3">
+                    <Info className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
+                    <div className="text-sm text-muted-foreground">
+                      <p>{meta.helpText}</p>
+                      <a
+                        href={meta.helpUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-primary hover:underline mt-1"
+                      >
+                        Open settings
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
                   </div>
 
+                  {/* Error inside dialog */}
+                  {connectError && (
+                    <div className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+                      <AlertTriangle className="h-4 w-4 mt-0.5 text-destructive flex-shrink-0" />
+                      <p className="text-sm text-destructive">{connectError}</p>
+                    </div>
+                  )}
+
                   {/* Token input */}
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium text-foreground">
-                      API Token / Personal Access Token
-                    </label>
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">API Token / Personal Access Token</label>
                     <div className="relative">
-                      <input
+                      <Input
                         type={showToken ? 'text' : 'password'}
                         value={connectToken}
                         onChange={(e) => setConnectToken(e.target.value)}
                         placeholder="Paste your token here"
-                        className={`${inputClass} pr-10`}
+                        className="pr-10"
                         autoComplete="off"
                       />
                       <button
@@ -584,57 +602,51 @@ export default function IntegrationsPage() {
                         onClick={() => setShowToken(!showToken)}
                         className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
                       >
-                        {showToken ? (
-                          <EyeOff className="h-4 w-4" />
-                        ) : (
-                          <Eye className="h-4 w-4" />
-                        )}
+                        {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                       </button>
                     </div>
                   </div>
 
                   {/* Workspace input */}
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium text-foreground">
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">
                       {meta.workspaceLabel}
                       {!meta.workspaceRequired && (
                         <span className="text-muted-foreground font-normal ml-1">(optional)</span>
                       )}
                     </label>
-                    <input
-                      type="text"
+                    <Input
                       value={connectWorkspace}
                       onChange={(e) => setConnectWorkspace(e.target.value)}
                       placeholder={meta.workspacePlaceholder}
-                      className={inputClass}
                     />
                   </div>
-                </>
-              );
-            })()}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" size="sm" onClick={() => setConnectProvider(null)}>
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleConnect}
-              disabled={
-                connecting ||
-                !connectToken.trim() ||
-                (!!connectProvider &&
-                  !!getProviderMeta(connectProvider)?.workspaceRequired &&
-                  !connectWorkspace.trim())
-              }
-            >
-              {connecting ? (
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          </DialogFooter>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setConnectProvider(null)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleConnect}
+                    disabled={
+                      connecting ||
+                      !connectToken.trim() ||
+                      (meta.workspaceRequired && !connectWorkspace.trim())
+                    }
+                  >
+                    {connecting ? (
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    ) : (
+                      <>
+                        <Plug className="h-4 w-4 mr-2" />
+                        Connect
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </>
+            );
+          })()}
         </DialogContent>
       </Dialog>
 
@@ -684,55 +696,58 @@ export default function IntegrationsPage() {
               Map an external project to a Tandemu team to sync issues.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          <div className="flex flex-col gap-4 py-4">
             {loadingProjects ? (
               <div className="flex items-center justify-center py-6">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
               </div>
             ) : (
               <>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium text-foreground">External Project</label>
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">External Project</label>
                   {externalProjects.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
                       No projects found. Verify your token has the right permissions.
                     </p>
                   ) : (
-                    <select
-                      value={selectedExternalProject}
-                      onChange={(e) => setSelectedExternalProject(e.target.value)}
-                      className={inputClass}
-                    >
-                      <option value="">Select a project...</option>
-                      {externalProjects.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                          {p.key ? ` (${p.key})` : ''}
-                        </option>
-                      ))}
-                    </select>
+                    <Select value={selectedExternalProject} onValueChange={setSelectedExternalProject}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a project..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {externalProjects.map((p) => (
+                            <SelectItem key={p.id} value={p.id}>
+                              {p.name}{p.key ? ` (${p.key})` : ''}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
                   )}
                 </div>
 
-                <div className="space-y-2">
-                  <label className="text-sm font-medium text-foreground">Tandemu Team</label>
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">Tandemu Team</label>
                   {teams.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
-                      No teams found. Create a team in Settings first.
+                      No teams found. Create a team first.
                     </p>
                   ) : (
-                    <select
-                      value={selectedTeamId}
-                      onChange={(e) => setSelectedTeamId(e.target.value)}
-                      className={inputClass}
-                    >
-                      <option value="">Select a team...</option>
-                      {teams.map((t) => (
-                        <option key={t.id} value={t.id}>
-                          {t.name}
-                        </option>
-                      ))}
-                    </select>
+                    <Select value={selectedTeamId} onValueChange={setSelectedTeamId}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a team..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {teams.map((t) => (
+                            <SelectItem key={t.id} value={t.id}>
+                              {t.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
                   )}
                 </div>
               </>

--- a/apps/frontend/src/app/teams/page.tsx
+++ b/apps/frontend/src/app/teams/page.tsx
@@ -4,39 +4,24 @@ import { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { Layers, Plus, Users, Trash2, UserPlus, ArrowLeft, UserMinus, Mail, Clock, ChevronsUpDown, Check } from 'lucide-react';
-import { cn } from '@/lib/utils';
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Layers, Plus, Users, Trash2, UserPlus, ArrowLeft, UserMinus, Mail, Clock, MoreHorizontal, Pencil } from 'lucide-react';
 import { TeamsSkeleton } from '@/components/ui/skeleton-helpers';
+import { CreateTeamDialog } from '@/components/teams/create-team-dialog';
+import { DeleteTeamDialog } from '@/components/teams/delete-team-dialog';
+import { RenameTeamDialog } from '@/components/teams/rename-team-dialog';
+import { AddMemberDialog } from '@/components/teams/add-member-dialog';
 import {
   getOrganizations,
   getTeams,
-  createTeam,
-  deleteTeam,
   getTeamMembers,
-  addTeamMember,
   removeTeamMember,
   getMembers,
   getInvites,
@@ -63,17 +48,11 @@ export default function TeamsPage() {
   const [teamInvites, setTeamInvites] = useState<Invite[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
 
-  // Create team dialog
+  // Dialog states
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [newTeamName, setNewTeamName] = useState('');
-  const [newTeamDescription, setNewTeamDescription] = useState('');
-  const [creating, setCreating] = useState(false);
-
-  // Add member dialog
   const [showAddMemberDialog, setShowAddMemberDialog] = useState(false);
-  const [selectedUserId, setSelectedUserId] = useState('');
-  const [addingMember, setAddingMember] = useState(false);
-  const [memberComboboxOpen, setMemberComboboxOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<TeamWithMembers | null>(null);
+  const [renameTarget, setRenameTarget] = useState<TeamWithMembers | null>(null);
 
   const loadTeams = useCallback(async (orgId: string) => {
     try {
@@ -86,7 +65,6 @@ export default function TeamsPage() {
       const pending = inviteList.filter((inv) => inv.status === 'pending');
       setPendingInvites(pending);
 
-      // Load member counts for each team and count pending invites per team
       const teamsWithCounts = await Promise.all(
         teamList.map(async (team) => {
           try {
@@ -119,40 +97,6 @@ export default function TeamsPage() {
       .finally(() => setLoading(false));
   }, [loadTeams]);
 
-  const handleCreateTeam = async () => {
-    if (!org || !newTeamName.trim()) return;
-    setCreating(true);
-    setError('');
-    try {
-      await createTeam(org.id, {
-        name: newTeamName.trim(),
-        description: newTeamDescription.trim() || undefined,
-      });
-      await loadTeams(org.id);
-      setShowCreateDialog(false);
-      setNewTeamName('');
-      setNewTeamDescription('');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create team');
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleDeleteTeam = async (teamId: string) => {
-    if (!org) return;
-    setError('');
-    try {
-      await deleteTeam(org.id, teamId);
-      if (selectedTeam?.id === teamId) {
-        setSelectedTeam(null);
-      }
-      await loadTeams(org.id);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete team');
-    }
-  };
-
   const handleSelectTeam = async (team: TeamWithMembers) => {
     if (!org) return;
     setSelectedTeam(team);
@@ -169,24 +113,6 @@ export default function TeamsPage() {
     }
   };
 
-  const handleAddMember = async () => {
-    if (!org || !selectedTeam || !selectedUserId) return;
-    setAddingMember(true);
-    setError('');
-    try {
-      await addTeamMember(org.id, selectedTeam.id, selectedUserId);
-      const members = await getTeamMembers(org.id, selectedTeam.id);
-      setTeamMembers(members);
-      await loadTeams(org.id);
-      setShowAddMemberDialog(false);
-      setSelectedUserId('');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add member');
-    } finally {
-      setAddingMember(false);
-    }
-  };
-
   const handleRemoveMember = async (userId: string) => {
     if (!org || !selectedTeam) return;
     setError('');
@@ -200,11 +126,16 @@ export default function TeamsPage() {
     }
   };
 
+  const refreshAfterMemberChange = async () => {
+    if (!org || !selectedTeam) return;
+    const members = await getTeamMembers(org.id, selectedTeam.id);
+    setTeamMembers(members);
+    await loadTeams(org.id);
+  };
+
   const availableMembers = orgMembers.filter(
     (m: any) => !teamMembers.some((tm) => tm.userId === (m.id ?? m.userId))
   );
-
-  const selectedMember = availableMembers.find((m: any) => (m.id ?? m.userId) === selectedUserId);
 
   if (loading) {
     return (
@@ -219,20 +150,44 @@ export default function TeamsPage() {
   }
 
   // Team detail view
-  if (selectedTeam) {
+  if (selectedTeam && org) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => setSelectedTeam(null)}>
-            <ArrowLeft className="h-4 w-4 mr-1" />
-            Back
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{selectedTeam.name}</h1>
-            {selectedTeam.description && (
-              <p className="text-muted-foreground">{selectedTeam.description}</p>
-            )}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Button variant="ghost" size="sm" onClick={() => setSelectedTeam(null)}>
+              <ArrowLeft className="h-4 w-4 mr-1" />
+              Back
+            </Button>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">{selectedTeam.name}</h1>
+              {selectedTeam.description && (
+                <p className="text-muted-foreground">{selectedTeam.description}</p>
+              )}
+            </div>
           </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuGroup>
+                <DropdownMenuItem onClick={() => setRenameTarget(selectedTeam)}>
+                  <Pencil className="h-4 w-4 mr-2" />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setDeleteTarget(selectedTeam)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {error && (
@@ -337,96 +292,40 @@ export default function TeamsPage() {
           </CardContent>
         </Card>
 
-        {/* Add Member Dialog */}
-        <Dialog open={showAddMemberDialog} onOpenChange={(open) => {
-          if (!open) {
-            setShowAddMemberDialog(false);
-            setSelectedUserId('');
-            setMemberComboboxOpen(false);
-          }
-        }}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Add Member to Team</DialogTitle>
-              <DialogDescription>Select an organization member to add to this team.</DialogDescription>
-            </DialogHeader>
-            <div className="py-4">
-              {availableMembers.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  All organization members are already in this team.
-                </p>
-              ) : (
-                <Popover open={memberComboboxOpen} onOpenChange={setMemberComboboxOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={memberComboboxOpen}
-                      className="w-full justify-between font-normal"
-                    >
-                      {selectedMember
-                        ? (selectedMember as any).name || (selectedMember as any).email
-                        : 'Select a member...'}
-                      <ChevronsUpDown className="opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-                    <Command>
-                      <CommandInput placeholder="Search members..." />
-                      <CommandList>
-                        <CommandEmpty>No members found.</CommandEmpty>
-                        <CommandGroup>
-                          {availableMembers.map((m: any) => {
-                            const id = m.id ?? m.userId;
-                            const label = m.name || m.email || id;
-                            return (
-                              <CommandItem
-                                key={id}
-                                value={label}
-                                onSelect={() => {
-                                  setSelectedUserId(id);
-                                  setMemberComboboxOpen(false);
-                                }}
-                              >
-                                <div className="flex flex-col">
-                                  <span>{label}</span>
-                                  {m.email && m.name && (
-                                    <span className="text-xs text-muted-foreground">{m.email}</span>
-                                  )}
-                                </div>
-                                <Check
-                                  className={cn(
-                                    'ml-auto',
-                                    selectedUserId === id ? 'opacity-100' : 'opacity-0',
-                                  )}
-                                />
-                              </CommandItem>
-                            );
-                          })}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-              )}
-            </div>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setShowAddMemberDialog(false)}>
-                Cancel
-              </Button>
-              <Button
-                onClick={handleAddMember}
-                disabled={addingMember || !selectedUserId}
-              >
-                {addingMember ? (
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                ) : (
-                  'Add Member'
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <AddMemberDialog
+          open={showAddMemberDialog}
+          onOpenChange={setShowAddMemberDialog}
+          orgId={org.id}
+          teamId={selectedTeam.id}
+          availableMembers={availableMembers}
+          onAdded={refreshAfterMemberChange}
+        />
+
+        <DeleteTeamDialog
+          open={!!deleteTarget}
+          onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+          orgId={org.id}
+          teamId={deleteTarget?.id ?? ''}
+          teamName={deleteTarget?.name ?? ''}
+          onDeleted={() => {
+            if (selectedTeam?.id === deleteTarget?.id) setSelectedTeam(null);
+            loadTeams(org.id);
+          }}
+        />
+
+        <RenameTeamDialog
+          open={!!renameTarget}
+          onOpenChange={(open) => { if (!open) setRenameTarget(null); }}
+          orgId={org.id}
+          teamId={renameTarget?.id ?? ''}
+          currentName={renameTarget?.name ?? ''}
+          onRenamed={(newName) => {
+            if (selectedTeam?.id === renameTarget?.id) {
+              setSelectedTeam((prev) => prev ? { ...prev, name: newName } : prev);
+            }
+            loadTeams(org.id);
+          }}
+        />
       </div>
     );
   }
@@ -481,7 +380,7 @@ export default function TeamsPage() {
                     size="icon"
                     onClick={(e) => {
                       e.stopPropagation();
-                      handleDeleteTeam(team.id);
+                      setDeleteTarget(team);
                     }}
                     className="h-8 w-8 text-muted-foreground hover:text-red-400 hover:bg-red-500/10"
                   >
@@ -515,55 +414,25 @@ export default function TeamsPage() {
         </div>
       )}
 
-      {/* Create Team Dialog */}
-      <Dialog open={showCreateDialog} onOpenChange={(open) => { if (!open) setShowCreateDialog(false); }}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Team</DialogTitle>
-            <DialogDescription>Add a new team to your organization.</DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3 py-4">
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">Name</label>
-              <Input
-                value={newTeamName}
-                onChange={(e) => setNewTeamName(e.target.value)}
-                placeholder="Engineering"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    handleCreateTeam();
-                  }
-                }}
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">Description</label>
-              <Input
-                value={newTeamDescription}
-                onChange={(e) => setNewTeamDescription(e.target.value)}
-                placeholder="Optional description"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" size="sm" onClick={() => setShowCreateDialog(false)}>
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleCreateTeam}
-              disabled={creating || !newTeamName.trim()}
-            >
-              {creating ? (
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                'Create'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {org && (
+        <>
+          <CreateTeamDialog
+            open={showCreateDialog}
+            onOpenChange={setShowCreateDialog}
+            orgId={org.id}
+            onCreated={() => loadTeams(org.id)}
+          />
+
+          <DeleteTeamDialog
+            open={!!deleteTarget}
+            onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+            orgId={org.id}
+            teamId={deleteTarget?.id ?? ''}
+            teamName={deleteTarget?.name ?? ''}
+            onDeleted={() => loadTeams(org.id)}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/teams/add-member-dialog.tsx
+++ b/apps/frontend/src/components/teams/add-member-dialog.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { ChevronsUpDown, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+import { addTeamMember } from '@/lib/api';
+import type { Membership } from '@tandemu/types';
+
+interface AddMemberDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  teamId: string;
+  availableMembers: Membership[];
+  onAdded: () => void;
+}
+
+export function AddMemberDialog({ open, onOpenChange, orgId, teamId, availableMembers, onAdded }: AddMemberDialogProps) {
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [comboboxOpen, setComboboxOpen] = useState(false);
+  const [adding, setAdding] = useState(false);
+
+  const selectedMember = availableMembers.find((m: any) => (m.id ?? m.userId) === selectedUserId);
+
+  const reset = () => {
+    setSelectedUserId('');
+    setComboboxOpen(false);
+  };
+
+  const handleAdd = async () => {
+    if (!selectedUserId) return;
+    setAdding(true);
+    try {
+      await addTeamMember(orgId, teamId, selectedUserId);
+      reset();
+      onOpenChange(false);
+      onAdded();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add member');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => {
+      if (!o) reset();
+      onOpenChange(o);
+    }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Member to Team</DialogTitle>
+          <DialogDescription>Select an organization member to add to this team.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          {availableMembers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              All organization members are already in this team.
+            </p>
+          ) : (
+            <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={comboboxOpen}
+                  className="w-full justify-between font-normal"
+                >
+                  {selectedMember
+                    ? (selectedMember as any).name || (selectedMember as any).email
+                    : 'Select a member...'}
+                  <ChevronsUpDown className="opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                <Command>
+                  <CommandInput placeholder="Search members..." />
+                  <CommandList>
+                    <CommandEmpty>No members found.</CommandEmpty>
+                    <CommandGroup>
+                      {availableMembers.map((m: any) => {
+                        const id = m.id ?? m.userId;
+                        const label = m.name || m.email || id;
+                        return (
+                          <CommandItem
+                            key={id}
+                            value={label}
+                            onSelect={() => {
+                              setSelectedUserId(id);
+                              setComboboxOpen(false);
+                            }}
+                          >
+                            <div className="flex flex-col">
+                              <span>{label}</span>
+                              {m.email && m.name && (
+                                <span className="text-xs text-muted-foreground">{m.email}</span>
+                              )}
+                            </div>
+                            <Check
+                              className={cn(
+                                'ml-auto',
+                                selectedUserId === id ? 'opacity-100' : 'opacity-0',
+                              )}
+                            />
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleAdd} disabled={adding || !selectedUserId}>
+            {adding ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              'Add Member'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/teams/create-team-dialog.tsx
+++ b/apps/frontend/src/components/teams/create-team-dialog.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { createTeam } from '@/lib/api';
+
+interface CreateTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  onCreated: () => void;
+}
+
+export function CreateTeamDialog({ open, onOpenChange, orgId, onCreated }: CreateTeamDialogProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const reset = () => {
+    setName('');
+    setDescription('');
+  };
+
+  const handleCreate = async () => {
+    if (!name.trim()) return;
+    setCreating(true);
+    try {
+      await createTeam(orgId, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      });
+      reset();
+      onOpenChange(false);
+      onCreated();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create team');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => {
+      if (!o) reset();
+      onOpenChange(o);
+    }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Team</DialogTitle>
+          <DialogDescription>Add a new team to your organization.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-foreground">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Engineering"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleCreate();
+                }
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-foreground">Description</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleCreate} disabled={creating || !name.trim()}>
+            {creating ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              'Create'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/teams/delete-team-dialog.tsx
+++ b/apps/frontend/src/components/teams/delete-team-dialog.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { deleteTeam } from '@/lib/api';
+
+interface DeleteTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  teamId: string;
+  teamName: string;
+  onDeleted: () => void;
+}
+
+export function DeleteTeamDialog({ open, onOpenChange, orgId, teamId, teamName, onDeleted }: DeleteTeamDialogProps) {
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteTeam(orgId, teamId);
+      onOpenChange(false);
+      onDeleted();
+      toast.success(`Team "${teamName}" deleted.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete team');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Team</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <span className="font-medium text-foreground">{teamName}</span>? All members will be removed from this team.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <div className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+            <AlertTriangle className="h-4 w-4 mt-0.5 text-destructive flex-shrink-0" />
+            <p className="text-sm text-destructive">This action cannot be undone.</p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+            {deleting ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              'Delete Team'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/teams/rename-team-dialog.tsx
+++ b/apps/frontend/src/components/teams/rename-team-dialog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { updateTeam } from '@/lib/api';
+
+interface RenameTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  teamId: string;
+  currentName: string;
+  onRenamed: (newName: string) => void;
+}
+
+export function RenameTeamDialog({ open, onOpenChange, orgId, teamId, currentName, onRenamed }: RenameTeamDialogProps) {
+  const [name, setName] = useState(currentName);
+  const [renaming, setRenaming] = useState(false);
+
+  useEffect(() => {
+    if (open) setName(currentName);
+  }, [open, currentName]);
+
+  const handleRename = async () => {
+    if (!name.trim() || name.trim() === currentName) return;
+    setRenaming(true);
+    try {
+      await updateTeam(orgId, teamId, { name: name.trim() });
+      onOpenChange(false);
+      onRenamed(name.trim());
+      toast.success('Team renamed.');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to rename team');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename Team</DialogTitle>
+          <DialogDescription>Enter a new name for this team.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Team name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleRename();
+              }
+            }}
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button onClick={handleRename} disabled={renaming || !name.trim() || name.trim() === currentName}>
+            {renaming ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              'Rename'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/install.sh
+++ b/install.sh
@@ -29,11 +29,11 @@ TANDEMU_RELEASE_URL="${TANDEMU_RELEASE_URL:-https://github.com/anthropics/tandem
 
 header() {
   echo ""
-  printf '%b\n' "${BOLD}  ┌────────────────────────────────────┐${NC}"
-  printf '%b\n' "${BOLD}  │                                      │${NC}"
-  printf '%b\n' "${BOLD}  │      ${BLUE}Tandemu${NC}${BOLD} — AI Teammate          │${NC}"
-  printf '%b\n' "${BOLD}  │                                      │${NC}"
-  printf '%b\n' "${BOLD}  └────────────────────────────────────┘${NC}"
+  printf '%b\n' "${BOLD}  ┌─────────────────────────────────────┐${NC}"
+  printf '%b\n' "${BOLD}  │                                     │${NC}"
+  printf '%b\n' "${BOLD}  │       ${BLUE}Tandemu${NC}${BOLD} — AI Teammate         │${NC}"
+  printf '%b\n' "${BOLD}  │                                     │${NC}"
+  printf '%b\n' "${BOLD}  └─────────────────────────────────────┘${NC}"
   echo ""
 }
 


### PR DESCRIPTION
## Summary
- Extract team dialogs (Create, Delete, Rename, Add Member) into reusable components under `src/components/teams/`
- Add dropdown menu on team detail page with Rename and Delete actions
- Add delete confirmation dialog used from both card view and detail view
- Fix integrations connect dialog: errors show inline instead of on page, uses shadcn Input/Select
- Replace page-level success banners with toast notifications
- Fix install.sh `echo -e` compatibility and box alignment

## Test plan
- [ ] Open Teams page, click trash icon on card → confirmation dialog appears
- [ ] Open team detail, click ⋯ menu → Rename and Delete options
- [ ] Rename a team → name updates in header and card list
- [ ] Delete a team from detail view → redirects to list
- [ ] Connect an integration with invalid token → error shows inside dialog
- [ ] Run `sh install.sh` → no `-e` prefix, boxes aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)