### PR TITLE
feat: reduce dev-level log noise in skills

### DIFF
--- a/apps/claude-plugins/lib/tandemu-env.sh
+++ b/apps/claude-plugins/lib/tandemu-env.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Shared Tandemu config loader — source this from skills to get env vars.
+# Usage: source "$(dirname "$0")/../lib/tandemu-env.sh"
+
+_TANDEMU_CONFIG=$(cat ~/.claude/tandemu.json 2>/dev/null)
+if [ -z "$_TANDEMU_CONFIG" ]; then
+  echo "ERROR: Tandemu not configured. Run install.sh to set up." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+eval "$(echo "$_TANDEMU_CONFIG" | python3 -c "
+import sys, json
+c = json.load(sys.stdin)
+print(f'TANDEMU_TOKEN={chr(39)}{c[\"auth\"][\"token\"]}{chr(39)}')
+print(f'TANDEMU_API={chr(39)}{c[\"api\"][\"url\"]}{chr(39)}')
+print(f'TANDEMU_ORG_ID={chr(39)}{c[\"organization\"][\"id\"]}{chr(39)}')
+print(f'TANDEMU_TEAM_ID={chr(39)}{c[\"team\"][\"id\"]}{chr(39)}')
+print(f'TANDEMU_USER_ID={chr(39)}{c[\"user\"][\"id\"]}{chr(39)}')
+print(f'TANDEMU_USER_EMAIL={chr(39)}{c[\"user\"][\"email\"]}{chr(39)}')
+print(f'TANDEMU_USER_NAME={chr(39)}{c[\"user\"][\"name\"]}{chr(39)}')
+")"
+
+unset _TANDEMU_CONFIG

--- a/apps/claude-plugins/skills/blockers/SKILL.md
+++ b/apps/claude-plugins/skills/blockers/SKILL.md
@@ -12,34 +12,33 @@ allowed-tools:
 
 Show the team's friction points and blockers. Options: $ARGUMENTS
 
+**Execution style:** Minimize tool call noise. Load config and fetch all API data in a single Bash call ("Fetch blocker data"). Keep the analysis and formatted report as separate steps.
+
 ## Steps
 
-### 1. Load Tandemu config
+### 1. Fetch blocker data
 
-Read `~/.claude/tandemu.json`:
-
-```bash
-cat ~/.claude/tandemu.json
-```
-
-Extract `auth.token`, `api.url`, `organization.id`, and `team.id`. If `--team` is specified, override the default team. Default time range: last 7 days (override with `--days`).
-
-If the file doesn't exist, tell the developer: "Tandemu is not configured. Run /tandemu to set it up."
-
-### 2. Fetch data from Tandemu API
+Load config and fetch all data in a **single Bash call** ("Fetch blocker data"):
 
 ```bash
-# Friction heatmap from telemetry
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/telemetry/friction-heatmap"
+# Load Tandemu config
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
-# DORA metrics
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/telemetry/dora-metrics"
+# If --team is specified, override $TANDEMU_TEAM_ID here
 
-# Tasks from connected ticket system — look for blocked/stale items
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks?teamId=<team_id>&sprint=current"
+echo "---FRICTION---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/friction-heatmap"
+
+echo "---DORA---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/dora-metrics"
+
+echo "---TASKS---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID"
 ```
 
-### 3. Identify blockers
+If the config load fails, tell the developer: "Tandemu is not configured. Run install.sh to set it up."
+
+### 2. Identify blockers
 
 **From telemetry (friction heatmap):**
 - Rank files by prompt loop count + error count
@@ -55,7 +54,7 @@ curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks?teamId=<team_id
 - For high-friction files, read the actual source code to understand why it's complex
 - Check if the friction files relate to any in-progress tasks
 
-### 4. Present the report
+### 3. Present the report
 
 ```markdown
 ## Team Blockers & Friction Report

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -13,6 +13,8 @@ allowed-tools:
 
 Help the developer wrap up their current task cleanly, measure the work done, and report telemetry.
 
+**Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, OTEL setup, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Prepare telemetry". Keep context-dependent operations (git diff, git stash) and user-facing operations (task selection, PR checks, summaries) as separate calls.
+
 ## Steps
 
 ### 1. Check for uncommitted work
@@ -81,21 +83,28 @@ If no PR exists and there are commits ahead of main, use AskUserQuestion:
 
 ### 4. Measure and report work
 
-Read the active task metadata:
+Load config, active task, and OTEL setup in a **single Bash call** ("Prepare telemetry"):
 
 ```bash
-cat ~/.claude/tandemu-active-task.json 2>/dev/null
+# Load Tandemu config
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+
+# Active task metadata
+echo "---ACTIVE_TASK---"
+cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
+
+# OTEL endpoint
+echo "---OTEL---"
+python3 -c "
+import json
+try:
+    s = json.load(open('$HOME/.claude/settings.json'))
+    print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
+except: print('http://localhost:4318')
+" 2>/dev/null
 ```
 
-Extract `taskId`, `title`, `startedAt`, `repos`. If the file does not exist, use the current repo and estimate start from the first commit on the branch.
-
-Read the Tandemu config:
-
-```bash
-cat ~/.claude/tandemu.json
-```
-
-Extract `organization.id` and `user.id`.
+Extract `taskId`, `title`, `startedAt`, `repos` from the active task. If the file does not exist, use the current repo and estimate start from the first commit on the branch. Extract `organization.id` and `user.id` from the config env vars. Extract the OTEL endpoint.
 
 #### 4a. Measure work across all repos
 
@@ -132,19 +141,7 @@ Calculate:
 
 #### 4b. Send telemetry
 
-Derive the OTEL endpoint:
-
-```bash
-OTEL_ENDPOINT=$(python3 -c "
-import json
-try:
-    s = json.load(open('$HOME/.claude/settings.json'))
-    print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
-except: print('http://localhost:4318')
-" 2>/dev/null)
-```
-
-Convert timestamps to nanoseconds using a single Python script to avoid errors:
+Convert timestamps to nanoseconds (use the OTEL endpoint from the setup call above):
 
 ```bash
 read START_NS END_NS DURATION_S TRACE_ID SPAN_ID <<< $(python3 -c "
@@ -249,14 +246,14 @@ If `METRICS_HTTP` is not `200`, tell the developer: "Telemetry failed (metrics r
 If the developer marked the task as "Done", update the status on the provider. First fetch the available statuses, then pick the one that best represents "done" or "completed":
 
 ```bash
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks/<taskId>/statuses?provider=<provider>"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "done", "completed", or "closed" from the returned list, then:
 
 ```bash
-curl -sf -X PATCH "<api_url>/api/tasks/<taskId>" \
-  -H "Authorization: Bearer <token>" \
+curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
+  -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"statusName": "<chosen status name>", "provider": "<provider>"}'
 ```

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -14,6 +14,8 @@ allowed-tools:
 
 Help the developer start their work session by picking a task.
 
+**Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Setup". Keep user-facing operations (task selection, PR checks, summaries) as separate, clearly described calls.
+
 ## Steps
 
 ### 0. Greet personally (memory)
@@ -27,34 +29,39 @@ If you remember what they worked on recently, mention it: "Last time you were wo
 
 Do this naturally, don't announce you're searching memories.
 
-### 1. Load Tandemu config
+### 1. Setup — load config, check active task, and check git state
 
-Read `~/.claude/tandemu.json`:
-
-```bash
-cat ~/.claude/tandemu.json
-```
-
-Extract `auth.token`, `api.url`, `organization.id`, and `team.id`.
-
-If the file doesn't exist, tell the developer: "Tandemu is not configured. Run /tandemu to set it up."
-
-### 2. Check for active task
+Run all setup reads in a **single Bash call**:
 
 ```bash
-cat ~/.claude/tandemu-active-task.json 2>/dev/null
+# Load Tandemu config
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+echo "---CONFIG---"
+echo "TOKEN=$TANDEMU_TOKEN"
+echo "API=$TANDEMU_API"
+echo "ORG=$TANDEMU_ORG_ID"
+echo "TEAM=$TANDEMU_TEAM_ID"
+echo "EMAIL=$TANDEMU_USER_EMAIL"
+echo "NAME=$TANDEMU_USER_NAME"
+
+# Check for active task
+echo "---ACTIVE_TASK---"
+cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
+
+# Git state
+echo "---GIT---"
+echo "REPO=$(git rev-parse --show-toplevel 2>/dev/null)"
+echo "STATUS=$(git status --short)"
 ```
 
-If the file exists and contains valid JSON:
+If the config load fails, tell the developer: "Tandemu is not configured. Run install.sh to set it up."
+
+### 2. Handle active task (if found)
+
+If the active task JSON was returned (not "NONE"):
 
 - Extract `taskId`, `title`, `startedAt`, `repos` from it.
 - Calculate how long ago the task was started.
-- Get the current repo path:
-
-```bash
-git rev-parse --show-toplevel 2>/dev/null
-```
-
 - Tell the developer: "You have an active task: **<title>** (started <relative time ago>)"
 - Use AskUserQuestion:
   - Question: "You're currently working on **<title>**. What would you like to do?"
@@ -66,17 +73,17 @@ git rev-parse --show-toplevel 2>/dev/null
 - If they choose **Continue here**:
   - If the current repo is not already in the `repos` array, add it by reading, modifying, and rewriting `~/.claude/tandemu-active-task.json`.
   - Check if a branch for the task already exists, if not create one.
-  - Skip to the readiness summary (Step 5).
+  - Skip to the readiness summary (Step 6).
 - If they choose **Pause and pick another**: tell the developer to run `/pause` first, then `/morning` again. Stop here.
 
-If the file does not exist, proceed to Step 3.
+If no active task was found, proceed to Step 3.
 
 ### 3. Fetch tasks from Tandemu
 
-Fetch tasks assigned to the current developer:
+Fetch tasks assigned to the current developer (use the config values from setup):
 
 ```bash
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks?teamId=<team_id>&mine=true"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID&mine=true"
 ```
 
 The response is `{ success, data: Task[] }` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`.
@@ -88,7 +95,7 @@ If the developer has assigned tasks, proceed to Step 4 with those.
 If no tasks are assigned to the developer, fetch **unassigned todo tasks** that they could pick up:
 
 ```bash
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks?teamId=<team_id>&status=todo&unassigned=true"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID&status=todo&unassigned=true"
 ```
 
 Tell the developer: "No tasks are assigned to you. Here are unassigned tasks you could pick up:"
@@ -113,13 +120,7 @@ Once the developer picks a task:
 
 #### 5a. Check for uncommitted changes
 
-Before switching branches, check if the working tree is dirty:
-
-```bash
-git status --short
-```
-
-If there is output (uncommitted changes exist), use AskUserQuestion:
+Use the git status output from the setup call. If it showed uncommitted changes, use AskUserQuestion:
 - Question: "You have uncommitted changes. What should I do before switching branches?"
 - Header: "Changes"
 - Options:
@@ -175,18 +176,18 @@ EOF
 
 ```bash
 # Fetch available statuses for this task
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks/<task.id>/statuses?provider=<task.provider>"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/statuses?provider=<task.provider>"
 ```
 
 This returns an array of `{ id, name, type }` objects — the actual statuses available in the team's workflow (e.g., "Backlog", "In Progress", "In Review", "Done"). Pick the one that best represents "in progress" or "started".
 
-Then send a single PATCH to update both status and assignee. Read the developer's email from `~/.claude/tandemu.json` (`user.email`):
+Then send a single PATCH to update both status and assignee:
 
 ```bash
-curl -sf -X PATCH "<api_url>/api/tasks/<task.id>" \
-  -H "Authorization: Bearer <token>" \
+curl -sf -X PATCH "$TANDEMU_API/api/tasks/<task.id>" \
+  -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"statusName": "<chosen status name>", "assigneeEmail": "<user.email>", "provider": "<task.provider>"}'
+  -d '{"statusName": "<chosen status name>", "assigneeEmail": "'"$TANDEMU_USER_EMAIL"'", "provider": "<task.provider>"}'
 ```
 
 If you can't determine which status to use, still send the assignee update without statusName. The endpoint accepts any combination of the fields.

--- a/apps/claude-plugins/skills/pause/SKILL.md
+++ b/apps/claude-plugins/skills/pause/SKILL.md
@@ -9,27 +9,41 @@ allowed-tools:
 
 Pause the current task so the developer can switch to something else.
 
+**Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, OTEL setup, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Setup". Keep user-facing operations (git stats, summaries) as separate calls.
+
 ## Steps
 
-### 1. Load config and active task
+### 1. Setup — load config, active task, and OTEL endpoint
 
-Read `~/.claude/tandemu.json`:
-
-```bash
-cat ~/.claude/tandemu.json
-```
-
-Extract `auth.token`, `api.url`, `organization.id`, `user.id`.
-
-Read the active task:
+Run all setup reads in a **single Bash call** ("Setup"):
 
 ```bash
-cat ~/.claude/tandemu-active-task.json 2>/dev/null
+# Load Tandemu config
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+echo "---CONFIG---"
+echo "TOKEN=$TANDEMU_TOKEN"
+echo "API=$TANDEMU_API"
+echo "ORG=$TANDEMU_ORG_ID"
+echo "USER=$TANDEMU_USER_ID"
+
+# Active task
+echo "---ACTIVE_TASK---"
+cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
+
+# OTEL endpoint
+echo "---OTEL---"
+python3 -c "
+import json
+try:
+    s = json.load(open('$HOME/.claude/settings.json'))
+    print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
+except: print('http://localhost:4318')
+" 2>/dev/null
 ```
 
-If the file does not exist, tell the developer: "No active task to pause. Use /morning to start one." Then stop.
+If the active task file does not exist, tell the developer: "No active task to pause. Use /morning to start one." Then stop.
 
-Extract `taskId`, `title`, `startedAt`, `repos`.
+Extract `taskId`, `title`, `startedAt`, `repos` from the active task JSON.
 
 ### 2. Snapshot progress
 
@@ -51,19 +65,7 @@ Sum additions, deletions, and commits across all repos.
 
 ### 3. Send partial telemetry
 
-Derive the OTEL endpoint:
-
-```bash
-OTEL_ENDPOINT=$(python3 -c "
-import json
-try:
-    s = json.load(open('$HOME/.claude/settings.json'))
-    print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
-except: print('http://localhost:4318')
-" 2>/dev/null)
-```
-
-Convert timestamps to nanoseconds and send a `task_session` span with `status=paused`:
+Convert timestamps and send a `task_session` span with `status=paused` (use the OTEL endpoint from setup):
 
 ```bash
 START_NS=$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('<startedAt>'.replace('Z','+00:00')).timestamp()*1e9))")
@@ -82,7 +84,7 @@ curl -sf -X POST "$OTEL_ENDPOINT/v1/traces" \
         ]
       },
       "scopeSpans": [{
-        "scope tandemu"},
+        "scope": {"name": "tandemu"},
         "spans": [{
           "traceId": "'"$TRACE_ID"'",
           "spanId": "'"$SPAN_ID"'",
@@ -107,14 +109,14 @@ curl -sf -X POST "$OTEL_ENDPOINT/v1/traces" \
 Set the task back to a paused/backlog state on the provider. First fetch available statuses, then pick the one that best represents "paused", "on hold", "todo", or "backlog":
 
 ```bash
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks/<taskId>/statuses?provider=<provider>"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "todo", "backlog", "on hold", or "paused" from the returned list, then:
 
 ```bash
-curl -sf -X PATCH "<api_url>/api/tasks/<taskId>" \
-  -H "Authorization: Bearer <token>" \
+curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
+  -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"statusName": "<chosen status name>", "provider": "<provider>"}'
 ```

--- a/apps/claude-plugins/skills/standup/SKILL.md
+++ b/apps/claude-plugins/skills/standup/SKILL.md
@@ -10,44 +10,42 @@ allowed-tools:
 
 Generate a team standup report. Options: $ARGUMENTS
 
+**Execution style:** Minimize tool call noise. Load config and fetch all API data in a single Bash call ("Fetch team data"). Keep the formatted report output as a separate step.
+
 ## Steps
 
-### 1. Load Tandemu config
+### 1. Fetch team data
 
-Read `~/.claude/tandemu.json`:
-
-```bash
-cat ~/.claude/tandemu.json
-```
-
-Extract `auth.token`, `api.url`, `organization.id`, and `team.id`. If `--team` is specified, override the default team.
-
-If the file doesn't exist, tell the developer: "Tandemu is not configured. Run /tandemu to set it up."
-
-### 2. Fetch data from Tandemu API
-
-Make these calls in parallel:
+Load config and fetch all data in a **single Bash call** ("Fetch team data"):
 
 ```bash
-# Team members (these are the Tandemu users on the team)
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/organizations/<org_id>/teams/<team_id>/members"
+# Load Tandemu config
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
-# All tasks from connected ticket system
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/tasks?teamId=<team_id>"
+# If --team is specified, override $TANDEMU_TEAM_ID here
 
-# Telemetry: session timesheets (last 24h)
 YESTERDAY=$(date -u -v-1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -d "yesterday" +%Y-%m-%dT00:00:00Z)
 NOW=$(date -u +%Y-%m-%dT23:59:59Z)
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/telemetry/timesheets?startDate=$YESTERDAY&endDate=$NOW"
 
-# Telemetry: AI ratio
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/telemetry/ai-ratio"
+echo "---MEMBERS---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/organizations/$TANDEMU_ORG_ID/teams/$TANDEMU_TEAM_ID/members"
 
-# Telemetry: friction events
-curl -sf -H "Authorization: Bearer <token>" "<api_url>/api/telemetry/friction-heatmap"
+echo "---TASKS---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID"
+
+echo "---TIMESHEETS---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/timesheets?startDate=$YESTERDAY&endDate=$NOW"
+
+echo "---AI_RATIO---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/ai-ratio"
+
+echo "---FRICTION---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/friction-heatmap"
 ```
 
-### 3. Compile the team standup
+If the config load fails, tell the developer: "Tandemu is not configured. Run install.sh to set it up."
+
+### 2. Compile the team standup
 
 **IMPORTANT attribution rules:**
 
@@ -108,7 +106,7 @@ Tasks assigned to people not on this Tandemu team:
 - If no blockers detected, say "No blockers detected."
 ```
 
-### 4. Format output
+### 3. Format output
 
 Default: markdown. If `--format slack`, use Slack bold markers. If `--format plain`, plain text.
 

--- a/install.sh
+++ b/install.sh
@@ -307,6 +307,13 @@ install_assets() {
     fail "Release download not yet implemented. Run install.sh from the Tandemu repo directory."
   fi
 
+  # Install shared lib
+  local lib_src="${SCRIPT_DIR}/apps/claude-plugins/lib"
+  if [ -d "$lib_src" ]; then
+    mkdir -p "$SKILLS_DIR/../lib"
+    cp -r "$lib_src"/* "$SKILLS_DIR/../lib/"
+  fi
+
   # Install skills (skip /tandemu — its logic is in this script)
   for skill_dir in "$skills_src"/*/; do
     local skill_name


### PR DESCRIPTION
## Summary
- Add shared `tandemu-env.sh` config loader that all skills source instead of inline config reads
- Add "Execution style" instruction to each skill to batch infrastructure commands into fewer tool calls
- Combine config/active-task/OTEL reads into single setup calls per skill
- Update `install.sh` to copy `lib/` directory alongside skills
- Fix malformed JSON in pause skill scope definition

## Test plan
- [ ] Run `/morning` — config/active-task/git-status should be 1 tool call instead of 3+
- [ ] Run `/finish` — config/active-task/OTEL setup should be 1 tool call instead of 3+
- [ ] Run `/standup` — config + all API fetches should be 1 tool call
- [ ] Run `/blockers` — config + all API fetches should be 1 tool call
- [ ] Run `install.sh` — verify `~/.claude/lib/tandemu-env.sh` gets installed
- [ ] Verify all skills still function correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)