### PR TITLE
fix: inject local timezone into skills for accurate time messages

### DIFF
--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -95,6 +95,13 @@ echo "API=$TANDEMU_API"
 # Active task metadata
 echo "---ACTIVE_TASK---"
 cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
+
+# Local time context for accurate relative dates
+echo "---LOCAL_TIME---"
+echo "TZ=$(date +%Z)"
+echo "OFFSET=$(date +%z)"
+echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
+echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
 ```
 
 Extract `taskId`, `title`, `startedAt`, `repos`, `category`, `labels` from the active task.
@@ -178,7 +185,7 @@ If you can't determine which status to use, skip this step silently.
 rm -f ~/.claude/tandemu-active-task.json
 ```
 
-Tell the developer (using values from the backend response):
+Tell the developer (using values from the backend response). **When reporting duration and times, use the developer's local timezone (from LOCAL_TIME setup) — say "started today at 2 PM" or "started yesterday", not raw UTC timestamps.**
 
 ```
 Task completed: <title>

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -54,6 +54,14 @@ REPO=$(git rev-parse --show-toplevel 2>/dev/null)
 echo "REPO=$REPO"
 echo "STATUS=$(git status --short)"
 
+# Local time context for accurate relative dates
+echo "---LOCAL_TIME---"
+echo "TZ=$(date +%Z)"
+echo "OFFSET=$(date +%z)"
+echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
+echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
+echo "LOCAL_YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)"
+
 # Refresh memory index for this repo
 REPO_NAME=$(basename "$REPO" 2>/dev/null || echo "unknown")
 echo "---MEMORY_INDEX---"
@@ -82,7 +90,7 @@ If the config load fails, tell the developer: "Tandemu is not configured. Run in
 If the active task JSON was returned (not "NONE"):
 
 - Extract `taskId`, `title`, `startedAt`, `repos` from it.
-- Calculate how long ago the task was started.
+- Calculate how long ago the task was started. **Use LOCAL_TODAY and LOCAL_YESTERDAY from setup to determine if the task was started "today" or "yesterday". Convert `startedAt` to the developer's local timezone (using the OFFSET from setup) before comparing dates. Do not rely on elapsed hours alone — a task started at 11 PM yesterday is "yesterday", not "11h ago".**
 - Tell the developer: "You have an active task: **<title>** (started <relative time ago>)"
 - Use AskUserQuestion:
   - Question: "You're currently working on **<title>**. What would you like to do?"

--- a/apps/claude-plugins/skills/pause/SKILL.md
+++ b/apps/claude-plugins/skills/pause/SKILL.md
@@ -30,6 +30,13 @@ echo "USER=$TANDEMU_USER_ID"
 echo "---ACTIVE_TASK---"
 cat ~/.claude/tandemu-active-task.json 2>/dev/null || echo "NONE"
 
+# Local time context for accurate relative dates
+echo "---LOCAL_TIME---"
+echo "TZ=$(date +%Z)"
+echo "OFFSET=$(date +%z)"
+echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
+echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
+
 # OTEL endpoint
 echo "---OTEL---"
 python3 -c "
@@ -130,6 +137,8 @@ rm -f ~/.claude/tandemu-active-task.json
 ```
 
 ### 6. Confirm
+
+**When reporting duration, use the developer's local timezone (from LOCAL_TIME setup) — say "started today at 2 PM" or "worked on since yesterday", not raw UTC timestamps or misleading elapsed-time-only descriptions.**
 
 ```
 Task paused: <title>

--- a/apps/claude-plugins/skills/standup/SKILL.md
+++ b/apps/claude-plugins/skills/standup/SKILL.md
@@ -24,8 +24,17 @@ source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --sho
 
 # If --team is specified, override $TANDEMU_TEAM_ID here
 
-YESTERDAY=$(date -u -v-1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -d "yesterday" +%Y-%m-%dT00:00:00Z)
-NOW=$(date -u +%Y-%m-%dT23:59:59Z)
+# Use local time (not UTC) so date boundaries match the developer's day
+YESTERDAY=$(date -v-1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -d "yesterday" +%Y-%m-%dT00:00:00Z)
+NOW=$(date +%Y-%m-%dT23:59:59Z)
+
+# Local time context for accurate relative dates
+echo "---LOCAL_TIME---"
+echo "TZ=$(date +%Z)"
+echo "OFFSET=$(date +%z)"
+echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
+echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
+echo "LOCAL_YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)"
 
 echo "---MEMBERS---"
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/organizations/$TANDEMU_ORG_ID/teams/$TANDEMU_TEAM_ID/members"
@@ -64,6 +73,7 @@ If the config load fails, tell the developer: "Tandemu is not configured. Run in
 - **Todo**: tasks with `status: todo`. Show at most 10, and mention how many more exist.
 - Do NOT use the word "sprint" in the report. Use "this week" or "recently" instead.
 - Ignore tasks with `status: done` that were completed more than 7 days ago — they are not relevant to a standup.
+- **Timezone handling**: When categorizing tasks as "done today", "done yesterday", or "done this week", convert `updatedAt` timestamps to the developer's local timezone (using LOCAL_TODAY, LOCAL_YESTERDAY, and OFFSET from setup) before comparing dates. Do not compare raw UTC timestamps against local day boundaries.
 
 **Report structure:**
 


### PR DESCRIPTION
## Summary
- Skills (`/morning`, `/standup`, `/finish`, `/pause`) now output the developer's local timezone, today's date, and yesterday's date in their setup blocks
- Claude uses this context to correctly say "today" vs "yesterday" based on calendar days in the developer's timezone, not UTC elapsed time
- Standup skill date window changed from UTC (`date -u`) to local time so timesheet queries align with the developer's actual day boundaries

Fixes SGS-103

## Test plan
- [ ] Run `/morning` with an active task started yesterday evening — should say "started yesterday" not "started Xh ago"
- [ ] Run `/standup` — "done this week" tasks should reflect local day boundaries
- [ ] Verify standup timesheet window captures today's local sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)