### PR TITLE
feat: add priority support to PATCH /api/tasks/:taskId

### DIFF
--- a/apps/backend/src/integrations/providers/asana.provider.ts
+++ b/apps/backend/src/integrations/providers/asana.provider.ts
@@ -184,7 +184,7 @@ export class AsanaProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName, assigneeEmail } = params;
+    const { accessToken, taskId, statusName, assigneeEmail, priority } = params;
 
     if (statusName) {
       const statuses = await this.getTaskStatuses({ accessToken, taskId, config: {} });
@@ -221,6 +221,27 @@ export class AsanaProvider implements TaskProvider {
         if (user) {
           await asanaFetch(`/tasks/${taskId}`, accessToken, 'PUT', { assignee: user.gid });
         }
+      }
+    }
+
+    if (priority) {
+      try {
+        // Fetch the task to find the priority custom field and its enum options
+        const taskData = await asanaFetch<{ gid: string; custom_fields: Array<{ gid: string; name: string; enum_options?: Array<{ gid: string; name: string }> }> }>(
+          `/tasks/${taskId}?opt_fields=custom_fields,custom_fields.name,custom_fields.enum_options,custom_fields.enum_options.name`,
+          accessToken,
+        );
+        const prioField = taskData.custom_fields?.find((f) => f.name.toLowerCase() === 'priority');
+        if (prioField?.enum_options) {
+          const target = prioField.enum_options.find((o) => o.name.toLowerCase().includes(priority.toLowerCase()));
+          if (target) {
+            await asanaFetch(`/tasks/${taskId}`, accessToken, 'PUT', {
+              custom_fields: { [prioField.gid]: target.gid },
+            });
+          }
+        }
+      } catch {
+        // Priority field may not exist — silently skip
       }
     }
   }

--- a/apps/backend/src/integrations/providers/clickup.provider.ts
+++ b/apps/backend/src/integrations/providers/clickup.provider.ts
@@ -179,10 +179,15 @@ export class ClickUpProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName, assigneeEmail } = params;
+    const { accessToken, taskId, statusName, assigneeEmail, priority } = params;
 
     const body: Record<string, unknown> = {};
     if (statusName) body.status = statusName;
+    if (priority) {
+      const prioMap: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4 };
+      const prioNum = prioMap[priority.toLowerCase()];
+      if (prioNum) body.priority = prioNum;
+    }
     // ClickUp uses user IDs for assignees — look up by email via team members
     // For now, assignment requires the ClickUp user ID which we don't have from email alone
     // Status update works directly

--- a/apps/backend/src/integrations/providers/github.provider.ts
+++ b/apps/backend/src/integrations/providers/github.provider.ts
@@ -127,15 +127,18 @@ export class GitHubProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName, assigneeEmail, config } = params;
+    const { accessToken, taskId, statusName, assigneeEmail, priority, config } = params;
     const repo = config.repo as string | undefined;
     if (!repo) return;
 
     const body: Record<string, unknown> = {};
     if (statusName) body.state = statusName.toLowerCase();
     if (assigneeEmail) {
-      // GitHub uses usernames, not emails — extract username portion as best effort
       body.assignees = [assigneeEmail.split('@')[0]];
+    }
+    if (priority) {
+      // GitHub uses labels for priority — add a priority label
+      body.labels = [`priority:${priority.toLowerCase()}`];
     }
 
     if (Object.keys(body).length === 0) return;

--- a/apps/backend/src/integrations/providers/jira.provider.ts
+++ b/apps/backend/src/integrations/providers/jira.provider.ts
@@ -164,7 +164,7 @@ export class JiraProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName, assigneeEmail, config } = params;
+    const { accessToken, taskId, statusName, assigneeEmail, priority, config } = params;
     const siteId = config.siteId as string | undefined;
     if (!siteId) return;
 
@@ -202,6 +202,18 @@ export class JiraProvider implements TaskProvider {
             body: JSON.stringify({ accountId: users[0].accountId }),
           });
         }
+      }
+    }
+
+    if (priority) {
+      const prioMap: Record<string, string> = { urgent: 'Highest', high: 'High', medium: 'Medium', low: 'Low', none: 'Lowest' };
+      const jiraPriority = prioMap[priority.toLowerCase()];
+      if (jiraPriority) {
+        await fetch(`${baseUrl}/issue/${taskId}`, {
+          method: 'PUT',
+          headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fields: { priority: { name: jiraPriority } } }),
+        });
       }
     }
   }

--- a/apps/backend/src/integrations/providers/linear.provider.ts
+++ b/apps/backend/src/integrations/providers/linear.provider.ts
@@ -210,13 +210,19 @@ export class LinearProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName, assigneeEmail } = params;
+    const { accessToken, taskId, statusName, assigneeEmail, priority } = params;
 
     const issue = await this.findIssueByIdentifier(accessToken, taskId);
     if (!issue) return;
 
     // Build a single mutation input with all requested changes
-    const input: Record<string, string> = {};
+    const input: Record<string, string | number> = {};
+
+    if (priority) {
+      const prioMap: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4, none: 0 };
+      const prioNum = prioMap[priority.toLowerCase()];
+      if (prioNum !== undefined) input.priority = prioNum;
+    }
 
     if (statusName) {
       const target = issue.team.states.nodes.find(

--- a/apps/backend/src/integrations/providers/monday.provider.ts
+++ b/apps/backend/src/integrations/providers/monday.provider.ts
@@ -293,11 +293,9 @@ export class MondayProvider implements TaskProvider {
   }
 
   async updateTask(params: TaskProviderUpdateParams): Promise<void> {
-    const { accessToken, taskId, statusName } = params;
-    // Monday.com assignment by email is not straightforward (requires people column + user lookup)
-    // Status update is supported
+    const { accessToken, taskId, statusName, priority } = params;
 
-    if (!statusName) return;
+    if (!statusName && !priority) return;
 
     const itemData = await mondayQuery<{
       items: Array<{
@@ -324,28 +322,42 @@ export class MondayProvider implements TaskProvider {
       throw new BadGatewayException('Monday.com item not found');
     }
 
-    const statusCol = item.column_values.find(
-      (c) => c.type === 'status' || (c.type === 'color' && c.title.toLowerCase() === 'status'),
-    );
-    const columnId = statusCol?.id ?? 'status';
+    const boardId = item.board.id;
 
-    await mondayQuery(
-      accessToken,
-      `mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: JSON!) {
-        change_simple_column_value(
-          board_id: $boardId,
-          item_id: $itemId,
-          column_id: $columnId,
-          value: $value
-        ) { id }
-      }`,
-      {
-        boardId: item.board.id,
-        itemId: taskId,
-        columnId,
-        value: statusName,
-      },
-    );
+    if (statusName) {
+      const statusCol = item.column_values.find(
+        (c) => c.type === 'status' || (c.type === 'color' && c.title.toLowerCase() === 'status'),
+      );
+      if (statusCol) {
+        await mondayQuery(
+          accessToken,
+          `mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: JSON!) {
+            change_simple_column_value(board_id: $boardId, item_id: $itemId, column_id: $columnId, value: $value) { id }
+          }`,
+          { boardId, itemId: taskId, columnId: statusCol.id, value: statusName },
+        );
+      }
+    }
+
+    if (priority) {
+      const prioCol = item.column_values.find(
+        (c) => c.title.toLowerCase() === 'priority',
+      );
+      if (prioCol) {
+        // Monday priority labels: "Critical", "High", "Medium", "Low"
+        const prioMap: Record<string, string> = { urgent: 'Critical', high: 'High', medium: 'Medium', low: 'Low' };
+        const mondayPriority = prioMap[priority.toLowerCase()];
+        if (mondayPriority) {
+          await mondayQuery(
+            accessToken,
+            `mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: JSON!) {
+              change_simple_column_value(board_id: $boardId, item_id: $itemId, column_id: $columnId, value: $value) { id }
+            }`,
+            { boardId, itemId: taskId, columnId: prioCol.id, value: mondayPriority },
+          );
+        }
+      }
+    }
   }
 
   async createTask(params: TaskProviderCreateParams): Promise<Task> {

--- a/apps/backend/src/integrations/providers/task-provider.interface.ts
+++ b/apps/backend/src/integrations/providers/task-provider.interface.ts
@@ -15,6 +15,7 @@ export interface TaskProviderUpdateParams {
   taskId: string;
   statusName?: string;
   assigneeEmail?: string;
+  priority?: string;
   config: Record<string, unknown>;
 }
 

--- a/apps/backend/src/integrations/tasks.controller.ts
+++ b/apps/backend/src/integrations/tasks.controller.ts
@@ -124,13 +124,13 @@ export class TasksController {
   async updateTask(
     @CurrentUser() user: RequestUser,
     @Param('taskId') taskId: string,
-    @Body() body: { statusName?: string; assigneeEmail?: string; provider: IntegrationProvider },
+    @Body() body: { statusName?: string; assigneeEmail?: string; priority?: string; provider: IntegrationProvider },
   ): Promise<{ success: boolean }> {
     await this.tasksService.updateTask(
       user.organizationId,
       taskId,
       body.provider,
-      { statusName: body.statusName, assigneeEmail: body.assigneeEmail },
+      { statusName: body.statusName, assigneeEmail: body.assigneeEmail, priority: body.priority },
     );
     return { success: true };
   }

--- a/apps/backend/src/integrations/tasks.service.ts
+++ b/apps/backend/src/integrations/tasks.service.ts
@@ -85,7 +85,7 @@ export class TasksService {
     orgId: string,
     taskId: string,
     provider: IntegrationProvider,
-    updates: { statusName?: string; assigneeEmail?: string },
+    updates: { statusName?: string; assigneeEmail?: string; priority?: string },
   ): Promise<void> {
     const integration = await this.integrationsService.findOne(orgId, provider);
     const taskProvider = getProvider(provider);
@@ -95,6 +95,7 @@ export class TasksService {
       taskId,
       statusName: updates.statusName,
       assigneeEmail: updates.assigneeEmail,
+      priority: updates.priority,
       config: integration.config,
     });
   }


### PR DESCRIPTION
## Summary
- Add optional `priority` field to `PATCH /api/tasks/:taskId` body
- Thread priority through service → TaskProviderUpdateParams → all 6 providers
- Linear: numeric priority (1-4, 0=none)
- ClickUp: numeric priority (1-4)
- Jira: name-based (Highest/High/Medium/Low/Lowest)
- GitHub: adds `priority:<level>` label
- Asana: finds "Priority" custom field by name, matches enum option
- Monday: finds "Priority" column by title, sets label value

## Test plan
- [ ] `PATCH /api/tasks/SGS-XX` with `{"priority": "high", "provider": "linear"}` updates priority on Linear
- [ ] Existing PATCH calls without priority field continue to work
- [ ] Priority field is optional — omitting it changes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)