### PR TITLE
feat: add task creation API and /create skill

### DIFF
--- a/apps/backend/src/integrations/providers/asana.provider.ts
+++ b/apps/backend/src/integrations/providers/asana.provider.ts
@@ -9,6 +9,7 @@ import type {
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
+  TaskProviderCreateParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -221,6 +222,55 @@ export class AsanaProvider implements TaskProvider {
         }
       }
     }
+  }
+
+  async createTask(params: TaskProviderCreateParams): Promise<Task> {
+    const { accessToken, externalProjectId, title, description, assigneeEmail } = params;
+
+    const data: Record<string, unknown> = {
+      projects: [externalProjectId],
+      name: title,
+    };
+    if (description) data.notes = description;
+
+    if (assigneeEmail) {
+      // Look up user by email
+      const task = await asanaFetch<{ data: { gid: string; workspace: { gid: string } } }>(
+        `/projects/${externalProjectId}`,
+        accessToken,
+      );
+      if (task?.data?.workspace?.gid) {
+        const usersRes = await asanaFetch<{ data: Array<{ gid: string; email: string }> }>(
+          `/workspaces/${task.data.workspace.gid}/users?opt_fields=email`,
+          accessToken,
+          'GET',
+        );
+        const user = usersRes?.data?.find((u) => u.email === assigneeEmail);
+        if (user) data.assignee = user.gid;
+      }
+    }
+
+    const created = await asanaFetch<{ data: AsanaTask }>(
+      '/tasks',
+      accessToken,
+      'POST',
+      { data },
+    );
+
+    return {
+      id: created.data.gid,
+      title: created.data.name,
+      description: created.data.notes ?? undefined,
+      status: 'todo',
+      priority: 'none',
+      assigneeName: created.data.assignee?.name,
+      assigneeEmail: created.data.assignee?.email,
+      labels: [],
+      url: created.data.permalink_url,
+      provider: 'asana',
+      externalProjectId,
+      updatedAt: new Date().toISOString(),
+    };
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/clickup.provider.ts
+++ b/apps/backend/src/integrations/providers/clickup.provider.ts
@@ -9,6 +9,7 @@ import type {
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
+  TaskProviderCreateParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -193,6 +194,38 @@ export class ClickUpProvider implements TaskProvider {
       const text = await response.text();
       throw new BadGatewayException(`ClickUp task update failed (${response.status}): ${text}`);
     }
+  }
+
+  async createTask(params: TaskProviderCreateParams): Promise<Task> {
+    const { accessToken, externalProjectId, title, description, priority } = params;
+
+    // For ClickUp, externalProjectId can be a folder or list. Create on the first list if it's a folder.
+    let listId = externalProjectId;
+    try {
+      const folder = await clickupFetch<ClickUpFolder>(`${CLICKUP_API}/folder/${externalProjectId}`, accessToken);
+      if (folder.lists.length > 0) listId = folder.lists[0]!.id;
+    } catch {
+      // Not a folder — use as list ID directly
+    }
+
+    const body: Record<string, unknown> = { name: title };
+    if (description) body.description = description;
+    if (priority) {
+      const prioMap: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4 };
+      if (prioMap[priority.toLowerCase()]) body.priority = prioMap[priority.toLowerCase()];
+    }
+
+    const res = await fetch(`${CLICKUP_API}/list/${listId}/task`, {
+      method: 'POST',
+      headers: { Authorization: accessToken, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new BadGatewayException(`ClickUp create task failed (${res.status}): ${text}`);
+    }
+    const task = (await res.json()) as ClickUpTask;
+    return mapTask(task, externalProjectId);
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/github.provider.ts
+++ b/apps/backend/src/integrations/providers/github.provider.ts
@@ -9,6 +9,7 @@ import type {
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
+  TaskProviderCreateParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -153,6 +154,39 @@ export class GitHubProvider implements TaskProvider {
       const body = await response.text();
       throw new BadGatewayException(`GitHub issue update failed (${response.status}): ${body}`);
     }
+  }
+
+  async createTask(params: TaskProviderCreateParams): Promise<Task> {
+    const { accessToken, externalProjectId, title, description, labels } = params;
+    // externalProjectId is "owner/repo"
+    const body: Record<string, unknown> = { title };
+    if (description) body.body = description;
+    if (labels && labels.length > 0) body.labels = labels;
+
+    const res = await fetch(`${GITHUB_API}/repos/${externalProjectId}/issues`, {
+      method: 'POST',
+      headers: { Authorization: `token ${accessToken}`, Accept: 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new BadGatewayException(`GitHub create issue failed (${res.status}): ${text}`);
+    }
+    const issue = (await res.json()) as GitHubIssue;
+    return {
+      id: `#${issue.number}`,
+      title: issue.title,
+      description: issue.body ?? undefined,
+      status: mapStatus(issue.state),
+      priority: mapPriority(issue.labels),
+      assigneeName: issue.assignee?.login,
+      assigneeEmail: issue.assignee?.email ?? undefined,
+      labels: issue.labels.map((l) => l.name),
+      url: issue.html_url,
+      provider: 'github',
+      externalProjectId,
+      updatedAt: issue.updated_at,
+    };
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/jira.provider.ts
+++ b/apps/backend/src/integrations/providers/jira.provider.ts
@@ -9,6 +9,7 @@ import type {
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
+  TaskProviderCreateParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -199,6 +200,58 @@ export class JiraProvider implements TaskProvider {
         }
       }
     }
+  }
+
+  async createTask(params: TaskProviderCreateParams): Promise<Task> {
+    const { accessToken, externalProjectId, title, description, assigneeEmail, config } = params;
+    const siteId = config.siteId as string | undefined;
+    if (!siteId) throw new BadGatewayException('Jira integration requires a siteId in config');
+
+    const baseUrl = `https://${siteId}.atlassian.net/rest/api/3`;
+    const authHeader = `Basic ${Buffer.from(`${accessToken}`).toString('base64')}`;
+
+    const fields: Record<string, unknown> = {
+      project: { key: externalProjectId },
+      summary: title,
+      issuetype: { name: 'Task' },
+    };
+    if (description) {
+      fields.description = { type: 'doc', version: 1, content: [{ type: 'paragraph', content: [{ type: 'text', text: description }] }] };
+    }
+    if (assigneeEmail) {
+      const searchRes = await fetch(`${baseUrl}/user/search?query=${encodeURIComponent(assigneeEmail)}`, {
+        headers: { Authorization: authHeader, Accept: 'application/json' },
+      });
+      if (searchRes.ok) {
+        const users = (await searchRes.json()) as Array<{ accountId: string }>;
+        if (users[0]) fields.assignee = { accountId: users[0].accountId };
+      }
+    }
+
+    const res = await fetch(`${baseUrl}/issue`, {
+      method: 'POST',
+      headers: { Authorization: authHeader, Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fields }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new BadGatewayException(`Jira create failed (${res.status}): ${text}`);
+    }
+    const created = (await res.json()) as { key: string; self: string };
+
+    return {
+      id: created.key,
+      title,
+      description,
+      status: 'todo',
+      priority: 'none',
+      assigneeEmail,
+      labels: [],
+      url: `https://${siteId}.atlassian.net/browse/${created.key}`,
+      provider: 'jira',
+      externalProjectId,
+      updatedAt: new Date().toISOString(),
+    };
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/linear.provider.ts
+++ b/apps/backend/src/integrations/providers/linear.provider.ts
@@ -9,6 +9,7 @@ import type {
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
+  TaskProviderCreateParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -239,6 +240,64 @@ export class LinearProvider implements TaskProvider {
       accessToken,
       `mutation { issueUpdate(id: "${issue.id}", input: { ${inputStr} }) { success } }`,
     );
+  }
+
+  async createTask(params: TaskProviderCreateParams): Promise<Task> {
+    const { accessToken, externalProjectId, title, description, assigneeEmail, priority } = params;
+
+    const input: string[] = [`teamId: "${externalProjectId}"`, `title: "${title.replace(/"/g, '\\"')}"`];
+    if (description) input.push(`description: "${description.replace(/"/g, '\\"')}"`);
+
+    if (assigneeEmail) {
+      const userData = await linearFetch<{ users: { nodes: Array<{ id: string }> } }>(
+        accessToken,
+        `query { users(filter: { email: { eq: "${assigneeEmail}" } }) { nodes { id } } }`,
+      );
+      const userId = userData.users.nodes[0]?.id;
+      if (userId) input.push(`assigneeId: "${userId}"`);
+    }
+
+    if (priority) {
+      const prioMap: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4, none: 0 };
+      const prioNum = prioMap[priority.toLowerCase()];
+      if (prioNum !== undefined) input.push(`priority: ${prioNum}`);
+    }
+
+    const data = await linearFetch<{
+      issueCreate: {
+        success: boolean;
+        issue: {
+          identifier: string;
+          title: string;
+          description: string | null;
+          state: { name: string };
+          priority: number;
+          assignee: { name: string; email: string } | null;
+          labels: { nodes: Array<{ name: string }> };
+          url: string;
+          updatedAt: string;
+        };
+      };
+    }>(
+      accessToken,
+      `mutation { issueCreate(input: { ${input.join(', ')} }) { success issue { identifier title description state { name } priority assignee { name email } labels { nodes { name } } url updatedAt } } }`,
+    );
+
+    const issue = data.issueCreate.issue;
+    return {
+      id: issue.identifier,
+      title: issue.title,
+      description: issue.description ?? undefined,
+      status: mapStatus(issue.state.name),
+      priority: mapPriority(issue.priority),
+      assigneeName: issue.assignee?.name,
+      assigneeEmail: issue.assignee?.email,
+      labels: issue.labels.nodes.map((l) => l.name),
+      url: issue.url,
+      provider: 'linear',
+      externalProjectId,
+      updatedAt: issue.updatedAt,
+    };
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/task-provider.interface.ts
+++ b/apps/backend/src/integrations/providers/task-provider.interface.ts
@@ -35,9 +35,21 @@ export interface ProviderStatus {
   type?: string;  // provider-specific category (e.g., ClickUp: "open"/"done"/"closed", Linear: workflow state type)
 }
 
+export interface TaskProviderCreateParams {
+  accessToken: string;
+  externalProjectId: string;
+  title: string;
+  description?: string;
+  assigneeEmail?: string;
+  priority?: string;
+  labels?: string[];
+  config: Record<string, unknown>;
+}
+
 export interface TaskProvider {
   fetchTasks(params: TaskProviderFetchParams): Promise<Task[]>;
   fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]>;
   getTaskStatuses(params: { accessToken: string; taskId: string; config: Record<string, unknown> }): Promise<ProviderStatus[]>;
   updateTask(params: TaskProviderUpdateParams): Promise<void>;
+  createTask(params: TaskProviderCreateParams): Promise<Task>;
 }

--- a/apps/backend/src/integrations/tasks.controller.ts
+++ b/apps/backend/src/integrations/tasks.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Param,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -129,5 +130,21 @@ export class TasksController {
       { statusName: body.statusName, assigneeEmail: body.assigneeEmail },
     );
     return { success: true };
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createTask(
+    @CurrentUser() user: RequestUser,
+    @Body() body: {
+      teamId: string;
+      title: string;
+      description?: string;
+      assigneeEmail?: string;
+      priority?: string;
+      labels?: string[];
+    },
+  ): Promise<Task> {
+    return this.tasksService.createTask(user.organizationId, body);
   }
 }

--- a/apps/backend/src/integrations/tasks.service.ts
+++ b/apps/backend/src/integrations/tasks.service.ts
@@ -99,6 +99,37 @@ export class TasksService {
     });
   }
 
+  async createTask(
+    orgId: string,
+    params: { teamId: string; title: string; description?: string; assigneeEmail?: string; priority?: string; labels?: string[] },
+  ): Promise<Task> {
+    const integrations = await this.integrationsService.findAll(orgId);
+    if (integrations.length === 0) {
+      throw new NotFoundException('No integrations configured for this organization');
+    }
+
+    for (const integration of integrations) {
+      const rawIntegration = await this.integrationsService.findOne(orgId, integration.provider);
+      const mappings = await this.integrationsService.getMappings(rawIntegration.id);
+      const mapping = mappings.find((m) => m.teamId === params.teamId);
+      if (!mapping) continue;
+
+      const provider = getProvider(integration.provider);
+      return provider.createTask({
+        accessToken: rawIntegration.access_token,
+        externalProjectId: mapping.externalProjectId,
+        title: params.title,
+        description: params.description,
+        assigneeEmail: params.assigneeEmail,
+        priority: params.priority,
+        labels: params.labels,
+        config: { ...rawIntegration.config, ...mapping.config },
+      });
+    }
+
+    throw new NotFoundException('No project mapping found for this team');
+  }
+
   async getProjects(orgId: string, providerName: IntegrationProvider): Promise<ExternalProject[]> {
     const integration = await this.integrationsService.findOne(orgId, providerName);
     const provider = getProvider(providerName);

--- a/apps/claude-plugins/CLAUDE.md
+++ b/apps/claude-plugins/CLAUDE.md
@@ -194,5 +194,6 @@ Also create a matching feature branch in the new repo (same name as the current 
 - `/morning` — Pick a task and start working
 - `/finish` — Complete a task, measure work, send telemetry
 - `/pause` — Pause current task, switch to another
+- `/create` — Create a new task in the ticket system
 - `/standup` — Generate a team standup report
 - `/blockers` — See what's slowing the team down

--- a/apps/claude-plugins/skills/create/SKILL.md
+++ b/apps/claude-plugins/skills/create/SKILL.md
@@ -1,0 +1,99 @@
+Create a new task in the team's ticket system. Use when you discover work that needs tracking while coding.
+
+## Steps
+
+### 1. Setup
+
+```bash
+source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+echo "---CONFIG---"
+echo "TOKEN=$TANDEMU_TOKEN"
+echo "API=$TANDEMU_API"
+echo "TEAM=$TANDEMU_TEAM_ID"
+echo "EMAIL=$TANDEMU_USER_EMAIL"
+
+echo "---ACTIVE_TASK---"
+cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
+```
+
+### 2. Get task details
+
+Use AskUserQuestion to get the task title. The developer should be able to type freely:
+- Question: "What needs to be done?"
+- Header: "New Task"
+- Options:
+  - Label: "Bug fix", Description: "Something is broken and needs fixing"
+  - Label: "Feature", Description: "New functionality to build"
+  - Label: "Tech debt", Description: "Cleanup, refactor, or improvement"
+
+The developer will likely select "Other" and type their own title. Use whatever they provide as the task title.
+
+Then optionally ask for priority:
+- Question: "What priority?"
+- Header: "Priority"
+- Options:
+  - Label: "Urgent", Description: "Drop everything"
+  - Label: "High", Description: "Do it soon"
+  - Label: "Medium", Description: "Normal priority"
+  - Label: "Low", Description: "When you get to it"
+
+### 3. Create the task
+
+```bash
+RESULT=$(curl -sf -X POST "$TANDEMU_API/api/tasks" \
+  -H "Authorization: Bearer $TANDEMU_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "teamId": "'"$TANDEMU_TEAM_ID"'",
+    "title": "<title from step 2>",
+    "description": "<description if provided>",
+    "assigneeEmail": "'"$TANDEMU_USER_EMAIL"'",
+    "priority": "<priority from step 2>"
+  }')
+echo "$RESULT"
+```
+
+Extract the task ID and URL from the response.
+
+### 4. What to do next
+
+If there's an active task (from step 1), use AskUserQuestion:
+- Question: "Task created: **<title>** (<task.id>). What would you like to do?"
+- Header: "Next"
+- Options:
+  - Label: "Continue current task", Description: "Keep working on <active task title>"
+  - Label: "Switch to new task", Description: "Pause current and start working on the new one"
+  - Label: "Leave for later", Description: "Task is logged — someone can pick it up"
+
+If **Continue current task**: just confirm and stop.
+
+If **Switch to new task**:
+  1. Pause the current task (send partial telemetry, update status back to todo)
+  2. Set up the new task: create branch, write active task file, update status to in progress
+  3. Show readiness summary (same as /morning step 6)
+
+If **Leave for later**: just confirm creation and stop.
+
+If there's NO active task, use AskUserQuestion:
+- Question: "Task created: **<title>** (<task.id>). What would you like to do?"
+- Header: "Next"
+- Options:
+  - Label: "Start working on it", Description: "Set it up as your active task"
+  - Label: "Leave for later", Description: "Task is logged — pick it up with /morning"
+
+### 5. Confirm
+
+Show:
+```
+Created: [<task.id>] <title>
+URL: <task.url>
+Priority: <priority>
+Status: <what was decided in step 4>
+```
+
+### Notes
+
+- The task is created in whichever ticket system is connected to the team (Linear, Jira, ClickUp, etc.)
+- The developer's email is auto-assigned unless they choose "Leave for later"
+- If no integration is configured, tell the developer to connect one at the dashboard
+- This skill works standalone or after /pause suggests it

--- a/apps/claude-plugins/skills/pause/SKILL.md
+++ b/apps/claude-plugins/skills/pause/SKILL.md
@@ -136,5 +136,5 @@ Task paused: <title>
 Duration: <elapsed time>
 Progress: <additions> additions, <deletions> deletions across <N> repo(s)
 
-Run /morning to pick a new task or resume this one later.
+Run /morning to pick a new task, /create to log a new one, or resume this one later.
 ```


### PR DESCRIPTION
## Summary

- Add `POST /api/tasks` endpoint for creating tasks via the Tandemu API
- Implement `createTask` in all 5 providers: Linear (issueCreate), Jira (REST), GitHub (create issue), ClickUp (create task), Asana (create task)
- New `/create` skill for logging tasks from the CLI
- Updated `/pause` to hint about `/create`
- Added `/create` to CLAUDE.md skills list

## Test plan

- [ ] `POST /api/tasks` with title + teamId → creates task in Linear
- [ ] `/create` skill prompts for title and priority, creates task
- [ ] `/create` while mid-task → offers to continue or switch
- [ ] `/pause` → shows /create hint in completion message

🤖 Generated with [Claude Code](https://claude.com/claude-code)