### PR TITLE
feat: encrypt customer integration tokens at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ APP_URL=http://localhost:3001
 FRONTEND_URL=http://localhost:3000
 JWT_SECRET=change-me-in-production
 
+# Encryption (SaaS — encrypts customer integration tokens at rest)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# ENCRYPTION_KEY=
+
 # OAuth (optional — providers auto-enabled when credentials are set)
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=

--- a/apps/backend/src/common/crypto.ts
+++ b/apps/backend/src/common/crypto.ts
@@ -1,0 +1,42 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit IV for GCM
+const KEY_VERSION = 1;
+
+/**
+ * Encrypt a plaintext string with AES-256-GCM.
+ * Output format: `keyVersion:iv:authTag:ciphertext` (all hex-encoded).
+ */
+export function encrypt(plaintext: string, keyHex: string): string {
+  const key = Buffer.from(keyHex, 'hex');
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${KEY_VERSION}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Decrypt a value produced by encrypt().
+ * Expects format: `keyVersion:iv:authTag:ciphertext`.
+ */
+export function decrypt(encrypted: string, keyHex: string): string {
+  const parts = encrypted.split(':');
+  if (parts.length !== 4) {
+    throw new Error('Invalid encrypted value format');
+  }
+  const [, ivHex, authTagHex, ciphertextHex] = parts;
+  const key = Buffer.from(keyHex, 'hex');
+  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(ivHex!, 'hex'));
+  decipher.setAuthTag(Buffer.from(authTagHex!, 'hex'));
+  return decipher.update(ciphertextHex!, 'hex', 'utf8') + decipher.final('utf8');
+}
+
+/**
+ * Check if a value looks like it was encrypted by encrypt().
+ * Used for backward compatibility during migration from plain text.
+ */
+export function isEncrypted(value: string): boolean {
+  return /^\d+:[0-9a-f]{24}:[0-9a-f]{32}:[0-9a-f]+$/.test(value);
+}

--- a/apps/backend/src/config/configuration.ts
+++ b/apps/backend/src/config/configuration.ts
@@ -24,6 +24,9 @@ export interface AppConfig {
     openmemoryHost: string;
     openmemoryPort: number;
   };
+  encryption: {
+    key: string;
+  };
   sentry: {
     dsn: string;
     environment: string;
@@ -75,6 +78,9 @@ export default (): AppConfig => {
       mem0ApiKey: process.env['MEM0_API_KEY'] ?? '',
       openmemoryHost: process.env['OPENMEMORY_HOST'] ?? 'localhost',
       openmemoryPort: parseInt(process.env['OPENMEMORY_PORT'] ?? '8765', 10),
+    },
+    encryption: {
+      key: process.env['ENCRYPTION_KEY'] ?? '',
     },
     sentry: {
       dsn: process.env['SENTRY_BACKEND_DSN'] ?? '',

--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { IntegrationsController } from './integrations.controller.js';
 import { TasksController } from './tasks.controller.js';
 import { IntegrationsService } from './integrations.service.js';
@@ -13,4 +13,19 @@ import { TeamsModule } from '../teams/teams.module.js';
   providers: [IntegrationsService, TasksService, GitHubGitService],
   exports: [IntegrationsService, TasksService, GitHubGitService],
 })
-export class IntegrationsModule {}
+export class IntegrationsModule implements OnModuleInit {
+  private readonly logger = new Logger(IntegrationsModule.name);
+
+  constructor(private readonly integrationsService: IntegrationsService) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      const count = await this.integrationsService.reencryptTokens();
+      if (count > 0) {
+        this.logger.log(`Auto-encrypted ${count} plain text token(s) on startup`);
+      }
+    } catch (err) {
+      this.logger.warn(`Token re-encryption on startup failed: ${err}`);
+    }
+  }
+}

--- a/apps/backend/src/integrations/integrations.service.ts
+++ b/apps/backend/src/integrations/integrations.service.ts
@@ -1,9 +1,12 @@
 import {
   ConflictException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { DatabaseService } from '../database/database.service.js';
+import { encrypt, decrypt, isEncrypted } from '../common/crypto.js';
 import type {
   Integration,
   IntegrationProvider,
@@ -22,6 +25,7 @@ interface IntegrationRow {
   external_workspace_id: string | null;
   external_workspace_name: string | null;
   config: Record<string, unknown>;
+  encryption_key_version: number;
   created_at: Date;
   updated_at: Date;
 }
@@ -68,21 +72,53 @@ function mapMapping(row: MappingRow): IntegrationProjectMapping {
 
 @Injectable()
 export class IntegrationsService {
-  constructor(private readonly db: DatabaseService) {}
+  private readonly logger = new Logger(IntegrationsService.name);
+  private readonly encryptionKey: string;
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionKey = this.configService.get<string>('encryption.key', '');
+    if (this.encryptionKey) {
+      this.logger.log('Token encryption: enabled');
+    } else {
+      this.logger.warn('Token encryption: disabled (ENCRYPTION_KEY not set)');
+    }
+  }
+
+  private encryptToken(plaintext: string): string {
+    if (!this.encryptionKey) return plaintext;
+    return encrypt(plaintext, this.encryptionKey);
+  }
+
+  private decryptToken(stored: string): string {
+    if (!this.encryptionKey) return stored;
+    if (!isEncrypted(stored)) return stored; // plain text (legacy/OSS)
+    return decrypt(stored, this.encryptionKey);
+  }
+
+  private get keyVersion(): number {
+    return this.encryptionKey ? 1 : 0;
+  }
 
   async create(orgId: string, dto: CreateIntegrationDto): Promise<Integration> {
     try {
+      const encryptedToken = this.encryptToken(dto.accessToken);
+      const encryptedRefresh = dto.refreshToken ? this.encryptToken(dto.refreshToken) : null;
+
       const result = await this.db.query<IntegrationRow>(
-        `INSERT INTO integrations (organization_id, provider, access_token, refresh_token, external_workspace_id, external_workspace_name)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO integrations (organization_id, provider, access_token, refresh_token, external_workspace_id, external_workspace_name, encryption_key_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
          RETURNING *`,
         [
           orgId,
           dto.provider,
-          dto.accessToken,
-          dto.refreshToken ?? null,
+          encryptedToken,
+          encryptedRefresh,
           dto.externalWorkspaceId ?? null,
           dto.externalWorkspaceName ?? null,
+          this.keyVersion,
         ],
       );
       return mapIntegration(result.rows[0]!);
@@ -101,10 +137,14 @@ export class IntegrationsService {
       `SELECT * FROM integrations WHERE organization_id = $1`,
       [orgId],
     );
-    return result.rows.map((row) => ({
-      ...mapIntegration(row),
-      maskedToken: maskToken(row.access_token),
-    }));
+    return result.rows.map((row) => {
+      // Decrypt to get the real token for masking (shows last 4 of actual token, not ciphertext)
+      const plainToken = this.decryptToken(row.access_token);
+      return {
+        ...mapIntegration(row),
+        maskedToken: maskToken(plainToken),
+      };
+    });
   }
 
   async findOne(orgId: string, provider: IntegrationProvider): Promise<IntegrationRow> {
@@ -115,7 +155,13 @@ export class IntegrationsService {
     if (result.rows.length === 0) {
       throw new NotFoundException(`No ${provider} integration found for this organization`);
     }
-    return result.rows[0]!;
+    const row = result.rows[0]!;
+    // Decrypt tokens before returning to callers (providers need plain text)
+    return {
+      ...row,
+      access_token: this.decryptToken(row.access_token),
+      refresh_token: row.refresh_token ? this.decryptToken(row.refresh_token) : null,
+    };
   }
 
   async delete(orgId: string, provider: IntegrationProvider): Promise<boolean> {
@@ -124,6 +170,35 @@ export class IntegrationsService {
       [orgId, provider],
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Re-encrypt all plain text tokens for an organization.
+   * Called on startup or via admin endpoint when ENCRYPTION_KEY is set.
+   */
+  async reencryptTokens(): Promise<number> {
+    if (!this.encryptionKey) return 0;
+
+    const result = await this.db.query<IntegrationRow>(
+      `SELECT * FROM integrations WHERE encryption_key_version = 0`,
+    );
+
+    let count = 0;
+    for (const row of result.rows) {
+      const encryptedToken = this.encryptToken(row.access_token);
+      const encryptedRefresh = row.refresh_token ? this.encryptToken(row.refresh_token) : null;
+
+      await this.db.query(
+        `UPDATE integrations SET access_token = $1, refresh_token = $2, encryption_key_version = $3, updated_at = now() WHERE id = $4`,
+        [encryptedToken, encryptedRefresh, this.keyVersion, row.id],
+      );
+      count++;
+    }
+
+    if (count > 0) {
+      this.logger.log(`Re-encrypted ${count} integration token(s)`);
+    }
+    return count;
   }
 
   async createMapping(integrationId: string, dto: CreateProjectMappingDto): Promise<IntegrationProjectMapping> {

--- a/packages/database/src/migrations/0010_encryption_key_version.sql
+++ b/packages/database/src/migrations/0010_encryption_key_version.sql
@@ -1,0 +1,4 @@
+-- Add encryption key version tracking for integration tokens
+ALTER TABLE integrations ADD COLUMN IF NOT EXISTS encryption_key_version INTEGER NOT NULL DEFAULT 0;
+-- 0 = plain text (unencrypted, legacy/OSS)
+-- 1+ = encrypted with the corresponding key version


### PR DESCRIPTION
## Summary
- Adds AES-256-GCM application-level encryption for integration `access_token` and `refresh_token`
- Encrypted format: `keyVersion:iv:authTag:ciphertext` — tamper-proof with unique IV per value
- Auto-reencrypts existing plain text tokens on startup when `ENCRYPTION_KEY` is set
- Key versioning (`encryption_key_version` column) supports future key rotation
- Opt-in via `ENCRYPTION_KEY` env var — OSS deployments without it keep plain text (backward compatible)
- Zero changes to providers, controllers, or frontend — encryption is transparent at the service layer

## Deploy steps
1. Generate key: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
2. Set `ENCRYPTION_KEY` in Railway
3. Deploy — migration adds column, startup auto-encrypts existing tokens
4. Verify logs: `Auto-encrypted N plain text token(s) on startup`

## Test plan
- [ ] Create integration with `ENCRYPTION_KEY` set — verify DB stores encrypted value (starts with `1:`)
- [ ] Fetch tasks — verify providers still work with decrypted tokens
- [ ] GET integrations — verify masked token shows last 4 of real token
- [ ] Unset `ENCRYPTION_KEY` — verify plain text storage still works (OSS path)
- [ ] Restart with key set and existing plain text rows — verify auto-reencryption

Closes SGS-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)