### PR TITLE
feat: multi-team support with team-scoped telemetry (SGS-59)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI Teammate plugin for Claude Code",
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "plugins": [
     {
       "name": "tandemu",
       "source": "./apps/claude-plugins",
       "description": "AI Teammate — task lifecycle, telemetry, and persistent memory",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "author": {
         "name": "Tandemu"
       }

--- a/apps/backend/src/teams/teams.controller.ts
+++ b/apps/backend/src/teams/teams.controller.ts
@@ -43,6 +43,15 @@ export class TeamsController {
     return this.teamsService.findAll(orgId);
   }
 
+  // Any member can list their own teams
+  @Get('mine')
+  async findMine(
+    @Param('orgId') orgId: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<Team[]> {
+    return this.teamsService.findByUserId(orgId, user.userId);
+  }
+
   // Any member can view a team
   @Get(':teamId')
   async findOne(

--- a/apps/backend/src/teams/teams.service.ts
+++ b/apps/backend/src/teams/teams.service.ts
@@ -34,6 +34,17 @@ export class TeamsService {
     return result.rows.map((row) => this.mapTeam(row));
   }
 
+  async findByUserId(orgId: string, userId: string): Promise<Team[]> {
+    const result = await this.db.query<TeamRow>(
+      `SELECT t.* FROM teams t
+       INNER JOIN team_members tm ON tm.team_id = t.id
+       WHERE t.organization_id = $1 AND tm.user_id = $2
+       ORDER BY t.created_at ASC`,
+      [orgId, userId],
+    );
+    return result.rows.map((row) => this.mapTeam(row));
+  }
+
   async findOne(teamId: string): Promise<Team> {
     const result = await this.db.query<TeamRow>(
       `SELECT * FROM teams WHERE id = $1`,

--- a/apps/backend/src/telemetry/telemetry.controller.ts
+++ b/apps/backend/src/telemetry/telemetry.controller.ts
@@ -27,8 +27,9 @@ export class TelemetryController {
     @Query('sprintId') sprintId?: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<AIvsManualRatio[]> {
-    return this.telemetryService.getAIvsManualRatio(user.organizationId, sprintId, startDate, endDate);
+    return this.telemetryService.getAIvsManualRatio(user.organizationId, sprintId, startDate, endDate, teamId);
   }
 
   @Get('friction-heatmap')
@@ -36,10 +37,11 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<FrictionEvent[]> {
     const [custom, native] = await Promise.all([
-      this.telemetryService.getFrictionHeatmap(user.organizationId, startDate, endDate),
-      this.telemetryService.getNativeFriction(user.organizationId, startDate, endDate),
+      this.telemetryService.getFrictionHeatmap(user.organizationId, startDate, endDate, teamId),
+      this.telemetryService.getNativeFriction(user.organizationId, startDate, endDate, teamId),
     ]);
     return [...custom, ...native];
   }
@@ -49,8 +51,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ) {
-    return this.telemetryService.getHotFiles(user.organizationId, startDate, endDate);
+    return this.telemetryService.getHotFiles(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('investment-allocation')
@@ -58,8 +61,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ) {
-    return this.telemetryService.getInvestmentAllocation(user.organizationId, startDate, endDate);
+    return this.telemetryService.getInvestmentAllocation(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('ai-effectiveness')
@@ -67,8 +71,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ) {
-    return this.telemetryService.getAIEffectiveness(user.organizationId, startDate, endDate);
+    return this.telemetryService.getAIEffectiveness(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('cost-metrics')
@@ -76,8 +81,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ) {
-    return this.telemetryService.getCostMetrics(user.organizationId, startDate, endDate);
+    return this.telemetryService.getCostMetrics(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('token-usage')
@@ -85,8 +91,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ) {
-    return this.telemetryService.getTokenUsage(user.organizationId, startDate, endDate);
+    return this.telemetryService.getTokenUsage(user.organizationId, startDate, endDate, teamId);
   }
 
   /** Claude Code-specific — will need normalization for Codex/Cursor */
@@ -95,8 +102,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<ToolUsageStat[]> {
-    return this.telemetryService.getToolUsageStats(user.organizationId, startDate, endDate);
+    return this.telemetryService.getToolUsageStats(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('developer-stats')
@@ -104,8 +112,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<DeveloperStat[]> {
-    const stats = await this.telemetryService.getDeveloperStats(user.organizationId, startDate, endDate);
+    const stats = await this.telemetryService.getDeveloperStats(user.organizationId, startDate, endDate, teamId);
 
     const userIds = [...new Set(stats.map((s) => s.userId))];
     if (userIds.length > 0) {
@@ -128,8 +137,9 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<TaskVelocityEntry[]> {
-    return this.telemetryService.getTaskVelocity(user.organizationId, startDate, endDate);
+    return this.telemetryService.getTaskVelocity(user.organizationId, startDate, endDate, teamId);
   }
 
   @Get('timesheets')
@@ -138,12 +148,14 @@ export class TelemetryController {
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
     @Query('userId') userId?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<TimesheetEntry[]> {
     const entries = await this.telemetryService.getTimesheets({
       organizationId: user.organizationId,
       startDate: startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
       endDate: endDate || new Date().toISOString(),
       userId,
+      teamId,
     });
 
     const userIds = [...new Set(entries.map((e) => e.userId))];
@@ -167,6 +179,7 @@ export class TelemetryController {
     @CurrentUser() user: RequestUser,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
   ): Promise<InsightsMetrics> {
     // Fetch org settings for ROI assumptions
     const orgResult = await this.db.query<{ settings: OrgSettings }>(
@@ -189,7 +202,7 @@ export class TelemetryController {
     }
 
     const metrics = await this.telemetryService.getInsightsMetrics(
-      user.organizationId, startDate, endDate, settings,
+      user.organizationId, startDate, endDate, settings, teamId,
     );
 
     return { ...metrics, orgMemoriesShared };

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -33,6 +33,7 @@ export interface TimesheetQuery {
   readonly startDate: string;
   readonly endDate: string;
   readonly userId?: string;
+  readonly teamId?: string;
 }
 
 export interface FinishTaskInput {
@@ -52,6 +53,7 @@ export interface FinishTaskInput {
   readonly changedFilesList: string[];
   readonly category?: string;
   readonly labels?: string[];
+  readonly teamId?: string;
 }
 
 export interface FinishTaskResult {
@@ -233,6 +235,7 @@ export class TelemetryService implements OnModuleDestroy {
               attributes: [
                 { key: 'user_id', value: { stringValue: userId } },
                 { key: 'task_id', value: { stringValue: taskId } },
+                { key: 'team_id', value: { stringValue: input.teamId ?? '' } },
                 { key: 'status', value: { stringValue: 'completed' } },
                 { key: 'ai_lines', value: { stringValue: String(aiLines) } },
                 { key: 'manual_lines', value: { stringValue: String(manualLines) } },
@@ -270,8 +273,8 @@ export class TelemetryService implements OnModuleDestroy {
               name: 'tandemu.lines_of_code',
               sum: {
                 dataPoints: [
-                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: aiLines, attributes: [{ key: 'type', value: { stringValue: 'ai' } }, { key: 'task_id', value: { stringValue: taskId } }] },
-                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: manualLines, attributes: [{ key: 'type', value: { stringValue: 'manual' } }, { key: 'task_id', value: { stringValue: taskId } }] },
+                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: aiLines, attributes: [{ key: 'type', value: { stringValue: 'ai' } }, { key: 'task_id', value: { stringValue: taskId } }, { key: 'team_id', value: { stringValue: input.teamId ?? '' } }] },
+                  { startTimeUnixNano: startNs.toString(), timeUnixNano: endNs.toString(), asDouble: manualLines, attributes: [{ key: 'type', value: { stringValue: 'manual' } }, { key: 'task_id', value: { stringValue: taskId } }, { key: 'team_id', value: { stringValue: input.teamId ?? '' } }] },
                 ],
                 aggregationTemporality: 2,
                 isMonotonic: true,
@@ -448,6 +451,7 @@ export class TelemetryService implements OnModuleDestroy {
     sprintId?: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<AIvsManualRatio[]> {
     try {
       const params: Record<string, string> = { organizationId };
@@ -460,6 +464,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND Attributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const query = `
         SELECT
@@ -473,6 +479,7 @@ export class TelemetryService implements OnModuleDestroy {
         WHERE ResourceAttributes['organization_id'] = {organizationId: String}
           AND MetricName = 'tandemu.lines_of_code'
           ${dateFilter}
+          ${teamFilter}
         GROUP BY organization_id
       `;
 
@@ -509,7 +516,7 @@ export class TelemetryService implements OnModuleDestroy {
     }
   }
 
-  async getFrictionHeatmap(organizationId: string, startDate?: string, endDate?: string): Promise<FrictionEvent[]> {
+  async getFrictionHeatmap(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<FrictionEvent[]> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -521,6 +528,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND LogAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -535,6 +544,7 @@ export class TelemetryService implements OnModuleDestroy {
           WHERE ResourceAttributes['organization_id'] = {organizationId: String}
             AND (SeverityText = 'prompt_loop' OR SeverityText = 'error')
             ${dateFilter}
+            ${teamFilter}
           ORDER BY Timestamp DESC
           LIMIT 1000
         `,
@@ -593,6 +603,10 @@ export class TelemetryService implements OnModuleDestroy {
         chQuery += ` AND SpanAttributes['user_id'] = {userId: String}`;
         params['userId'] = query.userId;
       }
+      if (query.teamId) {
+        chQuery += ` AND SpanAttributes['team_id'] = {teamId: String}`;
+        params['teamId'] = query.teamId;
+      }
 
       chQuery += ` GROUP BY userId, date ORDER BY date DESC`;
 
@@ -625,6 +639,7 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<DeveloperStat[]> {
     try {
       const params: Record<string, string> = { organizationId };
@@ -637,6 +652,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -650,6 +667,7 @@ export class TelemetryService implements OnModuleDestroy {
           WHERE ResourceAttributes['organization_id'] = {organizationId: String}
             AND SpanName = 'task_session'
             ${dateFilter}
+            ${teamFilter}
           GROUP BY userId
           ORDER BY sessions DESC
         `,
@@ -682,6 +700,7 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<TaskVelocityEntry[]> {
     try {
       const params: Record<string, string> = { organizationId };
@@ -694,6 +713,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -706,6 +727,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND SpanName = 'task_session'
             AND SpanAttributes['status'] = 'completed'
             ${dateFilter}
+            ${teamFilter}
           GROUP BY week
           ORDER BY week ASC
         `,
@@ -733,12 +755,15 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<Array<{ filePath: string; changeCount: number; taskCount: number; developerCount: number }>> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
       if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
       if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+      const teamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -752,6 +777,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND SpanName = 'task_session'
             AND SpanAttributes['changed_files'] != ''
             ${dateFilter}
+            ${teamFilter}
           GROUP BY file_path
           ORDER BY change_count DESC
           LIMIT 20
@@ -776,12 +802,15 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<Array<{ category: string; taskCount: number; totalHours: number }>> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
       if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
       if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+      const teamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -794,6 +823,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND SpanName = 'task_session'
             AND SpanAttributes['task_category'] != ''
             ${dateFilter}
+            ${teamFilter}
           GROUP BY category
         `,
         query_params: params,
@@ -815,12 +845,15 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<Array<{ filePath: string; aiTouchCount: number }>> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
       if (startDate) { dateFilter += ` AND Timestamp >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
       if (endDate) { dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+      const teamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -832,6 +865,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND SpanName = 'task_session'
             AND SpanAttributes['ai_files'] != ''
             ${dateFilter}
+            ${teamFilter}
           GROUP BY file_path
           ORDER BY ai_touch_count DESC
           LIMIT 20
@@ -854,12 +888,15 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<Array<{ date: string; totalCost: number }>> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
       if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
       if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+      const teamFilter = teamId ? ` AND Attributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -870,6 +907,7 @@ export class TelemetryService implements OnModuleDestroy {
           WHERE ResourceAttributes['organization_id'] = {organizationId: String}
             AND MetricName = 'claude_code.cost.usage'
             ${dateFilter}
+            ${teamFilter}
           GROUP BY date
           ORDER BY date ASC
         `,
@@ -891,12 +929,15 @@ export class TelemetryService implements OnModuleDestroy {
     organizationId: string,
     startDate?: string,
     endDate?: string,
+    teamId?: string,
   ): Promise<Array<{ tokenType: string; model: string; totalTokens: number }>> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
       if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
       if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+      const teamFilter = teamId ? ` AND Attributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -908,6 +949,7 @@ export class TelemetryService implements OnModuleDestroy {
           WHERE ResourceAttributes['organization_id'] = {organizationId: String}
             AND MetricName = 'claude_code.token.usage'
             ${dateFilter}
+            ${teamFilter}
           GROUP BY token_type, model
         `,
         query_params: params,
@@ -929,7 +971,7 @@ export class TelemetryService implements OnModuleDestroy {
    * Tool usage stats from Claude Code's native tool_result events.
    * Shows which tools the team uses, success rates, and avg duration.
    */
-  async getToolUsageStats(organizationId: string, startDate?: string, endDate?: string): Promise<ToolUsageStat[]> {
+  async getToolUsageStats(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<ToolUsageStat[]> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -941,6 +983,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND LogAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -955,6 +999,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND LogAttributes['event.name'] = 'tool_result'
             AND LogAttributes['tool_name'] != ''
             ${dateFilter}
+            ${teamFilter}
           GROUP BY toolName
           ORDER BY totalCalls DESC
         `,
@@ -992,7 +1037,7 @@ export class TelemetryService implements OnModuleDestroy {
    * Will need normalization layer for Codex (codex.tool.call) and Cursor (REST API).
    * Failed tool calls grouped by file path — augments custom friction logs.
    */
-  async getNativeFriction(organizationId: string, startDate?: string, endDate?: string): Promise<FrictionEvent[]> {
+  async getNativeFriction(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<FrictionEvent[]> {
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1004,6 +1049,8 @@ export class TelemetryService implements OnModuleDestroy {
         dateFilter += ` AND Timestamp <= parseDateTimeBestEffort({endDate: String})`;
         params.endDate = endDate;
       }
+      const teamFilter = teamId ? ` AND LogAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
 
       const resultSet = await this.client.query({
         query: `
@@ -1024,6 +1071,7 @@ export class TelemetryService implements OnModuleDestroy {
             AND LogAttributes['event.name'] = 'tool_result'
             AND LogAttributes['success'] = 'false'
             ${dateFilter}
+            ${teamFilter}
           GROUP BY session_id, user_id, repository_path
           HAVING repository_path != '' AND error_count >= 1
           ORDER BY error_count DESC
@@ -1158,6 +1206,7 @@ export class TelemetryService implements OnModuleDestroy {
     startDate?: string,
     endDate?: string,
     settings?: OrgSettings,
+    teamId?: string,
   ): Promise<InsightsMetrics> {
     const hourlyRate = settings?.developerHourlyRate ?? 75;
     const secsPerLine = settings?.aiLineTimeEstimateSeconds ?? 120;
@@ -1167,10 +1216,15 @@ export class TelemetryService implements OnModuleDestroy {
     let dateFilter = '';
     if (startDate) { dateFilter += ` AND TimeUnix >= parseDateTimeBestEffort({startDate: String})`; params.startDate = startDate; }
     if (endDate) { dateFilter += ` AND TimeUnix <= parseDateTimeBestEffort({endDate: String})`; params.endDate = endDate; }
+    const metricsTeamFilter = teamId ? ` AND Attributes['team_id'] = {teamId: String}` : '';
+    const tracesTeamFilter = teamId ? ` AND SpanAttributes['team_id'] = {teamId: String}` : '';
+    const logsTeamFilter = teamId ? ` AND LogAttributes['team_id'] = {teamId: String}` : '';
+    if (teamId) params.teamId = teamId;
 
     // Build a previous-period date filter for friction trend comparison
     let prevDateFilter = '';
     const prevParams: Record<string, string> = { organizationId };
+    if (teamId) prevParams.teamId = teamId;
     if (startDate && endDate) {
       const start = new Date(startDate).getTime();
       const end = new Date(endDate).getTime();
@@ -1197,6 +1251,7 @@ export class TelemetryService implements OnModuleDestroy {
             WHERE ResourceAttributes['organization_id'] = {organizationId: String}
               AND MetricName IN ('claude_code.cost.usage', 'tandemu.lines_of_code')
               ${dateFilter}
+              ${metricsTeamFilter}
             GROUP BY date
             ORDER BY date ASC
           `,
@@ -1213,6 +1268,7 @@ export class TelemetryService implements OnModuleDestroy {
               AND SpanName = 'task_session'
               AND SpanAttributes['status'] = 'completed'
               ${dateFilter.replace(/TimeUnix/g, 'Timestamp')}
+              ${tracesTeamFilter}
           `,
           query_params: params,
           format: 'JSONEachRow',
@@ -1240,6 +1296,7 @@ export class TelemetryService implements OnModuleDestroy {
               AND (SeverityText IN ('prompt_loop', 'error')
                    OR (LogAttributes['event.name'] = 'tool_result' AND LogAttributes['success'] = 'false'))
               ${dateFilter.replace(/TimeUnix/g, 'Timestamp')}
+              ${logsTeamFilter}
           `,
           query_params: params,
           format: 'JSONEachRow',
@@ -1255,6 +1312,7 @@ export class TelemetryService implements OnModuleDestroy {
                   AND (SeverityText IN ('prompt_loop', 'error')
                        OR (LogAttributes['event.name'] = 'tool_result' AND LogAttributes['success'] = 'false'))
                   ${prevDateFilter}
+                  ${logsTeamFilter}
               `,
               query_params: prevParams,
               format: 'JSONEachRow',

--- a/apps/claude-plugins/.claude-plugin/plugin.json
+++ b/apps/claude-plugins/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandemu",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "AI Teammate — task lifecycle, telemetry, and persistent memory for AI-native development",
   "author": {
     "name": "Tandemu",

--- a/apps/claude-plugins/lib/tandemu-env.sh
+++ b/apps/claude-plugins/lib/tandemu-env.sh
@@ -14,10 +14,24 @@ c = json.load(sys.stdin)
 print(f'TANDEMU_TOKEN={chr(39)}{c[\"auth\"][\"token\"]}{chr(39)}')
 print(f'TANDEMU_API={chr(39)}{c[\"api\"][\"url\"]}{chr(39)}')
 print(f'TANDEMU_ORG_ID={chr(39)}{c[\"organization\"][\"id\"]}{chr(39)}')
-print(f'TANDEMU_TEAM_ID={chr(39)}{c[\"team\"][\"id\"]}{chr(39)}')
 print(f'TANDEMU_USER_ID={chr(39)}{c[\"user\"][\"id\"]}{chr(39)}')
 print(f'TANDEMU_USER_EMAIL={chr(39)}{c[\"user\"][\"email\"]}{chr(39)}')
 print(f'TANDEMU_USER_NAME={chr(39)}{c[\"user\"][\"name\"]}{chr(39)}')
+
+# Multi-team support: read teams array
+teams = c.get('teams', [])
+if teams:
+    ids = ','.join(t['id'] for t in teams)
+    names = ','.join(t['name'] for t in teams)
+    print(f'TANDEMU_TEAM_ID={chr(39)}{teams[0][\"id\"]}{chr(39)}')
+    print(f'TANDEMU_TEAM_IDS={chr(39)}{ids}{chr(39)}')
+    print(f'TANDEMU_TEAM_NAMES={chr(39)}{names}{chr(39)}')
+    print(f'TANDEMU_TEAM_COUNT={len(teams)}')
+else:
+    print(\"TANDEMU_TEAM_ID=''\")
+    print(\"TANDEMU_TEAM_IDS=''\")
+    print(\"TANDEMU_TEAM_NAMES=''\")
+    print('TANDEMU_TEAM_COUNT=0')
 ")"
 
 unset _TANDEMU_CONFIG

--- a/apps/claude-plugins/skills/create/SKILL.md
+++ b/apps/claude-plugins/skills/create/SKILL.md
@@ -19,6 +19,9 @@ echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
 echo "TEAM=$TANDEMU_TEAM_ID"
+echo "TEAM_IDS=$TANDEMU_TEAM_IDS"
+echo "TEAM_NAMES=$TANDEMU_TEAM_NAMES"
+echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
 echo "EMAIL=$TANDEMU_USER_EMAIL"
 
 echo "---ACTIVE_TASK---"
@@ -49,12 +52,19 @@ Then optionally ask for priority:
 
 ### 3. Create the task
 
+**If `TEAM_COUNT` > 1**: use AskUserQuestion to let the developer choose which team to create the task in:
+- Question: "Which team should this task be created in?"
+- Header: "Team"
+- Options: one per team (from `TANDEMU_TEAM_IDS`/`TANDEMU_TEAM_NAMES`)
+
+Set `SELECTED_TEAM_ID` from the choice. If single team, use `$TANDEMU_TEAM_ID` directly.
+
 ```bash
 RESULT=$(curl -sf -X POST "$TANDEMU_API/api/tasks" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "teamId": "'"$TANDEMU_TEAM_ID"'",
+    "teamId": "'"$SELECTED_TEAM_ID"'",
     "title": "<title from step 2>",
     "description": "<description if provided>",
     "assigneeEmail": "'"$TANDEMU_USER_EMAIL"'",

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -151,7 +151,8 @@ RESULT=$(curl -sf -X POST "$TANDEMU_API/api/telemetry/tasks/<taskId>/finish" \
     ],
     "changedFilesList": ["<file1>", "<file2>"],
     "category": "<category from active task>",
-    "labels": ["<label1>", "<label2>"]
+    "labels": ["<label1>", "<label2>"],
+    "teamId": "<teamId from active task file, if present>"
   }')
 echo "$RESULT"
 ```

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -41,6 +41,9 @@ echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
 echo "ORG=$TANDEMU_ORG_ID"
 echo "TEAM=$TANDEMU_TEAM_ID"
+echo "TEAM_IDS=$TANDEMU_TEAM_IDS"
+echo "TEAM_NAMES=$TANDEMU_TEAM_NAMES"
+echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
 echo "EMAIL=$TANDEMU_USER_EMAIL"
 echo "NAME=$TANDEMU_USER_NAME"
 
@@ -126,10 +129,30 @@ If no active task was found, proceed to Step 3.
 
 ### 3. Fetch tasks from Tandemu
 
-Fetch tasks assigned to the current developer (use the config values from setup):
+**If `TEAM_COUNT` > 1**: use AskUserQuestion to let the developer pick which team's tasks to see:
+- Question: "Which team's tasks would you like to see?"
+- Header: "Team"
+- Options: one per team (built from `TANDEMU_TEAM_IDS` and `TANDEMU_TEAM_NAMES` by splitting on `,`), plus an "All teams" option with description "Show tasks from all my teams"
 
+Set `SELECTED_TEAM_ID` from the choice. If "All teams" is selected, set `SELECTED_TEAM_ID=ALL`.
+
+**If `TEAM_COUNT` = 1 or 0**: use `$TANDEMU_TEAM_ID` directly. No prompt.
+
+Fetch tasks assigned to the current developer:
+
+If `SELECTED_TEAM_ID=ALL`, fetch tasks from each team, merge, and deduplicate by task ID:
 ```bash
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID&mine=true&sort=priority&order=desc"
+# For each team ID in TANDEMU_TEAM_IDS (comma-separated), fetch and merge
+IFS=',' read -ra TEAM_IDS_ARRAY <<< "$TANDEMU_TEAM_IDS"
+for TID in "${TEAM_IDS_ARRAY[@]}"; do
+  curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TID&mine=true&sort=priority&order=desc"
+done
+# Merge results in Python, deduplicate by task id
+```
+
+Otherwise:
+```bash
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&mine=true&sort=priority&order=desc"
 ```
 
 The response is `{ success, data: Task[] }` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`. **The API returns tasks already sorted by priority (urgent first).** Do not re-sort — use the response order as-is.
@@ -138,10 +161,10 @@ Filter to tasks that are `todo` or `in_progress` status.
 
 If the developer has assigned tasks, proceed to Step 4 with those.
 
-If no tasks are assigned to the developer, fetch **unassigned todo tasks** that they could pick up:
+If no tasks are assigned to the developer, fetch **unassigned todo tasks** (using the same `SELECTED_TEAM_ID` or all-teams logic):
 
 ```bash
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID&status=todo&unassigned=true&sort=priority&order=desc"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&status=todo&unassigned=true&sort=priority&order=desc"
 ```
 
 Tell the developer: "No tasks are assigned to you. Here are unassigned tasks you could pick up:"
@@ -229,6 +252,7 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 cat > "$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json" << EOF
 {
   "taskId": "<task.id>",
+  "teamId": "<SELECTED_TEAM_ID or the team the task was fetched from>",
   "title": "<task.title>",
   "startedAt": "$NOW",
   "repos": ["$REPO_PATH"],

--- a/apps/claude-plugins/skills/setup/SKILL.md
+++ b/apps/claude-plugins/skills/setup/SKILL.md
@@ -126,18 +126,29 @@ Use the new `$TOKEN` for all subsequent API calls (team fetch, config writing).
 If there is **one organization**, use it directly (no prompt needed).
 If there are **zero organizations**, tell the developer to create one on the dashboard and stop.
 
-Fetch teams for the chosen org:
+Fetch the user's teams (teams they are a member of):
 ```bash
-TEAMS=$(curl -sf -H "Authorization: Bearer $TOKEN" "${API_URL}/api/organizations/${ORG_ID}/teams")
-echo "$TEAMS" | python3 -c "
+# Fetch teams the user belongs to
+MY_TEAMS=$(curl -sf -H "Authorization: Bearer $TOKEN" "${API_URL}/api/organizations/${ORG_ID}/teams/mine")
+
+# Fallback: if user is not assigned to any team yet, fetch all org teams
+if [ -z "$MY_TEAMS" ] || [ "$MY_TEAMS" = "[]" ]; then
+  MY_TEAMS=$(curl -sf -H "Authorization: Bearer $TOKEN" "${API_URL}/api/organizations/${ORG_ID}/teams")
+fi
+
+echo "$MY_TEAMS" | python3 -c "
 import json, sys
-teams = json.load(sys.stdin)['data']
+teams = json.load(sys.stdin)
+# Handle both raw array and {data: [...]} wrapper
+if isinstance(teams, dict):
+    teams = teams.get('data', [])
 if teams:
-    print(f\"TEAM_ID={teams[0]['id']}\")
-    print(f\"TEAM_NAME={teams[0]['name']}\")
+    import json as _j
+    print(f'TEAMS_JSON={_j.dumps([{\"id\": t[\"id\"], \"name\": t[\"name\"]} for t in teams])}')
+    print(f'TEAMS_COUNT={len(teams)}')
 else:
-    print('TEAM_ID=')
-    print('TEAM_NAME=')
+    print('TEAMS_JSON=[]')
+    print('TEAMS_COUNT=0')
 "
 ```
 
@@ -147,15 +158,28 @@ else:
 
 ```bash
 mkdir -p ~/.claude
-cat > ~/.claude/tandemu.json << EOF
-{
-  "auth": { "token": "${TOKEN}" },
-  "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
-  "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
-  "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
-  "api": { "url": "${API_URL}" }
+python3 << 'PYEOF'
+import json, os
+teams_json = os.environ.get("TEAMS_JSON", "[]")
+teams = json.loads(teams_json)
+
+config = {
+  "auth": {"token": os.environ["TOKEN"]},
+  "user": {
+    "id": os.environ["USER_ID"],
+    "email": os.environ["USER_EMAIL"],
+    "name": os.environ["USER_NAME"]
+  },
+  "organization": {"id": os.environ["ORG_ID"], "name": os.environ["ORG_NAME"]},
+  "teams": teams,
+  "api": {"url": os.environ["API_URL"]}
 }
-EOF
+
+config_path = os.path.expanduser("~/.claude/tandemu.json")
+with open(config_path, "w") as f:
+    json.dump(config, f, indent=2)
+print("OK")
+PYEOF
 ```
 
 #### 5b. Fetch setup config from API
@@ -346,7 +370,7 @@ Tandemu installed!
 
 Connected as: <USER_NAME> (<USER_EMAIL>)
 Organization: <ORG_NAME>
-Team: <TEAM_NAME>
+Teams: <comma-separated list of team names from TEAMS_JSON>
 API: <API_URL>
 Telemetry: enabled
 Memory: enabled

--- a/apps/claude-plugins/skills/standup/SKILL.md
+++ b/apps/claude-plugins/skills/standup/SKILL.md
@@ -22,7 +22,17 @@ Load config and fetch all data in a **single Bash call** ("Fetch team data"):
 # Load Tandemu config
 source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
-# If --team is specified, override $TANDEMU_TEAM_ID here
+# Multi-team support: resolve --team argument or prompt if multiple teams
+# Parse --team from arguments
+ACTIVE_TEAM_ID="$TANDEMU_TEAM_ID"
+ACTIVE_TEAM_NAME=""
+echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
+echo "TEAM_IDS=$TANDEMU_TEAM_IDS"
+echo "TEAM_NAMES=$TANDEMU_TEAM_NAMES"
+
+# If --team is specified, resolve name to ID
+# The Claude agent will parse the argument and do the lookup from TANDEMU_TEAM_NAMES/IDS
+# If TEAM_COUNT > 1 and no --team flag, Claude should use AskUserQuestion to prompt
 
 # Use local time (not UTC) so date boundaries match the developer's day
 YESTERDAY=$(date -v-1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -d "yesterday" +%Y-%m-%dT00:00:00Z)
@@ -37,10 +47,10 @@ echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
 echo "LOCAL_YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)"
 
 echo "---MEMBERS---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/organizations/$TANDEMU_ORG_ID/teams/$TANDEMU_TEAM_ID/members"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/organizations/$TANDEMU_ORG_ID/teams/$ACTIVE_TEAM_ID/members"
 
 echo "---TASKS---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TANDEMU_TEAM_ID"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$ACTIVE_TEAM_ID"
 
 echo "---TIMESHEETS---"
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/timesheets?startDate=$YESTERDAY&endDate=$NOW"

--- a/apps/frontend/src/app/activity/page.tsx
+++ b/apps/frontend/src/app/activity/page.tsx
@@ -27,12 +27,12 @@ export default function ActivityPage() {
   const [aiEffectiveness, setAiEffectiveness] = useState<AIEffectivenessEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const { startDate, endDate } = useFilterParams();
+  const { startDate, endDate, teamId } = useFilterParams();
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    const f = { startDate, endDate };
+    const f = { startDate, endDate, teamId };
     Promise.allSettled([
       getTimesheets(f),
       getDeveloperStats(f),
@@ -49,7 +49,7 @@ export default function ActivityPage() {
       .catch((err) => { if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load'); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [startDate, endDate]);
+  }, [startDate, endDate, teamId]);
 
   if (loading) {
     return (

--- a/apps/frontend/src/app/friction-map/page.tsx
+++ b/apps/frontend/src/app/friction-map/page.tsx
@@ -82,17 +82,17 @@ export default function FrictionMapPage() {
   const [frictionData, setFrictionData] = useState<FrictionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const { startDate, endDate } = useFilterParams();
+  const { startDate, endDate, teamId } = useFilterParams();
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getFrictionHeatmap({ startDate, endDate })
+    getFrictionHeatmap({ startDate, endDate, teamId })
       .then((events) => { if (!cancelled) setFrictionData(aggregateFriction(events)); })
       .catch((err) => { if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load friction data'); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [startDate, endDate]);
+  }, [startDate, endDate, teamId]);
 
   if (loading) {
     return (

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -26,14 +26,14 @@ export default function InsightsPage() {
   const [orgMemoryCount, setOrgMemoryCount] = useState(0);
   const [tokenData, setTokenData] = useState<TokenUsageEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  const { startDate, endDate } = useFilterParams();
+  const { startDate, endDate, teamId } = useFilterParams();
 
   useEffect(() => {
     let cancelled = false;
     async function fetchData() {
       setLoading(true);
       try {
-        const f = { startDate, endDate };
+        const f = { startDate, endDate, teamId };
         const [insights, memStats, tokens] = await Promise.allSettled([
           getInsightsMetrics(f),
           getMemoryStats(),
@@ -51,7 +51,7 @@ export default function InsightsPage() {
     }
     fetchData();
     return () => { cancelled = true; };
-  }, [startDate, endDate]);
+  }, [startDate, endDate, teamId]);
 
   if (loading) {
     return (
@@ -61,7 +61,7 @@ export default function InsightsPage() {
             <h1 className="text-3xl font-bold tracking-tight">Insights</h1>
             <p className="text-muted-foreground">Honest assessment of AI investment value</p>
           </div>
-          <TelemetryFilters showTeamFilter={false} />
+          <TelemetryFilters showTeamFilter={true} />
         </div>
         <DashboardSkeleton />
       </div>
@@ -78,7 +78,7 @@ export default function InsightsPage() {
           <h1 className="text-3xl font-bold tracking-tight">Insights</h1>
           <p className="text-muted-foreground">Honest assessment of AI investment value</p>
         </div>
-        <TelemetryFilters showTeamFilter={false} />
+        <TelemetryFilters showTeamFilter={true} />
       </div>
 
       {/* Assumptions banner */}

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -31,14 +31,14 @@ export default function DashboardPage() {
   const [investment, setInvestment] = useState<InvestmentAllocation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const { startDate, endDate } = useFilterParams();
+  const { startDate, endDate, teamId } = useFilterParams();
 
   useEffect(() => {
     let cancelled = false;
     async function fetchData() {
       setLoading(true);
       try {
-        const f = { startDate, endDate };
+        const f = { startDate, endDate, teamId };
         const [ai, timesheets, tools, velocity, invest] = await Promise.allSettled([
           getAIRatio(f), getTimesheets(f), getToolUsage(f), getTaskVelocity(f),
           getInvestmentAllocation(f),
@@ -57,7 +57,7 @@ export default function DashboardPage() {
     }
     fetchData();
     return () => { cancelled = true; };
-  }, [startDate, endDate]);
+  }, [startDate, endDate, teamId]);
 
   if (loading) {
     return (

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -164,6 +164,7 @@ export async function getMembers(orgId: string): Promise<Membership[]> {
 export interface TelemetryFilter {
   startDate?: string;
   endDate?: string;
+  teamId?: string;
 }
 
 function buildParams(filter?: TelemetryFilter): string {
@@ -171,6 +172,7 @@ function buildParams(filter?: TelemetryFilter): string {
   const p = new URLSearchParams();
   if (filter.startDate) p.set('startDate', filter.startDate);
   if (filter.endDate) p.set('endDate', filter.endDate);
+  if (filter.teamId) p.set('teamId', filter.teamId);
   const s = p.toString();
   return s ? `?${s}` : '';
 }


### PR DESCRIPTION
## Summary
- Enable users to belong to multiple teams with end-to-end team-scoped filtering
- Add `GET /teams/mine` backend endpoint, `team_id` span/metric tagging in `/finish`, and `teamId?` filter on all 15 ClickHouse queries + controller endpoints
- Wire the existing (previously dead) dashboard team selector through `TelemetryFilter` → `buildParams` → all 4 dashboard pages
- Update `tandemu-env.sh` to export multi-team vars, `/setup` to write `teams[]`, and `/morning`, `/standup`, `/create`, `/finish` skills for team selection

## Test plan
- [ ] Verify `GET /api/organizations/:orgId/teams/mine` returns the user's teams
- [ ] Re-run `/tandemu:setup` and confirm `~/.claude/tandemu.json` has `"teams": [...]`
- [ ] Run `/morning` with 2+ teams configured — should show team picker
- [ ] Complete a task via `/finish` and verify `team_id` appears in the ClickHouse span: `SELECT SpanAttributes['team_id'] FROM otel_traces WHERE SpanName='task_session' ORDER BY Timestamp DESC LIMIT 1`
- [ ] Select a team in the dashboard dropdown — API calls should include `?teamId=...` and metrics should scope accordingly
- [ ] Verify `tsc --noEmit` passes for both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)