### PR TITLE
feat: auto-compact context before task start and after finish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ It installs Claude Code skills and config. No Docker, no git, no server setup. T
 ### Single active task enforcement
 `~/.claude/tandemu-active-task.json` tracks the one active task across all Claude Code windows. `/morning` checks it before allowing a new task. Must `/pause` or `/finish` to switch.
 
+### Feature flags in tandemu.json
+`~/.claude/tandemu.json` has a `features` object with toggles:
+- `compactBeforeTask` (default `true`) — `/morning` runs `/compact` after the developer picks a task, before branch creation
+- `compactAfterFinish` (default `true`) — `/finish` runs `/compact` after switching back to the default branch
+
 ### Task status sync is dynamic
 No hardcoded status mappings. Skills fetch available statuses from the ticket system (`GET /api/tasks/:id/statuses?provider=linear`), then Claude picks the best match and sends `PATCH /api/tasks/:id` with `{ statusName, assigneeEmail, provider }`. Any combination of fields is accepted in a single call.
 

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -311,8 +311,20 @@ Would you like to start another task?
 If the developer is done with the task:
 
 ```bash
-git checkout main
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git branch -r 2>/dev/null | sed 's/^[* ]*//' | grep -E '^origin/(main|master|develop)$' | head -1 | sed 's@^origin/@@')
+git checkout "${DEFAULT_BRANCH:-main}"
 ```
+
+### 8. Compact context (if enabled)
+
+After switching back to the default branch, check if context compaction is enabled:
+
+```bash
+python3 -c "import json; c=json.load(open('$HOME/.claude/tandemu.json')); print(c.get('features',{}).get('compactAfterFinish', True))" 2>/dev/null
+```
+
+If the result is `True`, run `/compact` to free up context space. Do this silently — just run the compact command without announcing it.
 
 ### Notes
 

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -106,7 +106,17 @@ Use AskUserQuestion to present the tasks as a selectable list:
 
 If there are more than 4 tasks, show the top 4 by priority and mention how many more exist.
 
-### 5. Set up the chosen task
+### 5. Compact context (if enabled)
+
+After the developer picks a task, check if context compaction is enabled:
+
+```bash
+python3 -c "import json; c=json.load(open('$HOME/.claude/tandemu.json')); print(c.get('features',{}).get('compactBeforeTask', True))" 2>/dev/null
+```
+
+If the result is `True`, run `/compact` to free up context space before starting the new task. Do this silently — just run the compact command without announcing it.
+
+### 6. Set up the chosen task
 
 Once the developer picks a task:
 
@@ -160,7 +170,7 @@ If you can't determine which status to use, still send the assignee update witho
 - Search the codebase for files relevant to the task title/description
 - List the related files
 
-### 6. Confirm readiness
+### 7. Confirm readiness
 
 ```
 Ready to work on: <task title>

--- a/install.sh
+++ b/install.sh
@@ -207,7 +207,11 @@ write_configs() {
   "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
   "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
   "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
-  "api": { "url": "${API_URL}" }
+  "api": { "url": "${API_URL}" },
+  "features": {
+    "compactBeforeTask": true,
+    "compactAfterFinish": true
+  }
 }
 EOF
   ok "Config: ~/.claude/tandemu.json"


### PR DESCRIPTION
## Summary
- Add `features.compactBeforeTask` and `features.compactAfterFinish` toggles to `~/.claude/tandemu.json` (both default `true`)
- `/morning` runs `/compact` after the developer picks a task, before branch creation
- `/finish` runs `/compact` after switching back to the default branch
- `install.sh` writes the feature flags into the config

## Test plan
- [ ] Run `/morning` → pick task → compact runs before branch creation
- [ ] Run `/finish` → after switching to main → compact runs
- [ ] Set `compactBeforeTask: false` in config → compact skipped during `/morning`
- [ ] Set `compactAfterFinish: false` in config → compact skipped during `/finish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)