### PR TITLE
feat: org-wide shared memory with dual-scope search and draft gating

### DIFF
--- a/apps/backend/src/memory/memory.controller.ts
+++ b/apps/backend/src/memory/memory.controller.ts
@@ -15,13 +15,18 @@ import { JwtAuthGuard } from '../auth/auth.guard.js';
 import { CurrentUser } from '../auth/auth.decorator.js';
 import type { RequestUser } from '../auth/auth.decorator.js';
 import { MemoryService } from './memory.service.js';
+import { TasksService } from '../integrations/tasks.service.js';
 
 @Controller('memory')
 @UseGuards(JwtAuthGuard)
 export class MemoryController {
   private readonly logger = new Logger(MemoryController.name);
+  private readonly publishedTaskCache = new Map<string, boolean>();
 
-  constructor(private readonly memoryService: MemoryService) {}
+  constructor(
+    private readonly memoryService: MemoryService,
+    private readonly tasksService: TasksService,
+  ) {}
 
   @Get('config')
   getConfig(@Req() req: Request): { type: string; url: string } {
@@ -53,8 +58,18 @@ export class MemoryController {
     const upstreamUrl = this.memoryService.getUpstreamSseUrl(user.userId);
     const upstreamHeaders = this.memoryService.getUpstreamMessageHeaders();
 
-    // Inject user_id into MCP tool call arguments so memories are scoped per user
-    const enrichedBody = this.injectUserId(body, user.userId);
+    // Check if this is a search/get that needs dual-scope (personal + org)
+    const rpc = body as Record<string, unknown> | null;
+    const isSearch = rpc?.method === 'tools/call' && this.isSearchOrGetTool(rpc);
+
+    if (isSearch) {
+      // Dual-scope search: personal (user_id) + org (app_id)
+      await this.dualScopeSearch(body, user, upstreamUrl, upstreamHeaders, res);
+      return;
+    }
+
+    // For non-search calls: inject user_id and optionally app_id
+    const enrichedBody = this.injectScoping(body, user.userId, user.organizationId);
 
     let upstreamResponse: globalThis.Response;
     try {
@@ -82,7 +97,6 @@ export class MemoryController {
     const contentType = upstreamResponse.headers.get('content-type') ?? '';
 
     if (contentType.includes('text/event-stream') && upstreamResponse.body) {
-      // Streaming response — pipe SSE back to client
       res.setHeader('Content-Type', 'text/event-stream');
       res.setHeader('Cache-Control', 'no-cache');
       res.setHeader('Connection', 'keep-alive');
@@ -102,7 +116,6 @@ export class MemoryController {
         res.end();
       }
     } else {
-      // JSON response — forward directly
       const json = await upstreamResponse.json().catch(() => ({}));
       res.status(upstreamResponse.status).json(json);
     }
@@ -252,10 +265,21 @@ export class MemoryController {
   }
 
   /**
-   * Inject user_id into MCP tool call arguments so memories are scoped per user.
-   * MCP JSON-RPC tool calls have: { method: "tools/call", params: { name: "...", arguments: { ... } } }
+   * Check if a tool call is a search or get operation that needs dual-scope.
    */
-  private injectUserId(body: unknown, userId: string): unknown {
+  private isSearchOrGetTool(rpc: Record<string, unknown>): boolean {
+    const params = rpc.params as Record<string, unknown> | undefined;
+    const toolName = params?.name as string | undefined;
+    return toolName === 'search_memories' || toolName === 'get_memories';
+  }
+
+  /**
+   * Inject scoping into MCP tool call arguments.
+   * - user_id: always injected for personal scope
+   * - app_id: injected when Claude passes app_id: "org" (replaced with actual orgId)
+   * - metadata: for add_memory, inject draft status with taskId for org memories
+   */
+  private injectScoping(body: unknown, userId: string, organizationId: string): unknown {
     if (!body || typeof body !== 'object') return body;
     const rpc = body as Record<string, unknown>;
 
@@ -263,22 +287,299 @@ export class MemoryController {
       const params = rpc.params as Record<string, unknown>;
       if (params.arguments && typeof params.arguments === 'object') {
         const args = params.arguments as Record<string, unknown>;
-        // Set user_id on the arguments directly
-        if (!args.user_id) {
-          args.user_id = userId;
-        }
-        // Also ensure filters include user_id for search/get operations
-        if (!args.filters) {
-          args.filters = { user_id: userId };
-        } else if (typeof args.filters === 'object') {
-          const filters = args.filters as Record<string, unknown>;
-          if (!filters.user_id) {
-            filters.user_id = userId;
+
+        // Check if this is an org-scoped memory (app_id: "org")
+        const isOrgScope = args.app_id === 'org';
+
+        if (isOrgScope) {
+          // Replace "org" sentinel with actual organization ID
+          args.app_id = organizationId;
+          // Don't set user_id for org memories — they're shared
+          // But add metadata for draft gating
+          if (!args.metadata || typeof args.metadata !== 'object') {
+            args.metadata = {};
+          }
+          const metadata = args.metadata as Record<string, unknown>;
+          metadata.status = metadata.status ?? 'draft';
+          metadata.author_id = userId;
+        } else {
+          // Personal memory — inject user_id
+          if (!args.user_id) {
+            args.user_id = userId;
+          }
+          // Ensure filters include user_id for search/get
+          if (!args.filters) {
+            args.filters = { user_id: userId };
+          } else if (typeof args.filters === 'object') {
+            const filters = args.filters as Record<string, unknown>;
+            if (!filters.user_id) {
+              filters.user_id = userId;
+            }
           }
         }
       }
     }
 
     return body;
+  }
+
+  /**
+   * Dual-scope search: query personal memories (user_id) + org memories (app_id),
+   * merge results, and filter drafts from other users.
+   */
+  private async dualScopeSearch(
+    body: unknown,
+    user: RequestUser,
+    upstreamUrl: string,
+    upstreamHeaders: Record<string, string>,
+    res: Response,
+  ): Promise<void> {
+    const rpc = JSON.parse(JSON.stringify(body)) as Record<string, unknown>;
+    const params = rpc.params as Record<string, unknown>;
+    const args = (params.arguments ?? {}) as Record<string, unknown>;
+
+    // Build personal search body
+    const personalBody = JSON.parse(JSON.stringify(body));
+    const personalArgs = (personalBody.params as Record<string, unknown>).arguments as Record<string, unknown>;
+    personalArgs.user_id = user.userId;
+    if (!personalArgs.filters) personalArgs.filters = { user_id: user.userId };
+
+    // Build org search body
+    const orgBody = JSON.parse(JSON.stringify(body));
+    const orgArgs = (orgBody.params as Record<string, unknown>).arguments as Record<string, unknown>;
+    delete orgArgs.user_id;
+    orgArgs.app_id = user.organizationId;
+    orgArgs.filters = { app_id: user.organizationId };
+
+    const fetchUpstream = async (reqBody: unknown) => {
+      const response = await fetch(upstreamUrl, {
+        method: 'POST',
+        headers: { ...upstreamHeaders, 'Accept': 'text/event-stream, application/json' },
+        body: JSON.stringify(reqBody),
+      });
+      if (!response.ok) return null;
+      return response.json().catch(() => null);
+    };
+
+    try {
+      const [personalResult, orgResult] = await Promise.all([
+        fetchUpstream(personalBody),
+        fetchUpstream(orgBody),
+      ]);
+
+      // Extract results from MCP JSON-RPC responses
+      const personalMemories = this.extractMemories(personalResult);
+      const orgMemories = this.extractMemories(orgResult);
+
+      // Lazy-evaluate draft org memories:
+      // - Author's own drafts: always shown
+      // - Other users' drafts: check if the task is done → promote to published
+      // - Published: always shown
+      const filteredOrgMemories: Array<Record<string, unknown>> = [];
+      for (const mem of orgMemories) {
+        const metadata = mem.metadata as Record<string, unknown> | null;
+        if (!metadata) { filteredOrgMemories.push(mem); continue; }
+
+        const status = metadata.status as string | undefined;
+        if (status === 'published' || !status) { filteredOrgMemories.push(mem); continue; }
+
+        if (status === 'draft') {
+          // Author always sees their own drafts
+          if (metadata.author_id === user.userId) { filteredOrgMemories.push(mem); continue; }
+
+          // For other users' drafts: check if the task is finalized
+          const taskId = metadata.taskId as string | undefined;
+          if (taskId) {
+            const taskStatus = await this.getTaskFinalStatus(taskId, user);
+            if (taskStatus === 'done') {
+              // Promote to published — update the memory asynchronously
+              metadata.status = 'published';
+              this.promoteMemory(mem.id as string, upstreamUrl, upstreamHeaders).catch(() => {});
+              filteredOrgMemories.push(mem);
+            } else if (taskStatus === 'cancelled') {
+              // Cancelled work — delete the draft, knowledge may be invalid
+              this.deleteMemory(mem.id as string, upstreamUrl, upstreamHeaders).catch(() => {});
+              // Don't include in results
+            }
+            // 'pending' — skip, draft from unmerged work
+          }
+        }
+      }
+
+      // Merge and deduplicate by ID
+      const seen = new Set<string>();
+      const merged = [];
+      for (const mem of [...personalMemories, ...filteredOrgMemories]) {
+        if (!seen.has(mem.id)) {
+          seen.add(mem.id);
+          merged.push(mem);
+        }
+      }
+
+      // Sort by score descending
+      merged.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+
+      // Reconstruct the MCP response
+      const responseBody = personalResult ?? orgResult;
+      if (responseBody && typeof responseBody === 'object') {
+        const result = responseBody as Record<string, unknown>;
+        if (result.result && typeof result.result === 'object') {
+          // Tool result contains stringified JSON
+          const toolResult = result.result as Record<string, unknown>;
+          if (typeof toolResult.content === 'object' && Array.isArray(toolResult.content)) {
+            const content = toolResult.content as Array<Record<string, unknown>>;
+            if (content[0] && content[0].text) {
+              content[0].text = JSON.stringify({ results: merged });
+            }
+          }
+        } else if (typeof result.result === 'string') {
+          try {
+            const parsed = JSON.parse(result.result as string);
+            parsed.results = merged;
+            result.result = JSON.stringify(parsed);
+          } catch {
+            // Not JSON string, return as-is
+          }
+        }
+        res.json(responseBody);
+      } else {
+        res.json({ result: JSON.stringify({ results: merged }) });
+      }
+    } catch (err) {
+      this.logger.error(`Dual-scope search failed: ${err}`);
+      res.status(502).json({ error: 'Memory search failed' });
+    }
+  }
+
+  /**
+   * Extract memory objects from an MCP tool response.
+   */
+  private extractMemories(result: unknown): Array<Record<string, unknown>> {
+    if (!result || typeof result !== 'object') return [];
+    const rpc = result as Record<string, unknown>;
+
+    let resultsStr = '';
+    if (typeof rpc.result === 'string') {
+      resultsStr = rpc.result;
+    } else if (rpc.result && typeof rpc.result === 'object') {
+      const toolResult = rpc.result as Record<string, unknown>;
+      if (Array.isArray(toolResult.content)) {
+        const content = toolResult.content as Array<Record<string, unknown>>;
+        resultsStr = (content[0]?.text as string) ?? '';
+      }
+    }
+
+    try {
+      const parsed = JSON.parse(resultsStr);
+      return Array.isArray(parsed.results) ? parsed.results : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Check task status for draft memory promotion.
+   * Returns: 'done' (promote), 'cancelled' (delete), 'pending' (keep as draft)
+   */
+  private async getTaskFinalStatus(taskId: string, user: RequestUser): Promise<'done' | 'cancelled' | 'pending'> {
+    const cached = this.publishedTaskCache.get(taskId);
+    if (cached === true) return 'done';
+    if (cached === false) return 'pending';
+
+    try {
+      const tasks = await this.tasksService.getTasks(user.organizationId, {});
+      const task = tasks.find((t) => t.id === taskId);
+      if (task?.status === 'done') {
+        this.publishedTaskCache.set(taskId, true);
+        return 'done';
+      }
+      if (task?.status === 'cancelled') {
+        return 'cancelled';
+      }
+      this.publishedTaskCache.set(taskId, false);
+      return 'pending';
+    } catch {
+      return 'pending';
+    }
+  }
+
+  /**
+   * Promote a draft memory to published by updating its metadata.
+   */
+  private async promoteMemory(
+    memoryId: string,
+    upstreamUrl: string,
+    upstreamHeaders: Record<string, string>,
+  ): Promise<void> {
+    try {
+      await fetch(upstreamUrl, {
+        method: 'POST',
+        headers: { ...upstreamHeaders, 'Accept': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `promote-${memoryId}`,
+          method: 'tools/call',
+          params: {
+            name: 'update_memory',
+            arguments: {
+              memory_id: memoryId,
+              metadata: { status: 'published' },
+            },
+          },
+        }),
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to promote memory ${memoryId}: ${err}`);
+    }
+  }
+
+  /**
+   * Delete a memory (e.g., from cancelled task — knowledge may be invalid).
+   */
+  private async deleteMemory(
+    memoryId: string,
+    upstreamUrl: string,
+    upstreamHeaders: Record<string, string>,
+  ): Promise<void> {
+    try {
+      await fetch(upstreamUrl, {
+        method: 'POST',
+        headers: { ...upstreamHeaders, 'Accept': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `delete-${memoryId}`,
+          method: 'tools/call',
+          params: {
+            name: 'delete_memory',
+            arguments: { memory_id: memoryId },
+          },
+        }),
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to delete memory ${memoryId}: ${err}`);
+    }
+  }
+
+  /**
+   * Rewrite the endpoint URL in an SSE endpoint event to point to our proxy.
+   */
+  private rewriteEndpointEvent(message: string, backendBaseUrl: string): string {
+    const lines = message.split('\n');
+    const rewritten = lines.map((line) => {
+      if (line.startsWith('data:')) {
+        const url = line.slice(5).trim();
+        try {
+          const parsed = new URL(url);
+          const sessionId = parsed.searchParams.get('sessionId') ?? '';
+          return `data: ${backendBaseUrl}/messages?sessionId=${encodeURIComponent(sessionId)}`;
+        } catch {
+          const sessionMatch = url.match(/sessionId=([^&\s]+)/);
+          const sessionId = sessionMatch?.[1] ?? '';
+          return `data: ${backendBaseUrl}/messages?sessionId=${encodeURIComponent(sessionId)}`;
+        }
+      }
+      return line;
+    });
+    return rewritten.join('\n');
   }
 }

--- a/apps/backend/src/memory/memory.module.ts
+++ b/apps/backend/src/memory/memory.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { MemoryController } from './memory.controller.js';
 import { MemoryService } from './memory.service.js';
 import { AuthModule } from '../auth/auth.module.js';
+import { IntegrationsModule } from '../integrations/integrations.module.js';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, forwardRef(() => IntegrationsModule)],
   controllers: [MemoryController],
   providers: [MemoryService],
   exports: [MemoryService],

--- a/apps/claude-plugins/CLAUDE.md
+++ b/apps/claude-plugins/CLAUDE.md
@@ -56,27 +56,25 @@ You have access to MCP memory tools via the `tandemu-memory` server. The availab
 
 ### What to remember (do this continuously, not just at session boundaries)
 
-**Personal context** — store when you learn it, never ask for it directly:
+Memories are split into two scopes. The proxy handles merging — you just pass `app_id: "org"` when storing shared knowledge.
+
+**Personal memories** (default — stored with user_id only):
 - Their name (the moment you learn it, store it — this is priority #1)
 - Role, timezone, team
 - Communication style and preferences
 - Personal interests they mention (projects, hobbies, frustrations)
 - How they react to suggestions
+- **Coding DNA**: naming conventions, error handling style, framework preferences, testing approach, code organization habits, import style
 
-**Coding DNA** — store as you observe patterns across the session:
-- Naming conventions they use or enforce
-- Error handling style (try/catch? early returns? Result types?)
-- Framework and library preferences
-- Testing approach (TDD? tests after? which framework?)
-- Code organization habits (file structure, module patterns)
-- Import style, comment density, type annotation habits
-- When they override your suggestions — what they prefer instead
-
-**Project context** — store for cross-session continuity:
+**Shared org memories** (pass `app_id: "org"` in the add_memory call):
 - Architecture decisions and the reasoning behind them
 - Known gotchas in specific files or modules
-- Dependencies and their quirks
+- Dependencies and their quirks/workarounds
 - Patterns that worked vs ones that caused problems
+- Task learnings and key decisions
+- New libraries or patterns introduced to the codebase
+
+Shared memories are stored as drafts until the task is complete, then become visible to all team members. When searching, the proxy returns both personal and org-wide results automatically.
 
 ### When to store memories
 

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -279,18 +279,20 @@ Telemetry: trace ✓ | metrics ✓
 
 After measuring the work, store memories about this task. Do this silently — don't announce it.
 
-**Store task context:**
+**Store shared org memories** (pass `app_id: "org"` in the add_memory call — visible to all team members after task completes):
 - What was accomplished: "Completed <taskId> — <brief description of what was built/fixed>"
-- Key decisions made during the task
-- Any new patterns or libraries introduced
+- Key architecture decisions made during the task
+- New patterns or libraries introduced to the codebase
+- Known gotchas discovered in specific files or modules
+- Dependency quirks or workarounds found
 
-**Store coding observations (if any new ones were noticed during this task):**
-- Naming conventions the developer used
+**Store personal coding observations** (default user_id scope — only visible to this developer):
+- Naming conventions the developer used or enforced
 - Error handling patterns observed
 - File organization choices
 - Any corrections the developer made to your suggestions
 
-**Store communication style (if new patterns were noticed):**
+**Store personal communication style** (if new patterns were noticed):
 
 Review the developer's messages from this session. Look for persistent style patterns — NOT momentary mood. Only store if you noticed something new or different from what memory already has.
 


### PR DESCRIPTION
## Summary

- Split memory into personal (`user_id`) and org-wide (`app_id`) scopes
- Backend proxy merges both scopes on search transparently (dual-scope search)
- Org memories stored as drafts during `/finish` — promoted when task is done, deleted when cancelled
- Lazy task status evaluation: no webhooks needed, checks on search
- `app_id: "org"` convention in CLAUDE.md for Claude to use when storing shared knowledge
- Updated `/finish` to store architecture decisions and patterns as org-wide

## How it works

1. Claude stores personal memory (default) → scoped to `user_id`
2. Claude stores org memory (passes `app_id: "org"`) → scoped to `app_id` with draft status
3. Search queries → proxy issues TWO upstream searches, merges results
4. Drafts from other users → proxy checks task status, promotes if done, deletes if cancelled
5. Author always sees own drafts regardless of task status

## Test plan

- [ ] Store personal memory → only that user finds it
- [ ] Store org memory with `app_id: "org"` → stored as draft
- [ ] Author searches → sees own drafts
- [ ] Other user searches after task done → memory promoted to published
- [ ] Task cancelled → draft memory deleted
- [ ] Search returns merged personal + org results

🤖 Generated with [Claude Code](https://claude.com/claude-code)