### PR TITLE
fix: GraphQL variables for mutations, generic sub-project selection

### DIFF
--- a/apps/backend/src/integrations/integrations.controller.ts
+++ b/apps/backend/src/integrations/integrations.controller.ts
@@ -8,10 +8,12 @@ import {
   NotFoundException,
   Param,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { IntegrationsService } from './integrations.service.js';
 import { TasksService } from './tasks.service.js';
+import { getProvider } from './providers/index.js';
 import { JwtAuthGuard } from '../auth/auth.guard.js';
 import { RolesGuard } from '../auth/roles.guard.js';
 import { OrgRequiredGuard } from '../auth/org-required.guard.js';
@@ -107,5 +109,22 @@ export class IntegrationsController {
     @Param('provider') provider: IntegrationProvider,
   ) {
     return this.tasksService.getProjects(user.organizationId, provider);
+  }
+
+  // Fetch sub-projects within an external project (e.g. Linear projects in a team, ClickUp lists in a folder)
+  @Get(':provider/projects/:projectId/sub-projects')
+  @Roles(MembershipRole.OWNER, MembershipRole.ADMIN)
+  async getSubProjects(
+    @CurrentUser() user: RequestUser,
+    @Param('provider') provider: IntegrationProvider,
+    @Param('projectId') projectId: string,
+  ) {
+    const integration = await this.integrationsService.findOne(user.organizationId, provider);
+    const providerImpl = getProvider(provider);
+    if (!providerImpl.fetchSubProjects) return [];
+    return providerImpl.fetchSubProjects(integration.access_token, projectId, {
+      externalWorkspaceId: integration.external_workspace_id,
+      ...integration.config,
+    });
   }
 }

--- a/apps/backend/src/integrations/providers/asana.provider.ts
+++ b/apps/backend/src/integrations/providers/asana.provider.ts
@@ -122,14 +122,15 @@ const TASK_OPT_FIELDS = 'gid,name,notes,completed,assignee,assignee.email,assign
 
 export class AsanaProvider implements TaskProvider {
   async fetchTasks(params: TaskProviderFetchParams): Promise<Task[]> {
-    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone } = params;
+    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone, config } = params;
     const emails = assigneeEmails ?? (assigneeEmail ? [assigneeEmail] : []);
+    const sectionGid = config?.subProjectId as string | undefined;
 
-    // Fetch incomplete tasks
-    let tasks = await asanaFetch<AsanaTask[]>(
-      `/projects/${externalProjectId}/tasks?opt_fields=${TASK_OPT_FIELDS}&completed_since=now&limit=100`,
-      accessToken,
-    );
+    // Fetch incomplete tasks — from specific section if configured, otherwise whole project
+    const basePath = sectionGid
+      ? `/sections/${sectionGid}/tasks?opt_fields=${TASK_OPT_FIELDS}&completed_since=now&limit=100`
+      : `/projects/${externalProjectId}/tasks?opt_fields=${TASK_OPT_FIELDS}&completed_since=now&limit=100`;
+    let tasks = await asanaFetch<AsanaTask[]>(basePath, accessToken);
 
     // Also fetch recently completed tasks (for standup etc.) unless excludeDone is set
     if (!excludeDone) {
@@ -225,7 +226,8 @@ export class AsanaProvider implements TaskProvider {
   }
 
   async createTask(params: TaskProviderCreateParams): Promise<Task> {
-    const { accessToken, externalProjectId, title, description, assigneeEmail } = params;
+    const { accessToken, externalProjectId, title, description, assigneeEmail, config } = params;
+    const sectionGid = config?.subProjectId as string | undefined;
 
     const data: Record<string, unknown> = {
       projects: [externalProjectId],
@@ -249,6 +251,8 @@ export class AsanaProvider implements TaskProvider {
         if (user) data.assignee = user.gid;
       }
     }
+
+    if (sectionGid) data.memberships = [{ project: externalProjectId, section: sectionGid }];
 
     const created = await asanaFetch<{ data: AsanaTask }>(
       '/tasks',
@@ -288,5 +292,20 @@ export class AsanaProvider implements TaskProvider {
       id: p.gid,
       name: p.name,
     }));
+  }
+
+  async fetchSubProjects(accessToken: string, projectGid: string): Promise<ExternalProject[]> {
+    try {
+      const sections = await asanaFetch<Array<{ gid: string; name: string }>>(
+        `/projects/${projectGid}/sections?opt_fields=gid,name`,
+        accessToken,
+      );
+      return sections.map((s) => ({
+        id: s.gid,
+        name: s.name,
+      }));
+    } catch {
+      return [];
+    }
   }
 }

--- a/apps/backend/src/integrations/providers/clickup.provider.ts
+++ b/apps/backend/src/integrations/providers/clickup.provider.ts
@@ -111,35 +111,43 @@ function mapTask(task: ClickUpTask, externalProjectId: string): Task {
 
 export class ClickUpProvider implements TaskProvider {
   async fetchTasks(params: TaskProviderFetchParams): Promise<Task[]> {
-    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone } = params;
+    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone, config } = params;
     const emails = assigneeEmails ?? (assigneeEmail ? [assigneeEmail] : []);
 
-    // externalProjectId can be a folder ID (preferred) or a list ID.
-    // Try as folder first — fetch all lists in the folder and aggregate tasks.
-    // If that fails (404), fall back to treating it as a list ID.
     let allTasks: ClickUpTask[] = [];
     const includeClosed = excludeDone ? 'false' : 'true';
+    const subProjectId = config?.subProjectId as string | undefined;
 
-    try {
-      const folderData = await clickupFetch<ClickUpFolder>(
-        `${CLICKUP_API}/folder/${externalProjectId}`,
-        accessToken,
-      );
-      // It's a folder — fetch tasks from every list in it
-      for (const list of folderData.lists) {
-        const listData = await clickupFetch<ClickUpTasksResponse>(
-          `${CLICKUP_API}/list/${list.id}/task?include_closed=${includeClosed}&subtasks=true`,
-          accessToken,
-        );
-        allTasks.push(...listData.tasks);
-      }
-    } catch (err) {
-      // Not a folder — try as a list ID
+    if (subProjectId) {
+      // A specific list was selected — fetch only from that list
       const listData = await clickupFetch<ClickUpTasksResponse>(
-        `${CLICKUP_API}/list/${externalProjectId}/task?include_closed=${includeClosed}&subtasks=true`,
+        `${CLICKUP_API}/list/${subProjectId}/task?include_closed=${includeClosed}&subtasks=true`,
         accessToken,
       );
       allTasks = listData.tasks;
+    } else {
+      // externalProjectId can be a folder ID (preferred) or a list ID.
+      // Try as folder first — fetch all lists in the folder and aggregate tasks.
+      // If that fails (404), fall back to treating it as a list ID.
+      try {
+        const folderData = await clickupFetch<ClickUpFolder>(
+          `${CLICKUP_API}/folder/${externalProjectId}`,
+          accessToken,
+        );
+        for (const list of folderData.lists) {
+          const listData = await clickupFetch<ClickUpTasksResponse>(
+            `${CLICKUP_API}/list/${list.id}/task?include_closed=${includeClosed}&subtasks=true`,
+            accessToken,
+          );
+          allTasks.push(...listData.tasks);
+        }
+      } catch {
+        const listData = await clickupFetch<ClickUpTasksResponse>(
+          `${CLICKUP_API}/list/${externalProjectId}/task?include_closed=${includeClosed}&subtasks=true`,
+          accessToken,
+        );
+        allTasks = listData.tasks;
+      }
     }
 
     if (emails.length > 0) {
@@ -197,15 +205,18 @@ export class ClickUpProvider implements TaskProvider {
   }
 
   async createTask(params: TaskProviderCreateParams): Promise<Task> {
-    const { accessToken, externalProjectId, title, description, priority } = params;
+    const { accessToken, externalProjectId, title, description, priority, config } = params;
 
-    // For ClickUp, externalProjectId can be a folder or list. Create on the first list if it's a folder.
-    let listId = externalProjectId;
-    try {
-      const folder = await clickupFetch<ClickUpFolder>(`${CLICKUP_API}/folder/${externalProjectId}`, accessToken);
-      if (folder.lists.length > 0) listId = folder.lists[0]!.id;
-    } catch {
-      // Not a folder — use as list ID directly
+    // If a specific list was selected as sub-project, use it directly.
+    // Otherwise, resolve: folder → first list, or use as list ID directly.
+    let listId = (config?.subProjectId as string) || externalProjectId;
+    if (!config?.subProjectId) {
+      try {
+        const folder = await clickupFetch<ClickUpFolder>(`${CLICKUP_API}/folder/${externalProjectId}`, accessToken);
+        if (folder.lists.length > 0) listId = folder.lists[0]!.id;
+      } catch {
+        // Not a folder — use as list ID directly
+      }
     }
 
     const body: Record<string, unknown> = { name: title };
@@ -282,5 +293,20 @@ export class ClickUpProvider implements TaskProvider {
     }
 
     return projects;
+  }
+
+  async fetchSubProjects(accessToken: string, folderId: string): Promise<ExternalProject[]> {
+    try {
+      const folder = await clickupFetch<ClickUpFolder>(
+        `${CLICKUP_API}/folder/${folderId}`,
+        accessToken,
+      );
+      return folder.lists.map((list) => ({
+        id: list.id,
+        name: list.name,
+      }));
+    } catch {
+      return [];
+    }
   }
 }

--- a/apps/backend/src/integrations/providers/jira.provider.ts
+++ b/apps/backend/src/integrations/providers/jira.provider.ts
@@ -94,7 +94,11 @@ export class JiraProvider implements TaskProvider {
 
     const baseUrl = `https://${siteId}.atlassian.net/rest/api/3`;
 
+    const componentId = config?.subProjectId as string | undefined;
     let jql = `project = "${externalProjectId}"`;
+    if (componentId) {
+      jql += ` AND component = "${componentId}"`;
+    }
     if (emails.length === 1) {
       jql += ` AND assignee = "${emails[0]}"`;
     } else if (emails.length > 1) {
@@ -218,6 +222,10 @@ export class JiraProvider implements TaskProvider {
     if (description) {
       fields.description = { type: 'doc', version: 1, content: [{ type: 'paragraph', content: [{ type: 'text', text: description }] }] };
     }
+    const componentId = config?.subProjectId as string | undefined;
+    if (componentId) {
+      fields.components = [{ id: componentId }];
+    }
     if (assigneeEmail) {
       const searchRes = await fetch(`${baseUrl}/user/search?query=${encodeURIComponent(assigneeEmail)}`, {
         headers: { Authorization: authHeader, Accept: 'application/json' },
@@ -268,5 +276,23 @@ export class JiraProvider implements TaskProvider {
       name: p.name,
       key: p.key,
     }));
+  }
+
+  async fetchSubProjects(accessToken: string, projectKey: string, config?: Record<string, unknown>): Promise<ExternalProject[]> {
+    const siteId = config?.externalWorkspaceId as string | undefined;
+    if (!siteId) return [];
+
+    try {
+      const components = await jiraFetch<Array<{ id: string; name: string }>>(
+        `https://${siteId}.atlassian.net/rest/api/3/project/${projectKey}/component?maxResults=50`,
+        accessToken,
+      );
+      return components.map((c) => ({
+        id: c.id,
+        name: c.name,
+      }));
+    } catch {
+      return [];
+    }
   }
 }

--- a/apps/backend/src/integrations/providers/linear.provider.ts
+++ b/apps/backend/src/integrations/providers/linear.provider.ts
@@ -103,11 +103,15 @@ interface LinearTeamsResponse {
 
 export class LinearProvider implements TaskProvider {
   async fetchTasks(params: TaskProviderFetchParams): Promise<Task[]> {
-    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone } = params;
+    const { accessToken, externalProjectId, assigneeEmail, assigneeEmails, excludeDone, config } = params;
     const emails = assigneeEmails ?? (assigneeEmail ? [assigneeEmail] : []);
 
     // externalProjectId is the Linear team ID
     const filters: string[] = [`team: { id: { eq: "${externalProjectId}" } }`];
+    const subProjectId = config?.subProjectId as string | undefined;
+    if (subProjectId) {
+      filters.push(`project: { id: { eq: "${subProjectId}" } }`);
+    }
     if (emails.length === 1) {
       filters.push(`assignee: { email: { eq: "${emails[0]}" } }`);
     } else if (emails.length > 1) {
@@ -224,7 +228,8 @@ export class LinearProvider implements TaskProvider {
     if (assigneeEmail) {
       const userData = await linearFetch<{ users: { nodes: Array<{ id: string }> } }>(
         accessToken,
-        `query { users(filter: { email: { eq: "${assigneeEmail}" } }) { nodes { id } } }`,
+        `query ($email: String!) { users(filter: { email: { eq: $email } }) { nodes { id } } }`,
+        { email: assigneeEmail },
       );
       const userId = userData.users.nodes[0]?.id;
       if (userId) input.assigneeId = userId;
@@ -232,35 +237,40 @@ export class LinearProvider implements TaskProvider {
 
     if (Object.keys(input).length === 0) return;
 
-    const inputStr = Object.entries(input)
-      .map(([k, v]) => `${k}: "${v}"`)
-      .join(', ');
-
     await linearFetch<{ issueUpdate: { success: boolean } }>(
       accessToken,
-      `mutation { issueUpdate(id: "${issue.id}", input: { ${inputStr} }) { success } }`,
+      `mutation ($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success } }`,
+      { id: issue.id, input },
     );
   }
 
   async createTask(params: TaskProviderCreateParams): Promise<Task> {
-    const { accessToken, externalProjectId, title, description, assigneeEmail, priority } = params;
+    const { accessToken, externalProjectId, title, description, assigneeEmail, priority, config } = params;
 
-    const input: string[] = [`teamId: "${externalProjectId}"`, `title: "${title.replace(/"/g, '\\"')}"`];
-    if (description) input.push(`description: "${description.replace(/"/g, '\\"')}"`);
+    const inputObj: Record<string, unknown> = {
+      teamId: externalProjectId,
+      title,
+    };
+    if (description) inputObj.description = description;
+
+    // If the mapping config has a sub-project ID (Linear project), assign the issue to it
+    const subProjectId = config?.subProjectId as string | undefined;
+    if (subProjectId) inputObj.projectId = subProjectId;
 
     if (assigneeEmail) {
       const userData = await linearFetch<{ users: { nodes: Array<{ id: string }> } }>(
         accessToken,
-        `query { users(filter: { email: { eq: "${assigneeEmail}" } }) { nodes { id } } }`,
+        `query ($email: String!) { users(filter: { email: { eq: $email } }) { nodes { id } } }`,
+        { email: assigneeEmail },
       );
       const userId = userData.users.nodes[0]?.id;
-      if (userId) input.push(`assigneeId: "${userId}"`);
+      if (userId) inputObj.assigneeId = userId;
     }
 
     if (priority) {
       const prioMap: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4, none: 0 };
       const prioNum = prioMap[priority.toLowerCase()];
-      if (prioNum !== undefined) input.push(`priority: ${prioNum}`);
+      if (prioNum !== undefined) inputObj.priority = prioNum;
     }
 
     const data = await linearFetch<{
@@ -280,7 +290,8 @@ export class LinearProvider implements TaskProvider {
       };
     }>(
       accessToken,
-      `mutation { issueCreate(input: { ${input.join(', ')} }) { success issue { identifier title description state { name } priority assignee { name email } labels { nodes { name } } url updatedAt } } }`,
+      `mutation ($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { identifier title description state { name } priority assignee { name email } labels { nodes { name } } url updatedAt } } }`,
+      { input: inputObj },
     );
 
     const issue = data.issueCreate.issue;
@@ -321,6 +332,21 @@ export class LinearProvider implements TaskProvider {
       id: team.id,
       name: team.name,
       key: team.key,
+    }));
+  }
+
+  async fetchSubProjects(accessToken: string, teamId: string): Promise<ExternalProject[]> {
+    const data = await linearFetch<{
+      team: { projects: { nodes: Array<{ id: string; name: string }> } };
+    }>(
+      accessToken,
+      `query ($teamId: String!) { team(id: $teamId) { projects(first: 50) { nodes { id name } } } }`,
+      { teamId },
+    );
+
+    return data.team.projects.nodes.map((p) => ({
+      id: p.id,
+      name: p.name,
     }));
   }
 }

--- a/apps/backend/src/integrations/providers/monday.provider.ts
+++ b/apps/backend/src/integrations/providers/monday.provider.ts
@@ -81,7 +81,7 @@ interface MondayItem {
   id: string;
   name: string;
   column_values: MondayColumnValue[];
-  group: { title: string };
+  group: { id: string; title: string };
   updated_at: string;
   url: string;
 }
@@ -137,7 +137,8 @@ function getStatusColumnId(item: MondayItem): string {
 
 export class MondayProvider implements TaskProvider {
   async fetchTasks(params: TaskProviderFetchParams): Promise<Task[]> {
-    const { accessToken, externalProjectId, assigneeEmail } = params;
+    const { accessToken, externalProjectId, assigneeEmail, config } = params;
+    const groupId = config?.subProjectId as string | undefined;
 
     // Fetch items from the board
     const data = await mondayQuery<{
@@ -159,7 +160,7 @@ export class MondayProvider implements TaskProvider {
                 type
                 value
               }
-              group { title }
+              group { id title }
               updated_at
               url
             }
@@ -173,6 +174,11 @@ export class MondayProvider implements TaskProvider {
     if (!board) return [];
 
     let items = board.items_page.items;
+
+    // Filter by group if a sub-project (group) was selected
+    if (groupId) {
+      items = items.filter((item) => item.group?.id === groupId);
+    }
 
     // If filtering by email, we need to resolve user IDs to emails
     if (assigneeEmail) {
@@ -343,14 +349,19 @@ export class MondayProvider implements TaskProvider {
   }
 
   async createTask(params: TaskProviderCreateParams): Promise<Task> {
-    const { accessToken, externalProjectId, title } = params;
+    const { accessToken, externalProjectId, title, config } = params;
+    const groupId = config?.subProjectId as string | undefined;
+
+    const variables: Record<string, unknown> = { boardId: externalProjectId, itemName: title };
+    let mutation = `mutation ($boardId: ID!, $itemName: String!) { create_item(board_id: $boardId, item_name: $itemName) { id name board { id } column_values { id text type title } } }`;
+    if (groupId) {
+      variables.groupId = groupId;
+      mutation = `mutation ($boardId: ID!, $itemName: String!, $groupId: String!) { create_item(board_id: $boardId, group_id: $groupId, item_name: $itemName) { id name board { id } column_values { id text type title } } }`;
+    }
 
     const data = await mondayQuery<{
       create_item: { id: string; name: string; board: { id: string }; column_values: Array<{ id: string; text: string; type: string; title: string }> };
-    }>(
-      accessToken,
-      `mutation { create_item(board_id: ${externalProjectId}, item_name: "${title.replace(/"/g, '\\"')}") { id name board { id } column_values { id text type title } } }`,
-    );
+    }>(accessToken, mutation, variables);
 
     const item = data.create_item;
     return {
@@ -380,5 +391,25 @@ export class MondayProvider implements TaskProvider {
       id: b.id,
       name: b.name,
     }));
+  }
+
+  async fetchSubProjects(accessToken: string, boardId: string): Promise<ExternalProject[]> {
+    try {
+      const data = await mondayQuery<{
+        boards: Array<{ groups: Array<{ id: string; title: string }> }>;
+      }>(
+        accessToken,
+        `query ($boardId: [ID!]!) { boards(ids: $boardId) { groups { id title } } }`,
+        { boardId: [boardId] },
+      );
+      const board = data.boards[0];
+      if (!board) return [];
+      return board.groups.map((g) => ({
+        id: g.id,
+        name: g.title,
+      }));
+    } catch {
+      return [];
+    }
   }
 }

--- a/apps/backend/src/integrations/providers/task-provider.interface.ts
+++ b/apps/backend/src/integrations/providers/task-provider.interface.ts
@@ -52,4 +52,6 @@ export interface TaskProvider {
   getTaskStatuses(params: { accessToken: string; taskId: string; config: Record<string, unknown> }): Promise<ProviderStatus[]>;
   updateTask(params: TaskProviderUpdateParams): Promise<void>;
   createTask(params: TaskProviderCreateParams): Promise<Task>;
+  /** Optional: fetch sub-projects within a project (e.g. Linear projects in a team, ClickUp lists in a folder) */
+  fetchSubProjects?(accessToken: string, projectId: string, config?: Record<string, unknown>): Promise<ExternalProject[]>;
 }

--- a/apps/frontend/src/app/integrations/page.tsx
+++ b/apps/frontend/src/app/integrations/page.tsx
@@ -46,6 +46,7 @@ import {
   createProjectMapping,
   deleteProjectMapping,
   getTeams,
+  getSubProjects,
 } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 import type { Integration, IntegrationProjectMapping } from '@/lib/api';
@@ -164,6 +165,9 @@ export default function IntegrationsPage() {
   const [selectedExternalProject, setSelectedExternalProject] = useState('');
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [savingMapping, setSavingMapping] = useState(false);
+  const [subProjects, setSubProjects] = useState<Array<{ id: string; name: string }>>([]);
+  const [selectedSubProject, setSelectedSubProject] = useState('');
+  const [loadingSubProjects, setLoadingSubProjects] = useState(false);
 
   const [connectError, setConnectError] = useState('');
 
@@ -254,11 +258,33 @@ export default function IntegrationsPage() {
     }
   };
 
+  // When external project changes, fetch sub-projects (e.g. Linear projects within a team, ClickUp lists in a folder)
+  const handleExternalProjectChange = async (value: string) => {
+    setSelectedExternalProject(value);
+    setSelectedSubProject('');
+    setSubProjects([]);
+
+    if (addMappingProvider && value) {
+      setLoadingSubProjects(true);
+      try {
+        const projects = await getSubProjects(addMappingProvider, value);
+        setSubProjects(projects);
+        if (projects.length === 1) setSelectedSubProject(projects[0].id);
+      } catch {
+        setSubProjects([]);
+      } finally {
+        setLoadingSubProjects(false);
+      }
+    }
+  };
+
   // Open add mapping dialog
   const handleOpenAddMapping = async (provider: string) => {
     setAddMappingProvider(provider);
     setSelectedExternalProject('');
     setSelectedTeamId('');
+    setSubProjects([]);
+    setSelectedSubProject('');
     setLoadingProjects(true);
     try {
       const projects = await getExternalProjects(provider);
@@ -278,10 +304,13 @@ export default function IntegrationsPage() {
     setError('');
     try {
       const project = externalProjects.find((p) => p.id === selectedExternalProject);
+      const config: Record<string, unknown> = {};
+      if (selectedSubProject) config.subProjectId = selectedSubProject;
       await createProjectMapping(addMappingProvider, {
         teamId: selectedTeamId,
         externalProjectId: selectedExternalProject,
         externalProjectName: project?.name,
+        config: Object.keys(config).length > 0 ? config : undefined,
       });
       // Refresh mappings
       const mappings = await getProjectMappings(addMappingProvider);
@@ -708,7 +737,7 @@ export default function IntegrationsPage() {
                       No projects found. Verify your token has the right permissions.
                     </p>
                   ) : (
-                    <Select value={selectedExternalProject} onValueChange={setSelectedExternalProject}>
+                    <Select value={selectedExternalProject} onValueChange={handleExternalProjectChange}>
                       <SelectTrigger className="w-full">
                         <SelectValue placeholder="Select a project..." />
                       </SelectTrigger>
@@ -724,6 +753,39 @@ export default function IntegrationsPage() {
                     </Select>
                   )}
                 </div>
+
+                {loadingSubProjects && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                    Loading projects...
+                  </div>
+                )}
+
+                {subProjects.length > 1 && !loadingSubProjects && (
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">
+                      {addMappingProvider === 'clickup' ? 'List' :
+                       addMappingProvider === 'monday' ? 'Group' :
+                       addMappingProvider === 'asana' ? 'Section' :
+                       addMappingProvider === 'jira' ? 'Board' : 'Project'}{' '}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </label>
+                    <Select value={selectedSubProject} onValueChange={setSelectedSubProject}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a project..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {subProjects.map((p) => (
+                            <SelectItem key={p.id} value={p.id}>
+                              {p.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
                 <div className="flex flex-col gap-2">
                   <label className="text-sm font-medium">Tandemu Team</label>

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -453,9 +453,18 @@ export async function getProjectMappings(
   );
 }
 
+export async function getSubProjects(
+  provider: string,
+  projectId: string,
+): Promise<Array<{ id: string; name: string }>> {
+  return fetchApi<Array<{ id: string; name: string }>>(
+    `/api/integrations/${provider}/projects/${projectId}/sub-projects`
+  );
+}
+
 export async function createProjectMapping(
   provider: string,
-  data: { teamId: string; externalProjectId: string; externalProjectName?: string }
+  data: { teamId: string; externalProjectId: string; externalProjectName?: string; config?: Record<string, unknown> }
 ): Promise<IntegrationProjectMapping> {
   return fetchApi<IntegrationProjectMapping>(
     `/api/integrations/${provider}/mappings`,


### PR DESCRIPTION
## Summary
- **Description truncation fix**: Linear and Monday providers now use GraphQL `$variables` instead of inline string interpolation — fixes mutations breaking on newlines, quotes, and special characters
- **Generic sub-project selection**: New optional `fetchSubProjects()` on TaskProvider interface, implemented for all providers:
  - Linear: projects in a team
  - ClickUp: lists in a folder
  - Jira: components in a project
  - Asana: sections in a project
  - Monday: groups in a board
  - GitHub: no sub-level
- **Integrations UI**: After selecting a project, auto-fetches sub-entities. If >1 exists, shows a contextual dropdown (Project/List/Component/Section/Group). Fully optional.
- **fetchTasks + createTask**: All providers read `config.subProjectId` to filter and target the correct sub-entity

## Test plan
- [ ] Create a task via `/create` with a long multi-line description — verify it appears correctly on Linear
- [ ] Integrations page: add a Linear mapping → select team → verify project dropdown appears if team has projects
- [ ] Integrations page: add a ClickUp mapping → select folder → verify list dropdown appears
- [ ] Existing mappings without sub-project continue to work unchanged
- [ ] `/morning` with a sub-project mapping → verify tasks are filtered to that sub-entity
- [ ] No regressions on task fetching for any provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)