### PR TITLE
feat: competitive parity metrics — hot files, investment, AI effectiveness, cost

### DIFF
--- a/apps/backend/src/telemetry/telemetry.controller.ts
+++ b/apps/backend/src/telemetry/telemetry.controller.ts
@@ -41,6 +41,51 @@ export class TelemetryController {
     return [...custom, ...native];
   }
 
+  @Get('hot-files')
+  async getHotFiles(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.telemetryService.getHotFiles(user.organizationId, startDate, endDate);
+  }
+
+  @Get('investment-allocation')
+  async getInvestmentAllocation(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.telemetryService.getInvestmentAllocation(user.organizationId, startDate, endDate);
+  }
+
+  @Get('ai-effectiveness')
+  async getAIEffectiveness(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.telemetryService.getAIEffectiveness(user.organizationId, startDate, endDate);
+  }
+
+  @Get('cost-metrics')
+  async getCostMetrics(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.telemetryService.getCostMetrics(user.organizationId, startDate, endDate);
+  }
+
+  @Get('token-usage')
+  async getTokenUsage(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.telemetryService.getTokenUsage(user.organizationId, startDate, endDate);
+  }
+
   @Get('tool-usage')
   async getToolUsage(
     @CurrentUser() user: RequestUser,

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -414,6 +414,202 @@ export class TelemetryService implements OnModuleDestroy {
     }
   }
 
+  async getHotFiles(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<Array<{ filePath: string; changeCount: number; taskCount: number; developerCount: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+      if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            arrayJoin(splitByChar(',', SpanAttributes['changed_files'])) AS file_path,
+            count(*) AS change_count,
+            uniq(SpanAttributes['task_id']) AS task_count,
+            uniq(SpanAttributes['user_id']) AS developer_count
+          FROM otel_traces
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND SpanName = 'task_session'
+            AND SpanAttributes['changed_files'] != ''
+            ${dateFilter}
+          GROUP BY file_path
+          ORDER BY change_count DESC
+          LIMIT 20
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{ file_path: string; change_count: number; task_count: number; developer_count: number }>();
+      return rows.map((r) => ({
+        filePath: r.file_path,
+        changeCount: Number(r.change_count),
+        taskCount: Number(r.task_count),
+        developerCount: Number(r.developer_count),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async getInvestmentAllocation(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<Array<{ category: string; taskCount: number; totalHours: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+      if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            SpanAttributes['task_category'] AS category,
+            count(*) AS task_count,
+            sum(toFloat64OrZero(SpanAttributes['duration_seconds'])) / 3600 AS total_hours
+          FROM otel_traces
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND SpanName = 'task_session'
+            AND SpanAttributes['task_category'] != ''
+            ${dateFilter}
+          GROUP BY category
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{ category: string; task_count: number; total_hours: number }>();
+      return rows.map((r) => ({
+        category: r.category,
+        taskCount: Number(r.task_count),
+        totalHours: Math.round(Number(r.total_hours) * 10) / 10,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async getAIEffectiveness(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<Array<{ filePath: string; aiTouchCount: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+      if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            arrayJoin(splitByChar(',', SpanAttributes['ai_files'])) AS file_path,
+            count(*) AS ai_touch_count
+          FROM otel_traces
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND SpanName = 'task_session'
+            AND SpanAttributes['ai_files'] != ''
+            ${dateFilter}
+          GROUP BY file_path
+          ORDER BY ai_touch_count DESC
+          LIMIT 20
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{ file_path: string; ai_touch_count: number }>();
+      return rows.map((r) => ({
+        filePath: r.file_path,
+        aiTouchCount: Number(r.ai_touch_count),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async getCostMetrics(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<Array<{ date: string; totalCost: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+      if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            toDate(TimeUnix) AS date,
+            sum(Value) AS total_cost
+          FROM otel_metrics_sum
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND MetricName = 'claude_code.cost.usage'
+            ${dateFilter}
+          GROUP BY date
+          ORDER BY date ASC
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{ date: string; total_cost: number }>();
+      return rows.map((r) => ({
+        date: r.date,
+        totalCost: Math.round(Number(r.total_cost) * 100) / 100,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async getTokenUsage(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<Array<{ tokenType: string; model: string; totalTokens: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+      if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            Attributes['type'] AS token_type,
+            Attributes['model'] AS model,
+            sum(Value) AS total_tokens
+          FROM otel_metrics_sum
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND MetricName = 'claude_code.token.usage'
+            ${dateFilter}
+          GROUP BY token_type, model
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{ token_type: string; model: string; total_tokens: number }>();
+      return rows.map((r) => ({
+        tokenType: r.token_type,
+        model: r.model,
+        totalTokens: Number(r.total_tokens),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
   /**
    * Tool usage stats from Claude Code's native tool_result events.
    * Shows which tools the team uses, success rates, and avg duration.

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -133,11 +133,35 @@ For AI vs Manual attribution:
 - All other line additions are `manual_lines`.
 - If no commits have the Claude co-author tag, attribute all lines as `manual_lines`.
 
+Additionally, collect file-level data for each repo:
+
+```bash
+# Changed file paths
+git -C <repo> diff $DEFAULT_BRANCH...HEAD --name-only 2>/dev/null
+
+# Files touched by AI-attributed commits only
+for hash in <AI_COMMIT_HASHES>; do
+  git -C <repo> diff $hash^..$hash --name-only 2>/dev/null
+done | sort -u
+```
+
+Aggregate across all repos into comma-separated strings:
+- `changed_files`: all unique file paths changed on the branch
+- `file_count`: number of unique files changed
+- `ai_files`: file paths touched by AI-attributed commits only
+
+Also read `category` and `labels` from the active task file (set by `/morning`).
+
 Calculate:
 - `duration_seconds`: `startedAt` to now
 - `total_commits`: total commits across all repos
 - `ai_lines`: total additions from Claude-attributed commits
 - `manual_lines`: total additions minus `ai_lines`
+- `changed_files`: comma-separated file paths
+- `file_count`: number of unique files
+- `ai_files`: comma-separated file paths from AI commits
+- `task_category`: from active task file (feature/bugfix/tech_debt/maintenance/other)
+- `task_labels`: from active task file (comma-separated label names)
 
 #### 4b. Send telemetry
 
@@ -188,6 +212,11 @@ TRACE_HTTP=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$OTEL_ENDPOINT/v1/
             {"key": "manual_lines", "value": {"stringValue": "<manual_lines>"}},
             {"key": "duration_seconds", "value": {"stringValue": "'"$DURATION_S"'"}},
             {"key": "commits", "value": {"stringValue": "<total_commits>"}},
+            {"key": "changed_files", "value": {"stringValue": "<changed_files>"}},
+            {"key": "file_count", "value": {"stringValue": "<file_count>"}},
+            {"key": "ai_files", "value": {"stringValue": "<ai_files>"}},
+            {"key": "task_category", "value": {"stringValue": "<task_category>"}},
+            {"key": "task_labels", "value": {"stringValue": "<task_labels>"}},
             {"key": "deployment", "value": {"stringValue": "true"}}
           ],
           "status": {}

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -155,7 +155,12 @@ git pull origin "$DEFAULT_BRANCH" 2>/dev/null || true
 git checkout -b feat/<task.id>-<short-kebab-description>
 ```
 
-- Write the active task file:
+- Write the active task file. Infer the task category from labels:
+  - Labels containing "bug", "fix", "hotfix" → `bugfix`
+  - Labels containing "feature", "enhancement" → `feature`
+  - Labels containing "debt", "refactor", "chore" → `tech_debt`
+  - Labels containing "maintenance", "ops", "infra" → `maintenance`
+  - Default → `other`
 
 ```bash
 REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -167,7 +172,9 @@ cat > ~/.claude/tandemu-active-task.json << EOF
   "startedAt": "$NOW",
   "repos": ["$REPO_PATH"],
   "provider": "<task.provider>",
-  "url": "<task.url>"
+  "url": "<task.url>",
+  "category": "<inferred category>",
+  "labels": [<task.labels as JSON array>]
 }
 EOF
 ```

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Activity, Brain, Users, Code2, Timer, Wrench } from "lucide-react";
-import { getAIRatio, getTimesheets, getToolUsage, getDeveloperStats, getTaskVelocity } from '@/lib/api';
-import type { TimesheetEntry, ToolUsageStat, DeveloperStat, TaskVelocityEntry } from '@/lib/api';
+import { getAIRatio, getTimesheets, getToolUsage, getDeveloperStats, getTaskVelocity, getHotFiles, getInvestmentAllocation, getAIEffectiveness, getCostMetrics } from '@/lib/api';
+import type { TimesheetEntry, ToolUsageStat, DeveloperStat, TaskVelocityEntry, HotFile, InvestmentAllocation, AIEffectivenessEntry, CostEntry } from '@/lib/api';
 import type { AIvsManualRatio } from '@tandemu/types';
 import { InstallBanner } from '@/components/install-banner';
 import { BillingBanner } from '@/components/billing-banner';
@@ -13,6 +13,10 @@ import { AIRatioChart } from '@/components/charts/ai-ratio-chart';
 import { ToolUsageChart } from '@/components/charts/tool-usage-chart';
 import { DeveloperLeaderboard } from '@/components/charts/developer-leaderboard';
 import { VelocityChart } from '@/components/charts/velocity-chart';
+import { HotFilesChart } from '@/components/charts/hot-files-chart';
+import { InvestmentChart } from '@/components/charts/investment-chart';
+import { AIEffectivenessChart } from '@/components/charts/ai-effectiveness-chart';
+import { CostChart } from '@/components/charts/cost-chart';
 import { TelemetryFilters, useFilterParams } from '@/components/filters/telemetry-filters';
 import { DashboardSkeleton } from '@/components/ui/skeleton-helpers';
 
@@ -30,6 +34,10 @@ export default function DashboardPage() {
   const [toolData, setToolData] = useState<ToolUsageStat[]>([]);
   const [devStats, setDevStats] = useState<DeveloperStat[]>([]);
   const [velocityData, setVelocityData] = useState<TaskVelocityEntry[]>([]);
+  const [hotFiles, setHotFiles] = useState<HotFile[]>([]);
+  const [investment, setInvestment] = useState<InvestmentAllocation[]>([]);
+  const [aiEffectiveness, setAiEffectiveness] = useState<AIEffectivenessEntry[]>([]);
+  const [costData, setCostData] = useState<CostEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const { startDate, endDate } = useFilterParams();
@@ -40,8 +48,9 @@ export default function DashboardPage() {
       setLoading(true);
       try {
         const f = { startDate, endDate };
-        const [ai, timesheets, tools, devs, velocity] = await Promise.allSettled([
+        const [ai, timesheets, tools, devs, velocity, hot, invest, aiEff, cost] = await Promise.allSettled([
           getAIRatio(f), getTimesheets(f), getToolUsage(f), getDeveloperStats(f), getTaskVelocity(f),
+          getHotFiles(f), getInvestmentAllocation(f), getAIEffectiveness(f), getCostMetrics(f),
         ]);
         if (cancelled) return;
         if (ai.status === 'fulfilled') setAiData(ai.value);
@@ -49,6 +58,10 @@ export default function DashboardPage() {
         if (tools.status === 'fulfilled') setToolData(tools.value);
         if (devs.status === 'fulfilled') setDevStats(devs.value);
         if (velocity.status === 'fulfilled') setVelocityData(velocity.value);
+        if (hot.status === 'fulfilled') setHotFiles(hot.value);
+        if (invest.status === 'fulfilled') setInvestment(invest.value);
+        if (aiEff.status === 'fulfilled') setAiEffectiveness(aiEff.value);
+        if (cost.status === 'fulfilled') setCostData(cost.value);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load dashboard data');
       } finally {
@@ -205,8 +218,20 @@ export default function DashboardPage() {
             <DeveloperLeaderboard data={devStats} />
           </div>
 
-          {/* Velocity */}
-          <VelocityChart data={velocityData} />
+          {/* Velocity + Investment Row */}
+          <div className="grid gap-4 lg:grid-cols-2">
+            <VelocityChart data={velocityData} />
+            <InvestmentChart data={investment} />
+          </div>
+
+          {/* Hot Files + AI Effectiveness Row */}
+          <div className="grid gap-4 lg:grid-cols-2">
+            <HotFilesChart data={hotFiles} />
+            <AIEffectivenessChart data={aiEffectiveness} />
+          </div>
+
+          {/* Cost */}
+          <CostChart data={costData} />
         </>
       )}
     </div>

--- a/apps/frontend/src/components/charts/ai-effectiveness-chart.tsx
+++ b/apps/frontend/src/components/charts/ai-effectiveness-chart.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import type { AIEffectivenessEntry } from '@/lib/api';
+
+interface AIEffectivenessChartProps {
+  data: AIEffectivenessEntry[];
+}
+
+export function AIEffectivenessChart({ data }: AIEffectivenessChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>AI Effectiveness</CardTitle>
+          <CardDescription>Files where AI writes the most code</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No AI file attribution data yet</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>AI Effectiveness</CardTitle>
+        <CardDescription>Files where AI writes the most code</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>File</TableHead>
+              <TableHead className="text-right">AI Touches</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.slice(0, 15).map((entry) => (
+              <TableRow key={entry.filePath}>
+                <TableCell className="font-mono text-xs truncate max-w-[350px]">{entry.filePath}</TableCell>
+                <TableCell className="text-right">
+                  <span className="text-emerald-400 font-medium">{entry.aiTouchCount}</span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/charts/cost-chart.tsx
+++ b/apps/frontend/src/components/charts/cost-chart.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import type { CostEntry } from '@/lib/api';
+
+interface CostChartProps {
+  data: CostEntry[];
+}
+
+export function CostChart({ data }: CostChartProps) {
+  const chartData = data.map((d) => ({
+    date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    cost: d.totalCost,
+  }));
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>AI Cost</CardTitle>
+          <CardDescription>Daily Claude Code usage cost</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No cost data yet — enable OTEL in Claude Code</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalCost = data.reduce((s, d) => s + d.totalCost, 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>AI Cost</CardTitle>
+            <CardDescription>Daily Claude Code usage cost</CardDescription>
+          </div>
+          <div className="text-right">
+            <span className="text-2xl font-bold">${totalCost.toFixed(2)}</span>
+            <p className="text-xs text-muted-foreground">total in period</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart data={chartData}>
+            <defs>
+              <linearGradient id="colorCostGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#60a5fa" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#60a5fa" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="date" tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} width={40} tickFormatter={(v: number) => `$${v}`} />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--tooltip-bg)', border: '1px solid var(--tooltip-border)', borderRadius: '12px', fontSize: '12px' }}
+              labelStyle={{ color: '#a1a1aa' }}
+              formatter={(value: number) => [`$${value.toFixed(2)}`, 'Cost']}
+            />
+            <Area type="monotone" dataKey="cost" stroke="#60a5fa" fill="url(#colorCostGrad)" strokeWidth={2} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/charts/hot-files-chart.tsx
+++ b/apps/frontend/src/components/charts/hot-files-chart.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import type { HotFile } from '@/lib/api';
+
+interface HotFilesChartProps {
+  data: HotFile[];
+}
+
+function getHeatColor(count: number): string {
+  if (count >= 10) return 'text-red-400';
+  if (count >= 5) return 'text-yellow-400';
+  return 'text-muted-foreground';
+}
+
+export function HotFilesChart({ data }: HotFilesChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Hot Files</CardTitle>
+          <CardDescription>Most frequently changed files across tasks</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No file change data yet</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Hot Files</CardTitle>
+        <CardDescription>Most frequently changed files across tasks</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>File</TableHead>
+              <TableHead className="text-right">Changes</TableHead>
+              <TableHead className="text-right">Tasks</TableHead>
+              <TableHead className="text-right">Devs</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.slice(0, 15).map((file) => (
+              <TableRow key={file.filePath}>
+                <TableCell className="font-mono text-xs truncate max-w-[300px]">{file.filePath}</TableCell>
+                <TableCell className={`text-right font-medium ${getHeatColor(file.changeCount)}`}>{file.changeCount}</TableCell>
+                <TableCell className="text-right">{file.taskCount}</TableCell>
+                <TableCell className="text-right">{file.developerCount}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/charts/investment-chart.tsx
+++ b/apps/frontend/src/components/charts/investment-chart.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import type { InvestmentAllocation } from '@/lib/api';
+
+interface InvestmentChartProps {
+  data: InvestmentAllocation[];
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  feature: '#4ade80',
+  bugfix: '#f87171',
+  tech_debt: '#facc15',
+  maintenance: '#60a5fa',
+  other: '#71717a',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  feature: 'Features',
+  bugfix: 'Bug Fixes',
+  tech_debt: 'Tech Debt',
+  maintenance: 'Maintenance',
+  other: 'Other',
+};
+
+export function InvestmentChart({ data }: InvestmentChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Investment Allocation</CardTitle>
+          <CardDescription>Where engineering time goes</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No task category data yet</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    name: CATEGORY_LABELS[d.category] ?? d.category,
+    value: d.totalHours,
+    tasks: d.taskCount,
+    color: CATEGORY_COLORS[d.category] ?? '#71717a',
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Investment Allocation</CardTitle>
+        <CardDescription>Where engineering time goes</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={250}>
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              innerRadius={60}
+              outerRadius={90}
+              paddingAngle={2}
+              dataKey="value"
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={index} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--tooltip-bg)', border: '1px solid var(--tooltip-border)', borderRadius: '12px', fontSize: '12px' }}
+              formatter={(value: number, _name: string, props: { payload?: { tasks: number } }) => [
+                `${value}h (${props.payload?.tasks ?? 0} tasks)`,
+                'Time',
+              ]}
+            />
+            <Legend
+              formatter={(value: string) => <span style={{ color: '#a1a1aa', fontSize: '12px' }}>{value}</span>}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -240,6 +240,55 @@ export async function getTaskVelocity(filter?: TelemetryFilter): Promise<TaskVel
   return fetchApi<TaskVelocityEntry[]>(`/api/telemetry/task-velocity${buildParams(filter)}`);
 }
 
+export interface HotFile {
+  filePath: string;
+  changeCount: number;
+  taskCount: number;
+  developerCount: number;
+}
+
+export async function getHotFiles(filter?: TelemetryFilter): Promise<HotFile[]> {
+  return fetchApi<HotFile[]>(`/api/telemetry/hot-files${buildParams(filter)}`);
+}
+
+export interface InvestmentAllocation {
+  category: string;
+  taskCount: number;
+  totalHours: number;
+}
+
+export async function getInvestmentAllocation(filter?: TelemetryFilter): Promise<InvestmentAllocation[]> {
+  return fetchApi<InvestmentAllocation[]>(`/api/telemetry/investment-allocation${buildParams(filter)}`);
+}
+
+export interface AIEffectivenessEntry {
+  filePath: string;
+  aiTouchCount: number;
+}
+
+export async function getAIEffectiveness(filter?: TelemetryFilter): Promise<AIEffectivenessEntry[]> {
+  return fetchApi<AIEffectivenessEntry[]>(`/api/telemetry/ai-effectiveness${buildParams(filter)}`);
+}
+
+export interface CostEntry {
+  date: string;
+  totalCost: number;
+}
+
+export async function getCostMetrics(filter?: TelemetryFilter): Promise<CostEntry[]> {
+  return fetchApi<CostEntry[]>(`/api/telemetry/cost-metrics${buildParams(filter)}`);
+}
+
+export interface TokenUsageEntry {
+  tokenType: string;
+  model: string;
+  totalTokens: number;
+}
+
+export async function getTokenUsage(filter?: TelemetryFilter): Promise<TokenUsageEntry[]> {
+  return fetchApi<TokenUsageEntry[]>(`/api/telemetry/token-usage${buildParams(filter)}`);
+}
+
 // ---- Organizations (mutations) ----
 
 export async function createOrganization(data: { name: string; slug: string }): Promise<Organization> {

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -73,3 +73,32 @@ export interface TaskVelocityEntry {
   readonly avgDurationHours: number;
   readonly taskCount: number;
 }
+
+export interface HotFile {
+  readonly filePath: string;
+  readonly changeCount: number;
+  readonly taskCount: number;
+  readonly developerCount: number;
+}
+
+export interface InvestmentAllocation {
+  readonly category: string;
+  readonly taskCount: number;
+  readonly totalHours: number;
+}
+
+export interface AIEffectivenessEntry {
+  readonly filePath: string;
+  readonly aiTouchCount: number;
+}
+
+export interface CostEntry {
+  readonly date: string;
+  readonly totalCost: number;
+}
+
+export interface TokenUsageEntry {
+  readonly tokenType: string;
+  readonly model: string;
+  readonly totalTokens: number;
+}


### PR DESCRIPTION
## Summary
- **Hot Files**: Track most frequently changed files across tasks via new `changed_files` span attribute from `/finish`
- **Investment Allocation**: Auto-categorize tasks as feature/bugfix/tech_debt/maintenance from task labels (set at `/morning`, sent at `/finish`)
- **AI Effectiveness**: Track which files AI writes the most code in via `ai_files` span attribute
- **AI Cost**: Query native Claude Code `claude_code.cost.usage` OTEL metric for daily cost tracking
- **Token Usage**: Query native `claude_code.token.usage` for token breakdown by type and model

New backend endpoints: `hot-files`, `investment-allocation`, `ai-effectiveness`, `cost-metrics`, `token-usage`

Key insight: leverages Claude Code's native OTEL for cost/token data instead of manual collection. `/finish` only collects what native OTEL can't: AI vs manual attribution, task association, file-level change tracking.

## Test plan
- [ ] `/morning` stores `category` and `labels` in active task JSON
- [ ] `/finish` sends `changed_files`, `file_count`, `ai_files`, `task_category`, `task_labels` in span
- [ ] `GET /api/telemetry/hot-files` returns data (after at least one enriched /finish)
- [ ] `GET /api/telemetry/investment-allocation` returns category breakdown
- [ ] `GET /api/telemetry/ai-effectiveness` returns per-file AI touch data
- [ ] `GET /api/telemetry/cost-metrics` returns daily cost (if OTEL enabled)
- [ ] Dashboard renders all new charts (empty state when no data)
- [ ] No regressions on existing charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)