### PR TITLE
feat: auto-sync standalone skills on plugin update

### DIFF
--- a/apps/claude-plugins/.claude-plugin/plugin.json
+++ b/apps/claude-plugins/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "repository": "https://github.com/sebastiangrebe/tandemu",
   "license": "MIT",
-  "keywords": ["task-management", "telemetry", "memory", "ai-teammate", "developer-tools"]
+  "keywords": ["task-management", "telemetry", "memory", "ai-teammate", "developer-tools"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/apps/claude-plugins/hooks/hooks.json
+++ b/apps/claude-plugins/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/sync-skills.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/claude-plugins/hooks/sync-skills.sh
+++ b/apps/claude-plugins/hooks/sync-skills.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Sync standalone Tandemu skills from plugin to ~/.claude/skills/
+# Runs on SessionStart — silent, fast, no output unless updating.
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[ -z "$PLUGIN_ROOT" ] && exit 0
+
+VERSION_FILE="$HOME/.claude/tandemu-version.txt"
+PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_ROOT/.claude-plugin/plugin.json')).get('version',''))" 2>/dev/null)
+[ -z "$PLUGIN_VERSION" ] && exit 0
+
+INSTALLED_VERSION=""
+[ -f "$VERSION_FILE" ] && INSTALLED_VERSION=$(cat "$VERSION_FILE")
+
+# Skip if versions match
+[ "$PLUGIN_VERSION" = "$INSTALLED_VERSION" ] && exit 0
+
+# Sync skills (skip setup — it's the plugin entry point)
+for skill_dir in "$PLUGIN_ROOT/skills"/*/; do
+  skill_name=$(basename "$skill_dir")
+  [ "$skill_name" = "setup" ] && continue
+  rm -rf "$HOME/.claude/skills/$skill_name"
+  cp -r "$skill_dir" "$HOME/.claude/skills/$skill_name"
+done
+
+# Sync shared lib
+[ -d "$PLUGIN_ROOT/lib" ] && {
+  mkdir -p "$HOME/.claude/lib"
+  cp -r "$PLUGIN_ROOT/lib"/* "$HOME/.claude/lib/"
+}
+
+# Sync CLAUDE.md (only if it's Tandemu's)
+if [ -f "$PLUGIN_ROOT/CLAUDE.md" ]; then
+  if [ ! -f "$HOME/.claude/CLAUDE.md" ] || grep -q "Tandemu AI Teammate" "$HOME/.claude/CLAUDE.md" 2>/dev/null; then
+    cp "$PLUGIN_ROOT/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+  fi
+fi
+
+# Update version
+echo "$PLUGIN_VERSION" > "$VERSION_FILE"


### PR DESCRIPTION
## Summary

- Add `SessionStart` hook that compares plugin version against installed version
- When versions differ, syncs skills, shared lib, and CLAUDE.md from plugin to `~/.claude/skills/`
- Fast no-op when versions match (two file reads)
- Closes the update gap where plugin marketplace updates don't reach short-named standalone copies

## Test plan

- [ ] Install plugin, run `/tandemu:setup`, verify version file written
- [ ] Bump `plugin.json` version, start new session → hook syncs skills
- [ ] Verify `~/.claude/tandemu-version.txt` updated
- [ ] Start another session with matching versions → hook exits immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)