### PR TITLE
feat: check uncommitted changes before branch switch

### DIFF
--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -42,7 +42,10 @@ Check what the task was about:
 
 ```bash
 git branch --show-current
-git log main..HEAD --oneline
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+git log $DEFAULT_BRANCH..HEAD --oneline
 ```
 
 If there's a linked issue, check its state:
@@ -99,11 +102,16 @@ Extract `organization.id` and `user.id`.
 For each repo in the `repos` array:
 
 ```bash
+# Detect default branch for this repo
+DEFAULT_BRANCH=$(git -C <repo> symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git -C <repo> branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
 # Total lines added and removed on this branch
-git -C <repo> diff main...HEAD --numstat 2>/dev/null
+git -C <repo> diff $DEFAULT_BRANCH...HEAD --numstat 2>/dev/null
 
 # All commits on this branch
-git -C <repo> log main..HEAD --format='%H|||%an|||%s|||%b' 2>/dev/null
+git -C <repo> log $DEFAULT_BRANCH..HEAD --format='%H|||%an|||%s|||%b' 2>/dev/null
 ```
 
 For AI vs Manual attribution:
@@ -311,7 +319,9 @@ Would you like to start another task?
 If the developer is done with the task:
 
 ```bash
-git checkout main
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+git checkout "${DEFAULT_BRANCH:-main}"
 ```
 
 ### Notes

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -110,10 +110,44 @@ If there are more than 4 tasks, show the top 4 by priority and mention how many 
 
 Once the developer picks a task:
 
-- Create a feature branch from the default branch:
+#### 5a. Check for uncommitted changes
+
+Before switching branches, check if the working tree is dirty:
 
 ```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+git status --short
+```
+
+If there is output (uncommitted changes exist), use AskUserQuestion:
+- Question: "You have uncommitted changes. What should I do before switching branches?"
+- Header: "Changes"
+- Options:
+  - Label: "Commit on current branch", Description: "Stage and commit changes with a conventional commit message before switching"
+  - Label: "Stash for later", Description: "Stash changes — you can restore them later with git stash pop"
+  - Label: "Bring to new branch", Description: "Carry uncommitted changes into the new feature branch"
+
+If **Commit**: help write a commit message based on the diff, stage and commit, then proceed.
+If **Stash**: run `git stash push -m "WIP before <task.id>"`, then proceed.
+If **Bring to new branch**: do nothing — changes will carry over when creating the branch.
+
+If the working tree is clean, skip this step.
+
+#### 5b. Create a feature branch
+
+Detect the repo's default branch dynamically (supports main, master, develop, or whatever the remote uses):
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  # Fallback: check which common branch names exist on the remote
+  DEFAULT_BRANCH=$(git branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+fi
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+```
+
+Then switch and create the feature branch:
+
+```bash
 git checkout "$DEFAULT_BRANCH"
 git pull origin "$DEFAULT_BRANCH" 2>/dev/null || true
 git checkout -b feat/<task.id>-<short-kebab-description>

--- a/apps/claude-plugins/skills/pause/SKILL.md
+++ b/apps/claude-plugins/skills/pause/SKILL.md
@@ -38,8 +38,13 @@ Calculate elapsed time from `startedAt` to now.
 For each repo in the `repos` array, gather git stats:
 
 ```bash
-git -C <repo> diff main...HEAD --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {print a+0, d+0}'
-git -C <repo> rev-list main..HEAD --count 2>/dev/null || echo 0
+# Detect default branch for this repo
+DEFAULT_BRANCH=$(git -C <repo> symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git -C <repo> branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+git -C <repo> diff $DEFAULT_BRANCH...HEAD --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {print a+0, d+0}'
+git -C <repo> rev-list $DEFAULT_BRANCH..HEAD --count 2>/dev/null || echo 0
 ```
 
 Sum additions, deletions, and commits across all repos.
@@ -108,7 +113,7 @@ curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks/<taskId>/status
 Pick the status that best represents "todo", "backlog", "on hold", or "paused" from the returned list, then:
 
 ```bash
-curl -sf -X PATCH "<api_url>/api/tasks/<taskId>/status" \
+curl -sf -X PATCH "<api_url>/api/tasks/<taskId>" \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{"statusName": "<chosen status name>", "provider": "<provider>"}'


### PR DESCRIPTION
## Summary
- Add Step 5a to `/morning` skill: checks `git status` before switching branches, prompts developer to commit, stash, or carry changes
- Replace hardcoded `main` with dynamic default branch detection across all three skills (`/morning`, `/finish`, `/pause`)
- Detection chain: `origin/HEAD` → fallback `origin/(main|master|develop)` → `"main"`
- Update `/pause` skill to use consolidated `PATCH /api/tasks/:taskId` endpoint

## Test plan
- [ ] Run `/morning` with dirty working tree → prompted to commit/stash/carry
- [ ] Run `/morning` with clean tree → no prompt, proceeds directly
- [ ] Works on repos with `master` as default branch (not just `main`)
- [ ] `/finish` measures lines against correct base branch
- [ ] `/pause` uses new task update endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)