### PR TITLE
feat: add Insights page for AI investment value proof

### DIFF
--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -29,6 +29,7 @@ export class OrganizationsService {
         stripe_subscription_id: string | null;
         plan_tier: string;
         subscription_status: string;
+        settings: Record<string, unknown>;
         created_at: Date;
         updated_at: Date;
       }>(
@@ -60,6 +61,7 @@ export class OrganizationsService {
       stripe_subscription_id: string | null;
       plan_tier: string;
       subscription_status: string;
+      settings: Record<string, unknown>;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -81,6 +83,7 @@ export class OrganizationsService {
       stripe_subscription_id: string | null;
       plan_tier: string;
       subscription_status: string;
+      settings: Record<string, unknown>;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -124,6 +127,10 @@ export class OrganizationsService {
       fields.push(`stripe_subscription_id = $${paramIndex++}`);
       values.push(dto.stripeSubscriptionId);
     }
+    if (dto.settings !== undefined) {
+      fields.push(`settings = settings || $${paramIndex++}::jsonb`);
+      values.push(JSON.stringify(dto.settings));
+    }
 
     if (fields.length === 0) {
       return this.findOne(orgId);
@@ -140,6 +147,7 @@ export class OrganizationsService {
       stripe_subscription_id: string | null;
       plan_tier: string;
       subscription_status: string;
+      settings: Record<string, unknown>;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -246,6 +254,7 @@ export class OrganizationsService {
     stripe_subscription_id: string | null;
     plan_tier: string;
     subscription_status: string;
+    settings?: Record<string, unknown>;
     created_at: Date;
     updated_at: Date;
   }): Organization {
@@ -257,6 +266,9 @@ export class OrganizationsService {
       stripeSubscriptionId: row.stripe_subscription_id ?? undefined,
       planTier: row.plan_tier.toUpperCase() as Organization['planTier'],
       subscriptionStatus: row.subscription_status as Organization['subscriptionStatus'],
+      settings: row.settings && Object.keys(row.settings).length > 0
+        ? row.settings as Organization['settings']
+        : undefined,
       createdAt: row.created_at.toISOString(),
       updatedAt: row.updated_at.toISOString(),
     };

--- a/apps/backend/src/telemetry/telemetry.controller.ts
+++ b/apps/backend/src/telemetry/telemetry.controller.ts
@@ -5,7 +5,7 @@ import { JwtAuthGuard } from '../auth/auth.guard.js';
 import { OrgRequiredGuard } from '../auth/org-required.guard.js';
 import { CurrentUser } from '../auth/auth.decorator.js';
 import type { RequestUser } from '../auth/auth.decorator.js';
-import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry } from '@tandemu/types';
+import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry, InsightsMetrics, OrgSettings } from '@tandemu/types';
 import { DatabaseService } from '../database/database.service.js';
 
 @Controller('telemetry')
@@ -160,6 +160,39 @@ export class TelemetryController {
     }
 
     return entries;
+  }
+
+  @Get('insights')
+  async getInsightsMetrics(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ): Promise<InsightsMetrics> {
+    // Fetch org settings for ROI assumptions
+    const orgResult = await this.db.query<{ settings: OrgSettings }>(
+      `SELECT settings FROM organizations WHERE id = $1`,
+      [user.organizationId],
+    );
+    const settings = orgResult.rows[0]?.settings;
+
+    // Fetch org memory count (org memories use user_id = organizationId)
+    let orgMemoriesShared = 0;
+    try {
+      const countResult = await this.db.query<{ count: string }>(
+        `SELECT 0 AS count`, // Placeholder — org memory count comes from Mem0 via /memory/stats
+        [],
+      );
+      // We'll enrich from the memory stats endpoint client-side instead
+      orgMemoriesShared = 0;
+    } catch {
+      // Non-critical
+    }
+
+    const metrics = await this.telemetryService.getInsightsMetrics(
+      user.organizationId, startDate, endDate, settings,
+    );
+
+    return { ...metrics, orgMemoriesShared };
   }
 
   /**

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -5,7 +5,7 @@ import type { Queue } from 'bullmq';
 import { createClient } from '@clickhouse/client';
 import type { ClickHouseClient } from '@clickhouse/client';
 import { randomBytes } from 'crypto';
-import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry } from '@tandemu/types';
+import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry, InsightsMetrics, InsightsDaily, OrgSettings } from '@tandemu/types';
 import { MemoryService } from '../memory/memory.service.js';
 import { GitHubGitService } from '../integrations/providers/github-git.service.js';
 import { IntegrationsService } from '../integrations/integrations.service.js';
@@ -1107,6 +1107,211 @@ export class TelemetryService implements OnModuleDestroy {
       return { topUsed, leastUsed, totalTracked: rows.length };
     } catch {
       return { topUsed: [], leastUsed: [], totalTracked: 0 };
+    }
+  }
+
+  /**
+   * Compute insights metrics: throughput, capacity freed, cost efficiency, and Tandemu impact.
+   * All derived from existing ClickHouse data — no new instrumentation.
+   */
+  async getInsightsMetrics(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+    settings?: OrgSettings,
+  ): Promise<InsightsMetrics> {
+    const hourlyRate = settings?.developerHourlyRate ?? 75;
+    const secsPerLine = settings?.aiLineTimeEstimateSeconds ?? 120;
+    const currency = settings?.currency ?? 'USD';
+
+    const params: Record<string, string> = { organizationId };
+    let dateFilter = '';
+    if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
+    if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+
+    // Build a previous-period date filter for friction trend comparison
+    let prevDateFilter = '';
+    const prevParams: Record<string, string> = { organizationId };
+    if (startDate && endDate) {
+      const start = new Date(startDate).getTime();
+      const end = new Date(endDate).getTime();
+      const duration = end - start;
+      const prevStart = new Date(start - duration).toISOString();
+      const prevEnd = new Date(start).toISOString();
+      prevDateFilter = ` AND Timestamp >= parseDateTimeBestEffort({prevStart: String}) AND Timestamp <= parseDateTimeBestEffort({prevEnd: String})`;
+      prevParams.prevStart = prevStart;
+      prevParams.prevEnd = prevEnd;
+    }
+
+    try {
+      // Run all queries in parallel
+      const [dailyResult, taskResult, memoryHitsResult, frictionCurrentResult, frictionPrevResult] = await Promise.all([
+        // Query 1: Daily cost + AI/manual lines
+        this.client.query({
+          query: `
+            SELECT
+              toDate(TimeUnix) AS date,
+              sumIf(Value, MetricName = 'claude_code.cost.usage') AS ai_cost,
+              sumIf(Value, MetricName = 'tandemu.lines_of_code' AND Attributes['type'] = 'ai') AS ai_lines,
+              sumIf(Value, MetricName = 'tandemu.lines_of_code' AND Attributes['type'] = 'manual') AS manual_lines
+            FROM otel_metrics_sum
+            WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+              AND MetricName IN ('claude_code.cost.usage', 'tandemu.lines_of_code')
+              ${dateFilter}
+            GROUP BY date
+            ORDER BY date ASC
+          `,
+          query_params: params,
+          format: 'JSONEachRow',
+        }),
+
+        // Query 2: Completed task count
+        this.client.query({
+          query: `
+            SELECT count(*) AS task_count
+            FROM otel_traces
+            WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+              AND SpanName = 'task_session'
+              AND SpanAttributes['status'] = 'completed'
+              ${dateFilter.replace(/TimeUnix/g, 'Timestamp')}
+          `,
+          query_params: params,
+          format: 'JSONEachRow',
+        }),
+
+        // Query 3: Memory access count
+        this.client.query({
+          query: `
+            SELECT count(*) AS hits
+            FROM memory_access_log
+            WHERE organization_id = {organizationId: String}
+              ${startDate ? ` AND timestamp >= parseDateTimeBestEffort({startDate: String})` : ''}
+              ${endDate ? ` AND timestamp <= parseDateTimeBestEffort({endDate: String})` : ''}
+          `,
+          query_params: params,
+          format: 'JSONEachRow',
+        }),
+
+        // Query 4: Current-period friction count
+        this.client.query({
+          query: `
+            SELECT count(*) AS friction_count
+            FROM otel_logs
+            WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+              AND (SeverityText IN ('prompt_loop', 'error')
+                   OR (LogAttributes['event.name'] = 'tool_result' AND LogAttributes['success'] = 'false'))
+              ${dateFilter.replace(/TimeUnix/g, 'Timestamp')}
+          `,
+          query_params: params,
+          format: 'JSONEachRow',
+        }),
+
+        // Query 5: Previous-period friction count (for trend)
+        prevDateFilter
+          ? this.client.query({
+              query: `
+                SELECT count(*) AS friction_count
+                FROM otel_logs
+                WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+                  AND (SeverityText IN ('prompt_loop', 'error')
+                       OR (LogAttributes['event.name'] = 'tool_result' AND LogAttributes['success'] = 'false'))
+                  ${prevDateFilter}
+              `,
+              query_params: prevParams,
+              format: 'JSONEachRow',
+            })
+          : Promise.resolve(null),
+      ]);
+
+      // Parse results
+      const dailyRows = await dailyResult.json<{
+        date: string;
+        ai_cost: number;
+        ai_lines: number;
+        manual_lines: number;
+      }>();
+
+      const taskRows = await taskResult.json<{ task_count: number }>();
+      const totalTasks = Number(taskRows[0]?.task_count ?? 0);
+
+      const memoryRows = await memoryHitsResult.json<{ hits: number }>();
+      const memoryHits = Number(memoryRows[0]?.hits ?? 0);
+
+      const frictionRows = await frictionCurrentResult.json<{ friction_count: number }>();
+      const currentFriction = Number(frictionRows[0]?.friction_count ?? 0);
+
+      let frictionEventsReduced: number | null = null;
+      if (frictionPrevResult) {
+        const prevRows = await frictionPrevResult.json<{ friction_count: number }>();
+        const prevFriction = Number(prevRows[0]?.friction_count ?? 0);
+        if (prevFriction > 0) {
+          frictionEventsReduced = Math.round(((currentFriction - prevFriction) / prevFriction) * 100);
+        }
+      }
+
+      // Aggregate totals from daily rows
+      let totalAICost = 0;
+      let totalAILines = 0;
+      let totalManualLines = 0;
+      const daily: InsightsDaily[] = dailyRows.map((r) => {
+        const aiCost = Math.round(Number(r.ai_cost) * 100) / 100;
+        const aiLines = Number(r.ai_lines);
+        const manualLines = Number(r.manual_lines);
+        totalAICost += aiCost;
+        totalAILines += aiLines;
+        totalManualLines += manualLines;
+        return { date: r.date, aiCost, aiLines, manualLines };
+      });
+
+      totalAICost = Math.round(totalAICost * 100) / 100;
+
+      // Derived metrics
+      const productivityMultiplier = totalManualLines > 0
+        ? Math.round(((totalAILines + totalManualLines) / totalManualLines) * 100) / 100
+        : null;
+
+      const capacityFreedHours = Math.round(((totalAILines * secsPerLine) / 3600) * 10) / 10;
+
+      const costPerAILine = totalAILines > 0
+        ? Math.round((totalAICost / totalAILines) * 10000) / 10000
+        : null;
+
+      const costPerTask = totalTasks > 0
+        ? Math.round((totalAICost / totalTasks) * 100) / 100
+        : null;
+
+      return {
+        totalAILines,
+        totalManualLines,
+        totalTasks,
+        productivityMultiplier,
+        capacityFreedHours,
+        totalAICost,
+        costPerAILine,
+        costPerTask,
+        memoryHits,
+        frictionEventsReduced,
+        orgMemoriesShared: 0, // Populated by controller from memory service
+        daily,
+        assumptions: { developerHourlyRate: hourlyRate, aiLineTimeEstimateSeconds: secsPerLine, currency },
+      };
+    } catch (err) {
+      this.logger.warn(`Failed to get insights metrics: ${err}`);
+      return {
+        totalAILines: 0,
+        totalManualLines: 0,
+        totalTasks: 0,
+        productivityMultiplier: null,
+        capacityFreedHours: 0,
+        totalAICost: 0,
+        costPerAILine: null,
+        costPerTask: null,
+        memoryHits: 0,
+        frictionEventsReduced: null,
+        orgMemoriesShared: 0,
+        daily: [],
+        assumptions: { developerHourlyRate: hourlyRate, aiLineTimeEstimateSeconds: secsPerLine, currency },
+      };
     }
   }
 }

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Zap, Clock, DollarSign, Brain, TrendingDown, Share2, Info, Settings } from 'lucide-react';
+import { getInsightsMetrics, getMemoryStats } from '@/lib/api';
+import type { InsightsMetrics } from '@/lib/api';
+import { TelemetryFilters, useFilterParams } from '@/components/filters/telemetry-filters';
+import { ThroughputChart, CostEfficiencyChart } from '@/components/charts/insights-chart';
+import { DashboardSkeleton } from '@/components/ui/skeleton-helpers';
+
+function formatCurrency(value: number | null, currency = 'USD'): string {
+  if (value === null) return '-';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency, minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
+}
+
+function formatNumber(value: number | null): string {
+  if (value === null) return '-';
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+export default function InsightsPage() {
+  const [data, setData] = useState<InsightsMetrics | null>(null);
+  const [orgMemoryCount, setOrgMemoryCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const { startDate, endDate } = useFilterParams();
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchData() {
+      setLoading(true);
+      try {
+        const f = { startDate, endDate };
+        const [insights, memStats] = await Promise.allSettled([
+          getInsightsMetrics(f),
+          getMemoryStats(),
+        ]);
+        if (cancelled) return;
+        if (insights.status === 'fulfilled') setData(insights.value);
+        if (memStats.status === 'fulfilled') setOrgMemoryCount(memStats.value.org);
+      } catch {
+        // Non-critical
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchData();
+    return () => { cancelled = true; };
+  }, [startDate, endDate]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Insights</h1>
+            <p className="text-muted-foreground">Honest assessment of AI investment value</p>
+          </div>
+          <TelemetryFilters showTeamFilter={false} />
+        </div>
+        <DashboardSkeleton />
+      </div>
+    );
+  }
+
+  const hasData = data && (data.totalAILines > 0 || data.totalManualLines > 0 || data.totalAICost > 0);
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Insights</h1>
+          <p className="text-muted-foreground">Honest assessment of AI investment value</p>
+        </div>
+        <TelemetryFilters showTeamFilter={false} />
+      </div>
+
+      {/* Assumptions banner */}
+      {data && hasData && (
+        <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-4 py-2.5 text-sm text-muted-foreground">
+          <Info className="h-4 w-4 shrink-0" />
+          <span>
+            Calculations use <strong>${data.assumptions.developerHourlyRate}/hr</strong> developer rate
+            and <strong>{Math.round(data.assumptions.aiLineTimeEstimateSeconds / 60)} min/line</strong> manual estimate.
+          </span>
+          <Link href="/settings" className="ml-auto flex items-center gap-1 text-primary hover:underline whitespace-nowrap">
+            <Settings className="h-3.5 w-3.5" />
+            Change
+          </Link>
+        </div>
+      )}
+
+      {!hasData ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <Zap className="h-10 w-10 text-muted-foreground/40 mb-3" />
+            <h3 className="text-lg font-medium mb-1">No insights data yet</h3>
+            <p className="text-sm text-muted-foreground text-center max-w-md">
+              Complete tasks using the /morning and /finish workflow to generate throughput, cost, and impact metrics.
+              Enable OTEL in Claude Code for cost tracking.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Section 1: AI Coding Value */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight">AI Coding Value</h2>
+
+            {/* KPI Cards */}
+            <div className="grid gap-4 md:grid-cols-3">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Productivity Multiplier</CardTitle>
+                  <Zap className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {data.productivityMultiplier !== null ? `${data.productivityMultiplier}x` : '-'}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    total output / manual-only output
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Capacity Freed</CardTitle>
+                  <Clock className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {data.capacityFreedHours > 0 ? `${data.capacityFreedHours}h` : '-'}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    hours of manual work handled by AI
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Cost per Task</CardTitle>
+                  <DollarSign className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {formatCurrency(data.costPerTask, data.assumptions.currency)}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    AI cost per completed task
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Throughput stats */}
+            <div className="grid gap-4 md:grid-cols-4">
+              <Card className="bg-muted/30">
+                <CardContent className="pt-4 pb-3">
+                  <p className="text-xs text-muted-foreground mb-1">AI Lines</p>
+                  <p className="text-lg font-semibold">{formatNumber(data.totalAILines)}</p>
+                </CardContent>
+              </Card>
+              <Card className="bg-muted/30">
+                <CardContent className="pt-4 pb-3">
+                  <p className="text-xs text-muted-foreground mb-1">Manual Lines</p>
+                  <p className="text-lg font-semibold">{formatNumber(data.totalManualLines)}</p>
+                </CardContent>
+              </Card>
+              <Card className="bg-muted/30">
+                <CardContent className="pt-4 pb-3">
+                  <p className="text-xs text-muted-foreground mb-1">Tasks Completed</p>
+                  <p className="text-lg font-semibold">{formatNumber(data.totalTasks)}</p>
+                </CardContent>
+              </Card>
+              <Card className="bg-muted/30">
+                <CardContent className="pt-4 pb-3">
+                  <p className="text-xs text-muted-foreground mb-1">Total AI Cost</p>
+                  <p className="text-lg font-semibold">{formatCurrency(data.totalAICost, data.assumptions.currency)}</p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Charts */}
+            <div className="grid gap-4 md:grid-cols-2">
+              <ThroughputChart data={data.daily} />
+              <CostEfficiencyChart data={data.daily} />
+            </div>
+          </div>
+
+          {/* Section 2: Tandemu Impact */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight">Tandemu Impact</h2>
+            <p className="text-sm text-muted-foreground">
+              How memory and workflow features reduce ramp-up time and prevent repeated mistakes.
+            </p>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Memory Hits</CardTitle>
+                  <Brain className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{formatNumber(data.memoryHits)}</div>
+                  <p className="text-xs text-muted-foreground">
+                    times AI used stored knowledge
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Friction Trend</CardTitle>
+                  <TrendingDown className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className={`text-2xl font-bold ${
+                    data.frictionEventsReduced !== null
+                      ? data.frictionEventsReduced < 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                      : ''
+                  }`}>
+                    {data.frictionEventsReduced !== null
+                      ? `${data.frictionEventsReduced > 0 ? '+' : ''}${data.frictionEventsReduced}%`
+                      : '-'}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    tool failures vs previous period
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Knowledge Shared</CardTitle>
+                  <Share2 className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{formatNumber(orgMemoryCount)}</div>
+                  <p className="text-xs text-muted-foreground">
+                    org memories available to all members
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Building2, Users, Save, Plus, CreditCard } from 'lucide-react';
+import { Building2, Users, Save, Plus, CreditCard, Lightbulb } from 'lucide-react';
 import { SettingsSkeleton } from '@/components/ui/skeleton-helpers';
 import { InviteDialog } from '@/components/invite-dialog';
 import { toast } from 'sonner';
@@ -58,6 +58,11 @@ export default function SettingsPage() {
   const [invitesList, setInvitesList] = useState<Invite[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
 
+  // ROI settings
+  const [editHourlyRate, setEditHourlyRate] = useState(75);
+  const [editSecsPerLine, setEditSecsPerLine] = useState(120);
+  const [savingROI, setSavingROI] = useState(false);
+
   // Invite dialog
   const [showInviteDialog, setShowInviteDialog] = useState(false);
 
@@ -66,6 +71,9 @@ export default function SettingsPage() {
       setOrg(activeOrg);
       setEditOrgName(activeOrg.name);
       setEditOrgSlug(activeOrg.slug);
+      const s = (activeOrg as any).settings;
+      if (s?.developerHourlyRate) setEditHourlyRate(s.developerHourlyRate);
+      if (s?.aiLineTimeEstimateSeconds) setEditSecsPerLine(s.aiLineTimeEstimateSeconds);
 
       const [memberList, invites, teamList] = await Promise.all([
         getMembers(activeOrg.id),
@@ -181,6 +189,77 @@ export default function SettingsPage() {
                 <>
                   <Save className="h-4 w-4 mr-2" />
                   Save Changes
+                </>
+              )}
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+
+      {/* ROI Settings */}
+      {org && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Lightbulb className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <CardTitle>Insights Settings</CardTitle>
+                <CardDescription>Configure assumptions for the Insights page. Conservative defaults are pre-filled.</CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Developer Hourly Rate ($)</label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={editHourlyRate}
+                  onChange={(e) => setEditHourlyRate(Number(e.target.value))}
+                />
+                <p className="text-xs text-muted-foreground">Fully-loaded cost per developer hour</p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Est. Time per Manual Line (seconds)</label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={editSecsPerLine}
+                  onChange={(e) => setEditSecsPerLine(Number(e.target.value))}
+                />
+                <p className="text-xs text-muted-foreground">How long a developer takes to write one line manually</p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              These values estimate how much manual coding work AI replaces. They are used to calculate capacity freed on the Insights page.
+            </p>
+          </CardContent>
+          <CardFooter className="border-t px-6 py-4 flex justify-end">
+            <Button
+              onClick={async () => {
+                if (!org) return;
+                setSavingROI(true);
+                try {
+                  const updated = await updateOrganization(org.id, {
+                    settings: { developerHourlyRate: editHourlyRate, aiLineTimeEstimateSeconds: editSecsPerLine },
+                  });
+                  setOrg(updated);
+                  toast.success('Insights settings saved.');
+                } catch (err) {
+                  toast.error(err instanceof Error ? err.message : 'Failed to save settings');
+                } finally {
+                  setSavingROI(false);
+                }
+              }}
+              disabled={savingROI}
+            >
+              {savingROI ? (
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Save
                 </>
               )}
             </Button>

--- a/apps/frontend/src/components/charts/cost-chart.tsx
+++ b/apps/frontend/src/components/charts/cost-chart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
 import {
   AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
 } from 'recharts';
@@ -66,6 +67,11 @@ export function CostChart({ data }: CostChartProps) {
           </AreaChart>
         </ResponsiveContainer>
       </CardContent>
+      <CardFooter className="border-t px-6 py-3">
+        <Link href="/insights" className="text-sm text-primary hover:underline">
+          View Insights &rarr;
+        </Link>
+      </CardFooter>
     </Card>
   );
 }

--- a/apps/frontend/src/components/charts/insights-chart.tsx
+++ b/apps/frontend/src/components/charts/insights-chart.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import type { InsightsDaily } from '@/lib/api';
+
+interface ThroughputChartProps {
+  data: InsightsDaily[];
+}
+
+export function ThroughputChart({ data }: ThroughputChartProps) {
+  const chartData = data.map((d) => ({
+    date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    aiLines: d.aiLines,
+    manualLines: d.manualLines,
+  }));
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Code Throughput</CardTitle>
+          <CardDescription>AI-generated vs manually-written lines over time</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No data yet — complete tasks with /finish to see throughput</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Code Throughput</CardTitle>
+        <CardDescription>AI-generated vs manually-written lines over time</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={260}>
+          <AreaChart data={chartData}>
+            <defs>
+              <linearGradient id="colorAILines" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#60a5fa" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#60a5fa" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="colorManualLines" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#a1a1aa" stopOpacity={0.2} />
+                <stop offset="95%" stopColor="#a1a1aa" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="date" tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} width={50} />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--tooltip-bg)', border: '1px solid var(--tooltip-border)', borderRadius: '12px', fontSize: '12px' }}
+              labelStyle={{ color: '#a1a1aa' }}
+            />
+            <Legend wrapperStyle={{ fontSize: '12px' }} />
+            <Area type="monotone" dataKey="aiLines" name="AI Lines" stroke="#60a5fa" fill="url(#colorAILines)" strokeWidth={2} />
+            <Area type="monotone" dataKey="manualLines" name="Manual Lines" stroke="#a1a1aa" fill="url(#colorManualLines)" strokeWidth={2} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface CostEfficiencyChartProps {
+  data: InsightsDaily[];
+}
+
+export function CostEfficiencyChart({ data }: CostEfficiencyChartProps) {
+  const chartData = data.map((d) => ({
+    date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    cost: d.aiCost,
+    costPerLine: d.aiLines > 0 ? Math.round((d.aiCost / d.aiLines) * 10000) / 10000 : 0,
+  }));
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost Efficiency</CardTitle>
+          <CardDescription>Daily AI cost and cost per line trend</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">No cost data yet — enable OTEL in Claude Code</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cost Efficiency</CardTitle>
+        <CardDescription>Daily AI cost and cost per line trend</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={260}>
+          <AreaChart data={chartData}>
+            <defs>
+              <linearGradient id="colorCostEff" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#f87171" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#f87171" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="date" tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 12, fill: '#71717a' }} axisLine={false} tickLine={false} width={50} tickFormatter={(v: number) => `$${v}`} />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--tooltip-bg)', border: '1px solid var(--tooltip-border)', borderRadius: '12px', fontSize: '12px' }}
+              labelStyle={{ color: '#a1a1aa' }}
+              formatter={(value: number, name: string) => [
+                name === 'cost' ? `$${value.toFixed(2)}` : `$${value.toFixed(4)}`,
+                name === 'cost' ? 'Daily Cost' : 'Cost/Line',
+              ]}
+            />
+            <Legend wrapperStyle={{ fontSize: '12px' }} />
+            <Area type="monotone" dataKey="cost" name="Daily Cost" stroke="#f87171" fill="url(#colorCostEff)" strokeWidth={2} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Search,
   Layers,
   Brain,
+  Lightbulb,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth";
 import { useTheme } from "@/lib/theme";
@@ -66,6 +67,7 @@ const overviewItems = [
 ];
 
 const analyticsItems = [
+  { href: "/insights", label: "Insights", icon: Lightbulb },
   { href: "/friction-map", label: "Friction Map", icon: Flame },
 ];
 

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -280,6 +280,37 @@ export async function getTokenUsage(filter?: TelemetryFilter): Promise<TokenUsag
   return fetchApi<TokenUsageEntry[]>(`/api/telemetry/token-usage${buildParams(filter)}`);
 }
 
+export interface InsightsDaily {
+  date: string;
+  aiCost: number;
+  aiLines: number;
+  manualLines: number;
+}
+
+export interface InsightsMetrics {
+  totalAILines: number;
+  totalManualLines: number;
+  totalTasks: number;
+  productivityMultiplier: number | null;
+  capacityFreedHours: number;
+  totalAICost: number;
+  costPerAILine: number | null;
+  costPerTask: number | null;
+  memoryHits: number;
+  frictionEventsReduced: number | null;
+  orgMemoriesShared: number;
+  daily: InsightsDaily[];
+  assumptions: {
+    developerHourlyRate: number;
+    aiLineTimeEstimateSeconds: number;
+    currency: string;
+  };
+}
+
+export async function getInsightsMetrics(filter?: TelemetryFilter): Promise<InsightsMetrics> {
+  return fetchApi<InsightsMetrics>(`/api/telemetry/insights${buildParams(filter)}`);
+}
+
 // ---- Organizations (mutations) ----
 
 export async function createOrganization(data: { name: string; slug: string }): Promise<Organization> {
@@ -289,7 +320,7 @@ export async function createOrganization(data: { name: string; slug: string }): 
   });
 }
 
-export async function updateOrganization(orgId: string, data: { name?: string; slug?: string }): Promise<Organization> {
+export async function updateOrganization(orgId: string, data: { name?: string; slug?: string; settings?: { developerHourlyRate?: number; aiLineTimeEstimateSeconds?: number; currency?: string } }): Promise<Organization> {
   return fetchApi<Organization>(`/api/organizations/${orgId}`, {
     method: "PATCH",
     body: JSON.stringify(data),

--- a/packages/database/src/migrations/0009_org_settings.sql
+++ b/packages/database/src/migrations/0009_org_settings.sql
@@ -1,0 +1,2 @@
+-- Add settings JSONB column to organizations for org-level configuration (ROI params, etc.)
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS settings JSONB NOT NULL DEFAULT '{}';

--- a/packages/types/src/org.ts
+++ b/packages/types/src/org.ts
@@ -14,6 +14,7 @@ export interface Organization {
   readonly stripeSubscriptionId?: string;
   readonly planTier: PlanTier;
   readonly subscriptionStatus: SubscriptionStatus;
+  readonly settings?: OrgSettings;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -48,12 +49,22 @@ export interface UpdateOrganizationDto {
   readonly stripeCustomerId?: string;
   readonly stripeSubscriptionId?: string;
   readonly subscriptionStatus?: SubscriptionStatus;
+  readonly settings?: Partial<OrgSettings>;
 }
 
 export interface InviteMemberDto {
   readonly email: string;
   readonly organizationId: string;
   readonly role: MembershipRole;
+}
+
+export interface OrgSettings {
+  /** Fully-loaded hourly cost of one developer in USD. Default: 75 */
+  readonly developerHourlyRate?: number;
+  /** Estimated seconds a developer takes to write one line manually. Default: 120 */
+  readonly aiLineTimeEstimateSeconds?: number;
+  /** Currency code. Default: 'USD' */
+  readonly currency?: string;
 }
 
 export interface TeamSettings {

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -93,3 +93,48 @@ export interface TokenUsageEntry {
   readonly model: string;
   readonly totalTokens: number;
 }
+
+export interface InsightsDaily {
+  readonly date: string;
+  readonly aiCost: number;
+  readonly aiLines: number;
+  readonly manualLines: number;
+}
+
+export interface InsightsMetrics {
+  // Throughput
+  readonly totalAILines: number;
+  readonly totalManualLines: number;
+  readonly totalTasks: number;
+  /** (aiLines + manualLines) / manualLines — null if no manual lines */
+  readonly productivityMultiplier: number | null;
+
+  // Capacity freed
+  /** Hours of manual coding work handled by AI */
+  readonly capacityFreedHours: number;
+
+  // Cost efficiency
+  readonly totalAICost: number;
+  /** totalAICost / totalAILines — null if no AI lines */
+  readonly costPerAILine: number | null;
+  /** totalAICost / totalTasks — null if no tasks */
+  readonly costPerTask: number | null;
+
+  // Tandemu impact
+  /** Times memories were accessed in the period */
+  readonly memoryHits: number;
+  /** % change in friction events vs previous period (negative = improvement) */
+  readonly frictionEventsReduced: number | null;
+  /** Number of org-scoped memories shared across team */
+  readonly orgMemoriesShared: number;
+
+  // Charting
+  readonly daily: readonly InsightsDaily[];
+
+  // Transparency
+  readonly assumptions: {
+    readonly developerHourlyRate: number;
+    readonly aiLineTimeEstimateSeconds: number;
+    readonly currency: string;
+  };
+}


### PR DESCRIPTION
## Summary
- New `/insights` page with honest AI investment value metrics: productivity multiplier, capacity freed (hours), cost per task, cost per AI line
- **Tandemu Impact** section: memory hits, friction trend vs previous period, org knowledge shared
- Org-level ROI settings (developer hourly rate, time per manual line) configurable from Settings page
- All metrics computed from existing ClickHouse data — no new instrumentation needed
- Transparent assumptions banner always visible on the page
- Migration: `0009_org_settings.sql` adds `settings JSONB` to organizations table

## Files changed
- **3 new**: insights page, insights chart component, DB migration
- **9 modified**: types, backend service/controller, org service, frontend API/sidebar/settings/cost-chart

## Test plan
- [ ] Run migration `0009_org_settings.sql` against Postgres
- [ ] `GET /api/telemetry/insights` returns computed metrics
- [ ] Navigate to `/insights` — KPI cards and charts render
- [ ] Update ROI settings in Settings page → verify insights recalculates
- [ ] New org with no data shows empty state (not NaN)
- [ ] Cost chart has "View Insights →" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)