### PR TITLE
feat: BullMQ background task queue for fire-and-forget ops

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,15 +13,18 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.0.0",
+    "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^10.4.0",
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.4.0",
+    "@nestjs/event-emitter": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.4.0",
     "@tandemu/database": "workspace:*",
     "@tandemu/telemetry": "workspace:*",
     "@tandemu/types": "workspace:*",
     "bcryptjs": "^2.4.3",
+    "bullmq": "^5.71.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "jsonwebtoken": "^9.0.2",
@@ -29,8 +32,7 @@
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.0",
-    "@nestjs/event-emitter": "^2.1.0"
+    "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { InvitesModule } from './invites/invites.module.js';
 import { IntegrationsModule } from './integrations/integrations.module.js';
 import { MemoryModule } from './memory/memory.module.js';
 import { SetupModule } from './setup/setup.module.js';
+import { QueueModule } from './queue/queue.module.js';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { SetupModule } from './setup/setup.module.js';
     IntegrationsModule,
     MemoryModule,
     SetupModule,
+    QueueModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/backend/src/memory/memory.controller.ts
+++ b/apps/backend/src/memory/memory.controller.ts
@@ -24,10 +24,13 @@ import type { RequestUser } from '../auth/auth.decorator.js';
 import { MembershipRole } from '@tandemu/types';
 import { MemoryScope } from '@tandemu/types';
 import type { MemoryEntry, MemoryListResponse, MemoryStatsResponse, FileTreeNode, GapEntry } from '@tandemu/types';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Queue } from 'bullmq';
 import { MemoryService } from './memory.service.js';
 import { TasksService } from '../integrations/tasks.service.js';
 import { TelemetryService } from '../telemetry/telemetry.service.js';
 import { AuthService } from '../auth/auth.service.js';
+import type { MemoryOpsJobData, TelemetryJobData } from '../queue/queue.types.js';
 
 @Controller('memory')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -41,6 +44,8 @@ export class MemoryController {
     private readonly tasksService: TasksService,
     private readonly telemetryService: TelemetryService,
     private readonly authService: AuthService,
+    @InjectQueue('memory-ops') private readonly memoryOpsQueue: Queue<MemoryOpsJobData>,
+    @InjectQueue('telemetry') private readonly telemetryQueue: Queue<TelemetryJobData>,
   ) {}
 
   private async resolveUserName(userId: string): Promise<string | undefined> {
@@ -457,11 +462,21 @@ export class MemoryController {
             if (taskStatus === 'done') {
               // Promote to published — update the memory asynchronously
               metadata.status = 'published';
-              this.promoteMemory(mem.id as string, upstreamUrl, upstreamHeaders).catch(() => {});
+              this.memoryOpsQueue.add('promote-memory', {
+                type: 'promote-memory',
+                memoryId: mem.id as string,
+                upstreamUrl,
+                upstreamHeaders,
+              });
               filteredOrgMemories.push(mem);
             } else if (taskStatus === 'cancelled') {
               // Cancelled work — delete the draft, knowledge may be invalid
-              this.deleteMemoryUpstream(mem.id as string, upstreamUrl, upstreamHeaders).catch(() => {});
+              this.memoryOpsQueue.add('delete-memory-upstream', {
+                type: 'delete-memory-upstream',
+                memoryId: mem.id as string,
+                upstreamUrl,
+                upstreamHeaders,
+              });
               // Don't include in results
             }
             // 'pending' — skip, draft from unmerged work
@@ -605,62 +620,6 @@ export class MemoryController {
     }
   }
 
-  /**
-   * Promote a draft memory to published by updating its metadata.
-   */
-  private async promoteMemory(
-    memoryId: string,
-    upstreamUrl: string,
-    upstreamHeaders: Record<string, string>,
-  ): Promise<void> {
-    try {
-      await fetch(upstreamUrl, {
-        method: 'POST',
-        headers: { ...upstreamHeaders, 'Accept': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: `promote-${memoryId}`,
-          method: 'tools/call',
-          params: {
-            name: 'update_memory',
-            arguments: {
-              memory_id: memoryId,
-              metadata: { status: 'published' },
-            },
-          },
-        }),
-      });
-    } catch (err) {
-      this.logger.warn(`Failed to promote memory ${memoryId}: ${err}`);
-    }
-  }
-
-  /**
-   * Delete a memory (e.g., from cancelled task — knowledge may be invalid).
-   */
-  private async deleteMemoryUpstream(
-    memoryId: string,
-    upstreamUrl: string,
-    upstreamHeaders: Record<string, string>,
-  ): Promise<void> {
-    try {
-      await fetch(upstreamUrl, {
-        method: 'POST',
-        headers: { ...upstreamHeaders, 'Accept': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: `delete-${memoryId}`,
-          method: 'tools/call',
-          params: {
-            name: 'delete_memory',
-            arguments: { memory_id: memoryId },
-          },
-        }),
-      });
-    } catch (err) {
-      this.logger.warn(`Failed to delete memory ${memoryId}: ${err}`);
-    }
-  }
 
   // ---- Shared MCP helper ----
 
@@ -799,15 +758,20 @@ export class MemoryController {
           const taskStatus = await this.getTaskFinalStatus(taskId, user);
           if (taskStatus === 'done') {
             metadata.status = 'published';
-            this.callMcpTool('update_memory', {
-              memory_id: mem.id as string,
-              metadata: { status: 'published' },
-            }, user).catch(() => {});
+            this.memoryOpsQueue.add('mcp-tool-call', {
+              type: 'mcp-tool-call',
+              toolName: 'update_memory',
+              args: { memory_id: mem.id as string, metadata: { status: 'published' } },
+              userId: user.userId,
+            });
             filtered.push(mem);
           } else if (taskStatus === 'cancelled') {
-            this.callMcpTool('delete_memory', {
-              memory_id: mem.id as string,
-            }, user).catch(() => {});
+            this.memoryOpsQueue.add('mcp-tool-call', {
+              type: 'mcp-tool-call',
+              toolName: 'delete_memory',
+              args: { memory_id: mem.id as string },
+              userId: user.userId,
+            });
           }
           // 'pending' — skip
         }
@@ -908,11 +872,14 @@ export class MemoryController {
         return this.toMemoryEntry(m, isOrg ? 'org' : 'personal');
       });
 
-      // Fire-and-forget access logging
-      this.telemetryService.logMemoryAccess(
-        resultMemories.map((m) => m.id),
-        user.organizationId, user.userId, 'search',
-      ).catch(() => {});
+      // Queue access logging
+      this.telemetryQueue.add('memory-access-log', {
+        type: 'memory-access-log',
+        memoryIds: resultMemories.map((m) => m.id),
+        organizationId: user.organizationId,
+        userId: user.userId,
+        accessType: 'search',
+      });
 
       return { memories: resultMemories };
     }
@@ -936,10 +903,13 @@ export class MemoryController {
 
     const resultMemories = memories.map((m) => this.toMemoryEntry(m, scope === 'org' ? 'org' : 'personal'));
 
-    this.telemetryService.logMemoryAccess(
-      resultMemories.map((m) => m.id),
-      user.organizationId, user.userId, 'search',
-    ).catch(() => {});
+    this.telemetryQueue.add('memory-access-log', {
+      type: 'memory-access-log',
+      memoryIds: resultMemories.map((m) => m.id),
+      organizationId: user.organizationId,
+      userId: user.userId,
+      accessType: 'search',
+    });
 
     return { memories: resultMemories };
   }

--- a/apps/backend/src/memory/memory.module.ts
+++ b/apps/backend/src/memory/memory.module.ts
@@ -1,14 +1,22 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
 import { MemoryController } from './memory.controller.js';
 import { MemoryService } from './memory.service.js';
 import { AuthModule } from '../auth/auth.module.js';
 import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { TelemetryModule } from '../telemetry/telemetry.module.js';
+import { MemoryOpsProcessor } from '../queue/memory-ops.processor.js';
 
 @Module({
-  imports: [AuthModule, forwardRef(() => IntegrationsModule), forwardRef(() => TelemetryModule)],
+  imports: [
+    AuthModule,
+    forwardRef(() => IntegrationsModule),
+    forwardRef(() => TelemetryModule),
+    BullModule.registerQueue({ name: 'memory-ops' }),
+    BullModule.registerQueue({ name: 'telemetry' }),
+  ],
   controllers: [MemoryController],
-  providers: [MemoryService],
+  providers: [MemoryService, MemoryOpsProcessor],
   exports: [MemoryService],
 })
 export class MemoryModule {}

--- a/apps/backend/src/queue/index.ts
+++ b/apps/backend/src/queue/index.ts
@@ -1,0 +1,12 @@
+export { QueueModule } from './queue.module.js';
+export type {
+  MemoryOpsJobData,
+  TelemetryJobData,
+  PromoteMemoryJob,
+  DeleteMemoryUpstreamJob,
+  McpToolCallJob,
+  MemoryAccessLogJob,
+  OtlpTraceJob,
+  OtlpMetricsJob,
+  GitSelfHealJob,
+} from './queue.types.js';

--- a/apps/backend/src/queue/memory-ops.processor.ts
+++ b/apps/backend/src/queue/memory-ops.processor.ts
@@ -1,0 +1,103 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import type { Job } from 'bullmq';
+import { MemoryService } from '../memory/memory.service.js';
+import type { MemoryOpsJobData } from './queue.types.js';
+
+@Processor('memory-ops')
+export class MemoryOpsProcessor extends WorkerHost {
+  private readonly logger = new Logger(MemoryOpsProcessor.name);
+
+  constructor(private readonly memoryService: MemoryService) {
+    super();
+  }
+
+  async process(job: Job<MemoryOpsJobData>): Promise<void> {
+    switch (job.data.type) {
+      case 'promote-memory':
+        await this.promoteMemory(job.data.memoryId, job.data.upstreamUrl, job.data.upstreamHeaders);
+        break;
+      case 'delete-memory-upstream':
+        await this.deleteMemoryUpstream(job.data.memoryId, job.data.upstreamUrl, job.data.upstreamHeaders);
+        break;
+      case 'mcp-tool-call':
+        await this.mcpToolCall(job.data.toolName, job.data.args, job.data.userId);
+        break;
+    }
+  }
+
+  private async promoteMemory(
+    memoryId: string,
+    upstreamUrl: string,
+    upstreamHeaders: Record<string, string>,
+  ): Promise<void> {
+    const res = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers: { ...upstreamHeaders, 'Accept': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: `promote-${memoryId}`,
+        method: 'tools/call',
+        params: {
+          name: 'update_memory',
+          arguments: {
+            memory_id: memoryId,
+            metadata: { status: 'published' },
+          },
+        },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Promote memory ${memoryId} failed: ${res.status}`);
+    }
+    this.logger.debug(`Promoted memory ${memoryId}`);
+  }
+
+  private async deleteMemoryUpstream(
+    memoryId: string,
+    upstreamUrl: string,
+    upstreamHeaders: Record<string, string>,
+  ): Promise<void> {
+    const res = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers: { ...upstreamHeaders, 'Accept': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: `delete-${memoryId}`,
+        method: 'tools/call',
+        params: {
+          name: 'delete_memory',
+          arguments: { memory_id: memoryId },
+        },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Delete memory ${memoryId} failed: ${res.status}`);
+    }
+    this.logger.debug(`Deleted memory ${memoryId}`);
+  }
+
+  private async mcpToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+    userId: string,
+  ): Promise<void> {
+    const upstreamUrl = this.memoryService.getUpstreamSseUrl(userId);
+    const upstreamHeaders = this.memoryService.getUpstreamMessageHeaders();
+
+    const res = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers: { ...upstreamHeaders, 'Accept': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: `queue-${toolName}-${Date.now()}`,
+        method: 'tools/call',
+        params: { name: toolName, arguments: args },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`MCP tool call ${toolName} failed: ${res.status}`);
+    }
+    this.logger.debug(`MCP tool call ${toolName} completed`);
+  }
+}

--- a/apps/backend/src/queue/queue.module.ts
+++ b/apps/backend/src/queue/queue.module.ts
@@ -1,0 +1,38 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { ConfigService } from '@nestjs/config';
+
+@Module({
+  imports: [
+    BullModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        connection: {
+          url: config.get<string>('redis.url', 'redis://localhost:6379'),
+        },
+      }),
+    }),
+    BullModule.registerQueue(
+      {
+        name: 'memory-ops',
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 1000 },
+          removeOnComplete: { age: 3600 },
+          removeOnFail: { age: 604800 },
+        },
+      },
+      {
+        name: 'telemetry',
+        defaultJobOptions: {
+          attempts: 2,
+          backoff: { type: 'fixed', delay: 2000 },
+          removeOnComplete: { age: 600 },
+          removeOnFail: { age: 86400 },
+        },
+      },
+    ),
+  ],
+  exports: [BullModule],
+})
+export class QueueModule {}

--- a/apps/backend/src/queue/queue.types.ts
+++ b/apps/backend/src/queue/queue.types.ts
@@ -1,0 +1,63 @@
+import type { FinishTaskInput } from '../telemetry/telemetry.service.js';
+
+// ── memory-ops queue ──
+
+export interface PromoteMemoryJob {
+  readonly type: 'promote-memory';
+  readonly memoryId: string;
+  readonly upstreamUrl: string;
+  readonly upstreamHeaders: Record<string, string>;
+}
+
+export interface DeleteMemoryUpstreamJob {
+  readonly type: 'delete-memory-upstream';
+  readonly memoryId: string;
+  readonly upstreamUrl: string;
+  readonly upstreamHeaders: Record<string, string>;
+}
+
+export interface McpToolCallJob {
+  readonly type: 'mcp-tool-call';
+  readonly toolName: string;
+  readonly args: Record<string, unknown>;
+  readonly userId: string;
+}
+
+export type MemoryOpsJobData =
+  | PromoteMemoryJob
+  | DeleteMemoryUpstreamJob
+  | McpToolCallJob;
+
+// ── telemetry queue ──
+
+export interface MemoryAccessLogJob {
+  readonly type: 'memory-access-log';
+  readonly memoryIds: string[];
+  readonly organizationId: string;
+  readonly userId: string;
+  readonly accessType: 'search' | 'list' | 'mcp_proxy';
+}
+
+export interface OtlpTraceJob {
+  readonly type: 'otlp-trace';
+  readonly payload: Record<string, unknown>;
+  readonly otelEndpoint: string;
+}
+
+export interface OtlpMetricsJob {
+  readonly type: 'otlp-metrics';
+  readonly payload: Record<string, unknown>;
+  readonly otelEndpoint: string;
+}
+
+export interface GitSelfHealJob {
+  readonly type: 'git-self-heal';
+  readonly organizationId: string;
+  readonly input: FinishTaskInput;
+}
+
+export type TelemetryJobData =
+  | MemoryAccessLogJob
+  | OtlpTraceJob
+  | OtlpMetricsJob
+  | GitSelfHealJob;

--- a/apps/backend/src/queue/telemetry.processor.ts
+++ b/apps/backend/src/queue/telemetry.processor.ts
@@ -1,0 +1,58 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger, Inject, forwardRef } from '@nestjs/common';
+import type { Job } from 'bullmq';
+import { TelemetryService } from '../telemetry/telemetry.service.js';
+import type { TelemetryJobData } from './queue.types.js';
+
+@Processor('telemetry')
+export class TelemetryProcessor extends WorkerHost {
+  private readonly logger = new Logger(TelemetryProcessor.name);
+
+  constructor(
+    @Inject(forwardRef(() => TelemetryService))
+    private readonly telemetryService: TelemetryService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<TelemetryJobData>): Promise<void> {
+    switch (job.data.type) {
+      case 'memory-access-log':
+        await this.telemetryService.logMemoryAccess(
+          job.data.memoryIds,
+          job.data.organizationId,
+          job.data.userId,
+          job.data.accessType,
+        );
+        break;
+      case 'otlp-trace':
+        await this.sendOtlp(job.data.otelEndpoint, '/v1/traces', job.data.payload);
+        break;
+      case 'otlp-metrics':
+        await this.sendOtlp(job.data.otelEndpoint, '/v1/metrics', job.data.payload);
+        break;
+      case 'git-self-heal':
+        await this.telemetryService.selfHealGitMemories(
+          job.data.organizationId,
+          job.data.input,
+        );
+        break;
+    }
+  }
+
+  private async sendOtlp(
+    endpoint: string,
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const res = await fetch(`${endpoint}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`OTLP ${path} failed: ${res.status}`);
+    }
+    this.logger.debug(`OTLP ${path} sent successfully`);
+  }
+}

--- a/apps/backend/src/telemetry/telemetry.module.ts
+++ b/apps/backend/src/telemetry/telemetry.module.ts
@@ -1,4 +1,5 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
 import { TelemetryController } from './telemetry.controller.js';
 import { OtlpProxyController } from './otlp-proxy.controller.js';
 import { TelemetryService } from './telemetry.service.js';
@@ -6,11 +7,18 @@ import { AuthModule } from '../auth/auth.module.js';
 import { DatabaseModule } from '../database/database.module.js';
 import { MemoryModule } from '../memory/memory.module.js';
 import { IntegrationsModule } from '../integrations/integrations.module.js';
+import { TelemetryProcessor } from '../queue/telemetry.processor.js';
 
 @Module({
-  imports: [AuthModule, DatabaseModule, forwardRef(() => MemoryModule), forwardRef(() => IntegrationsModule)],
+  imports: [
+    AuthModule,
+    DatabaseModule,
+    forwardRef(() => MemoryModule),
+    forwardRef(() => IntegrationsModule),
+    BullModule.registerQueue({ name: 'telemetry' }),
+  ],
   controllers: [TelemetryController, OtlpProxyController],
-  providers: [TelemetryService],
+  providers: [TelemetryService, TelemetryProcessor],
   exports: [TelemetryService],
 })
 export class TelemetryModule {}

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, OnModuleDestroy, Logger, Inject, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Queue } from 'bullmq';
 import { createClient } from '@clickhouse/client';
 import type { ClickHouseClient } from '@clickhouse/client';
 import { randomBytes } from 'crypto';
@@ -7,6 +9,7 @@ import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry }
 import { MemoryService } from '../memory/memory.service.js';
 import { GitHubGitService } from '../integrations/providers/github-git.service.js';
 import { IntegrationsService } from '../integrations/integrations.service.js';
+import type { TelemetryJobData } from '../queue/queue.types.js';
 
 export interface TimesheetEntry {
   readonly userId: string;
@@ -69,6 +72,7 @@ export class TelemetryService implements OnModuleDestroy {
     @Inject(forwardRef(() => MemoryService)) private readonly memoryService: MemoryService,
     @Inject(forwardRef(() => GitHubGitService)) private readonly gitHubGitService: GitHubGitService,
     @Inject(forwardRef(() => IntegrationsService)) private readonly integrationsService: IntegrationsService,
+    @InjectQueue('telemetry') private readonly telemetryQueue: Queue<TelemetryJobData>,
   ) {
     const clickhouseUrl = this.configService.get<string>('clickhouse.url', 'http://localhost:8123');
     this.client = createClient({
@@ -208,93 +212,81 @@ export class TelemetryService implements OnModuleDestroy {
       ? (await this.getNativeAIAttribution(organizationId, input.startedAt, now.toISOString()).catch(() => ({ aiFilePaths: [] as string[], totalNativeAiLines: 0 }))).aiFilePaths.join(',')
       : '';
 
-    // Send trace span
-    try {
-      const traceRes = await fetch(`${otelEndpoint}/v1/traces`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          resourceSpans: [{
-            resource: {
+    // Queue trace span
+    this.telemetryQueue.add('otlp-trace', {
+      type: 'otlp-trace',
+      otelEndpoint,
+      payload: {
+        resourceSpans: [{
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'claude-code' } },
+              { key: 'organization_id', value: { stringValue: organizationId } },
+            ],
+          },
+          scopeSpans: [{
+            scope: { name: 'tandemu' },
+            spans: [{
+              traceId, spanId, name: 'task_session', kind: 1,
+              startTimeUnixNano: startNs.toString(),
+              endTimeUnixNano: endNs.toString(),
               attributes: [
-                { key: 'service.name', value: { stringValue: 'claude-code' } },
-                { key: 'organization_id', value: { stringValue: organizationId } },
+                { key: 'user_id', value: { stringValue: userId } },
+                { key: 'task_id', value: { stringValue: taskId } },
+                { key: 'status', value: { stringValue: 'completed' } },
+                { key: 'ai_lines', value: { stringValue: String(aiLines) } },
+                { key: 'manual_lines', value: { stringValue: String(manualLines) } },
+                { key: 'duration_seconds', value: { stringValue: String(durationSeconds) } },
+                { key: 'commits', value: { stringValue: String(input.commits.length) } },
+                { key: 'changed_files', value: { stringValue: changedFiles } },
+                { key: 'file_count', value: { stringValue: String(input.changedFilesList.length) } },
+                { key: 'ai_files', value: { stringValue: aiFilesList } },
+                { key: 'task_category', value: { stringValue: input.category ?? 'other' } },
+                { key: 'task_labels', value: { stringValue: (input.labels ?? []).join(',') } },
+                { key: 'deployment', value: { stringValue: 'true' } },
               ],
-            },
-            scopeSpans: [{
-              scope: { name: 'tandemu' },
-              spans: [{
-                traceId, spanId, name: 'task_session', kind: 1,
-                startTimeUnixNano: startNs.toString(),
-                endTimeUnixNano: endNs.toString(),
-                attributes: [
-                  { key: 'user_id', value: { stringValue: userId } },
-                  { key: 'task_id', value: { stringValue: taskId } },
-                  { key: 'status', value: { stringValue: 'completed' } },
-                  { key: 'ai_lines', value: { stringValue: String(aiLines) } },
-                  { key: 'manual_lines', value: { stringValue: String(manualLines) } },
-                  { key: 'duration_seconds', value: { stringValue: String(durationSeconds) } },
-                  { key: 'commits', value: { stringValue: String(input.commits.length) } },
-                  { key: 'changed_files', value: { stringValue: changedFiles } },
-                  { key: 'file_count', value: { stringValue: String(input.changedFilesList.length) } },
-                  { key: 'ai_files', value: { stringValue: aiFilesList } },
-                  { key: 'task_category', value: { stringValue: input.category ?? 'other' } },
-                  { key: 'task_labels', value: { stringValue: (input.labels ?? []).join(',') } },
-                  { key: 'deployment', value: { stringValue: 'true' } },
+              status: {},
+            }],
+          }],
+        }],
+      },
+    });
+
+    // Queue metrics
+    this.telemetryQueue.add('otlp-metrics', {
+      type: 'otlp-metrics',
+      otelEndpoint,
+      payload: {
+        resourceMetrics: [{
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'claude-code' } },
+              { key: 'organization_id', value: { stringValue: organizationId } },
+            ],
+          },
+          scopeMetrics: [{
+            scope: { name: 'tandemu' },
+            metrics: [{
+              name: 'tandemu.lines_of_code',
+              sum: {
+                dataPoints: [
+                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: aiLines, attributes: [{ key: 'type', value: { stringValue: 'ai' } }, { key: 'task_id', value: { stringValue: taskId } }] },
+                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: manualLines, attributes: [{ key: 'type', value: { stringValue: 'manual' } }, { key: 'task_id', value: { stringValue: taskId } }] },
                 ],
-                status: {},
-              }],
+                aggregationTemporality: 2,
+                isMonotonic: true,
+              },
             }],
           }],
-        }),
-      });
-      if (!traceRes.ok) {
-        this.logger.error(`OTLP trace failed: ${traceRes.status}`);
-      }
-    } catch (err) {
-      this.logger.error('Failed to send OTLP trace', err);
-    }
+        }],
+      },
+    });
 
-    // Send metrics
-    try {
-      const metricsRes = await fetch(`${otelEndpoint}/v1/metrics`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          resourceMetrics: [{
-            resource: {
-              attributes: [
-                { key: 'service.name', value: { stringValue: 'claude-code' } },
-                { key: 'organization_id', value: { stringValue: organizationId } },
-              ],
-            },
-            scopeMetrics: [{
-              scope: { name: 'tandemu' },
-              metrics: [{
-                name: 'tandemu.lines_of_code',
-                sum: {
-                  dataPoints: [
-                    { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: aiLines, attributes: [{ key: 'type', value: { stringValue: 'ai' } }, { key: 'task_id', value: { stringValue: taskId } }] },
-                    { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: manualLines, attributes: [{ key: 'type', value: { stringValue: 'manual' } }, { key: 'task_id', value: { stringValue: taskId } }] },
-                  ],
-                  aggregationTemporality: 2,
-                  isMonotonic: true,
-                },
-              }],
-            }],
-          }],
-        }),
-      });
-      if (!metricsRes.ok) {
-        this.logger.error(`OTLP metrics failed: ${metricsRes.status}`);
-      }
-    } catch (err) {
-      this.logger.error('Failed to send OTLP metrics', err);
-    }
-
-    // Fire-and-forget: self-heal git history into org memories
-    this.selfHealGitMemories(organizationId, input).catch((err) => {
-      this.logger.warn(`Self-healing git memories failed: ${err}`);
+    // Queue git self-healing
+    this.telemetryQueue.add('git-self-heal', {
+      type: 'git-self-heal',
+      organizationId,
+      input,
     });
 
     return {
@@ -310,7 +302,7 @@ export class TelemetryService implements OnModuleDestroy {
    * Self-healing: auto-index merged PRs for changed files as org memories.
    * Runs as fire-and-forget after task completion.
    */
-  private async selfHealGitMemories(
+  async selfHealGitMemories(
     organizationId: string,
     input: FinishTaskInput,
   ): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "turbo run test"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "turbo": "^2.4.0",
     "typescript": "^5.7.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       turbo:
         specifier: ^2.4.0
         version: 2.8.19
@@ -20,6 +23,9 @@ importers:
       '@clickhouse/client':
         specifier: ^1.0.0
         version: 1.18.2
+      '@nestjs/bullmq':
+        specifier: ^11.0.4
+        version: 11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.71.1)
       '@nestjs/common':
         specifier: ^10.4.0
         version: 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -50,6 +56,9 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      bullmq:
+        specifier: ^5.71.1
+        version: 5.71.1
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -1175,6 +1184,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1227,9 +1239,52 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
+
+  '@nestjs/bull-shared@11.0.4':
+    resolution: {integrity: sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
+  '@nestjs/bullmq@11.0.4':
+    resolution: {integrity: sha512-wBzK9raAVG0/6NTMdvLGM4/FQ1lsB35/pYS8L6a0SDgkTiLpd7mAjQ8R692oMx5s7IjvgntaZOuTUrKYLNfIkA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      bullmq: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@nestjs/common@10.4.22':
     resolution: {integrity: sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==}
@@ -2776,6 +2831,9 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bullmq@5.71.1:
+    resolution: {integrity: sha512-kOBfdcsHmO6wwmIjpersoVdYQ7jkjTgky4Yop0loc7QwSdgxliSzD69U9ijZuRrkyCJwz5p5eqxeGeQkJ0YGZQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -2952,6 +3010,10 @@ packages:
       typescript:
         optional: true
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3074,6 +3136,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3657,6 +3723,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -3937,8 +4007,14 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -3982,6 +4058,10 @@ packages:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4102,6 +4182,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
   msw@2.12.14:
     resolution: {integrity: sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==}
     engines: {node: '>=18'}
@@ -4180,6 +4267,9 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -4197,6 +4287,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -4591,6 +4685,14 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redis@4.7.1:
     resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
@@ -4776,6 +4878,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5929,6 +6034,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
+  '@ioredis/commands@1.5.1': {}
+
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -6022,6 +6129,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -6030,6 +6155,20 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@nestjs/bull-shared@11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
+
+  '@nestjs/bullmq@11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.71.1)':
+    dependencies:
+      '@nestjs/bull-shared': 11.0.4(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      bullmq: 5.71.1
+      tslib: 2.8.1
 
   '@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
@@ -7431,7 +7570,7 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 25.5.0
       form-data: 4.0.5
 
   '@types/node@18.19.130':
@@ -7690,6 +7829,18 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bullmq@5.71.1:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -7853,6 +8004,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -7937,6 +8092,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -8575,6 +8732,20 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -8804,7 +8975,11 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -8840,6 +9015,8 @@ snapshots:
   lucide-react@0.468.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -8939,6 +9116,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.5.0)
@@ -9035,6 +9228,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-abort-controller@3.1.1: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
@@ -9046,6 +9241,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.36: {}
 
@@ -9527,6 +9727,12 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redis@4.7.1:
     dependencies:
       '@redis/bloom': 1.2.0(@redis/client@1.6.1)
@@ -9807,6 +10013,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- Add Redis-backed BullMQ task queues (`memory-ops` and `telemetry`) to offload 7 fire-and-forget operations from HTTP request handlers
- **memory-ops queue**: draft memory promotion/deletion, MCP tool calls (3 retries, exponential backoff)
- **telemetry queue**: ClickHouse access logging, OTLP trace/metric sends, git PR self-healing (2 retries, best-effort)
- Fix all pre-existing TypeScript build errors (15 errors from missing `@types/node` fetch/Response types)

Closes SGS-115

## Test plan
- [ ] `pnpm build` compiles cleanly (0 errors)
- [ ] `docker compose up -d` — Redis service healthy
- [ ] POST `/api/telemetry/tasks/:taskId/finish` returns immediately, OTLP sends happen via queue
- [ ] GET `/api/memory/search?query=test` — access log job appears in Redis (`bull:telemetry:*`)
- [ ] Memory draft promotion triggers `bull:memory-ops:*` job instead of blocking search

🤖 Generated with [Claude Code](https://claude.com/claude-code)