### PR TITLE
feat: billing prompt after signup + FREE tier seat limit

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -8,6 +8,7 @@ import { getAIRatio, getDORAMetrics, getTimesheets } from '@/lib/api';
 import type { TimesheetEntry } from '@/lib/api';
 import type { AIvsManualRatio, DORAMetrics } from '@tandemu/types';
 import { InstallBanner } from '@/components/install-banner';
+import { BillingBanner } from '@/components/billing-banner';
 import { ActivityChart } from '@/components/charts/activity-chart';
 import { AIRatioChart } from '@/components/charts/ai-ratio-chart';
 import { TelemetryFilters, useFilterParams } from '@/components/filters/telemetry-filters';
@@ -136,6 +137,8 @@ export default function DashboardPage() {
         </div>
         <TelemetryFilters />
       </div>
+
+      <BillingBanner />
 
       {/* KPI Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -273,10 +273,32 @@ export default function SettingsPage() {
                   </CardDescription>
                 </div>
               </div>
-              <Button size="sm" variant="outline" onClick={() => setShowInviteDialog(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Invite
-              </Button>
+              {process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' && org.planTier === 'FREE' ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={async () => {
+                    try {
+                      const { url } = await createCheckout({
+                        organizationId: org.id,
+                        planTier: 'PRO',
+                        successUrl: `${window.location.origin}/settings?billing=success`,
+                        cancelUrl: `${window.location.origin}/settings`,
+                      });
+                      window.location.href = url;
+                    } catch (err) {
+                      toast.error(err instanceof Error ? err.message : 'Failed to start checkout');
+                    }
+                  }}
+                >
+                  Upgrade to Invite
+                </Button>
+              ) : (
+                <Button size="sm" variant="outline" onClick={() => setShowInviteDialog(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Invite
+                </Button>
+              )}
             </div>
           </CardHeader>
           <CardContent className="space-y-6">

--- a/apps/frontend/src/app/setup/page.tsx
+++ b/apps/frontend/src/app/setup/page.tsx
@@ -460,9 +460,18 @@ export default function SetupPage() {
             {/* Step 3: Invite Members */}
             {step === 2 && (
               <div className="space-y-6">
-                <p className="text-sm text-muted-foreground">
-                  Add people to your organization. You can also do this later.
-                </p>
+                {process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' ? (
+                  <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 px-4 py-3">
+                    <p className="text-sm text-muted-foreground">
+                      Inviting team members requires the Pro plan ($10/seat/month).
+                      You can upgrade from the Settings page after setup, or skip this step.
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Add people to your organization. You can also do this later.
+                  </p>
+                )}
                 <div className="flex gap-2">
                   <Input
                     type="email"

--- a/apps/frontend/src/components/billing-banner.tsx
+++ b/apps/frontend/src/components/billing-banner.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import { X, CreditCard } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/lib/auth';
+import { createCheckout } from '@/lib/api';
+import { toast } from 'sonner';
+
+export function BillingBanner() {
+  const { currentOrg } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  const billingEnabled = process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true';
+  const isFree = currentOrg?.planTier === 'FREE';
+  const storageKey = currentOrg ? `tandemu_billing_dismissed_${currentOrg.id}` : '';
+
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === 'undefined' || !storageKey) return true;
+    return localStorage.getItem(storageKey) === 'true';
+  });
+
+  if (!billingEnabled || !isFree || dismissed || !currentOrg) return null;
+
+  const handleUpgrade = async () => {
+    setLoading(true);
+    try {
+      const { url } = await createCheckout({
+        organizationId: currentOrg.id,
+        planTier: 'PRO',
+        successUrl: `${window.location.origin}/settings?billing=success`,
+        cancelUrl: window.location.href,
+      });
+      window.location.href = url;
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to start checkout');
+      setLoading(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(storageKey, 'true');
+    setDismissed(true);
+  };
+
+  return (
+    <div className="relative rounded-lg border border-blue-500/20 bg-blue-500/5 px-4 py-3 sm:px-6 sm:py-4">
+      <button
+        onClick={handleDismiss}
+        className="absolute top-3 right-3 text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6 pr-6">
+        <div className="flex items-center gap-3">
+          <CreditCard className="h-5 w-5 text-blue-500 shrink-0" />
+          <div>
+            <p className="text-sm font-medium">You&apos;re on the Free plan (1 seat)</p>
+            <p className="text-sm text-muted-foreground">
+              Upgrade to Pro for $10/seat/month to add team members and unlock full telemetry.
+            </p>
+          </div>
+        </div>
+        <Button
+          size="sm"
+          onClick={handleUpgrade}
+          disabled={loading}
+          className="shrink-0 sm:ml-auto"
+        >
+          {loading ? 'Redirecting...' : 'Upgrade to Pro'}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add dismissible billing banner on dashboard for FREE plan orgs (gated on `NEXT_PUBLIC_BILLING_ENABLED`)
- Replace invite button with "Upgrade to Invite" on settings page for FREE tier
- Add Pro requirement note on setup wizard invite step
- Backend seat limit enforced via interceptor in platform repo (not in OSS)

## Test plan

- [ ] Sign up → complete setup → dashboard shows billing banner
- [ ] Click "Upgrade to Pro" → redirects to Stripe checkout
- [ ] Dismiss banner → refresh → stays hidden (localStorage per org)
- [ ] Switch orgs → banner reappears for FREE org
- [ ] Settings page: invite button replaced with upgrade CTA on FREE
- [ ] OSS mode (no `NEXT_PUBLIC_BILLING_ENABLED`): no banner, normal invite button
- [ ] PRO plan: no banner, normal invite flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)