### PR TITLE
feat: cleanup user memories on org member removal (SGS-92)

### DIFF
--- a/apps/backend/src/memory/memory-cleanup.listener.ts
+++ b/apps/backend/src/memory/memory-cleanup.listener.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Queue } from 'bullmq';
+
+@Injectable()
+export class MemoryCleanupListener {
+  private readonly logger = new Logger(MemoryCleanupListener.name);
+
+  constructor(
+    @InjectQueue('memory-ops') private readonly memoryOpsQueue: Queue,
+  ) {}
+
+  @OnEvent('organization.member_removed')
+  async handleMemberRemoved(payload: { organizationId: string; userId: string }): Promise<void> {
+    this.logger.log(`Enqueueing memory cleanup for user ${payload.userId} removed from org ${payload.organizationId}`);
+    await this.memoryOpsQueue.add('cleanup-user-memories', {
+      type: 'cleanup-user-memories' as const,
+      userId: payload.userId,
+      organizationId: payload.organizationId,
+    });
+  }
+}

--- a/apps/backend/src/memory/memory.module.ts
+++ b/apps/backend/src/memory/memory.module.ts
@@ -8,6 +8,7 @@ import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { TelemetryModule } from '../telemetry/telemetry.module.js';
 import { OrganizationsModule } from '../organizations/organizations.module.js';
 import { MemoryOpsProcessor } from '../queue/memory-ops.processor.js';
+import { MemoryCleanupListener } from './memory-cleanup.listener.js';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { MemoryOpsProcessor } from '../queue/memory-ops.processor.js';
     BullModule.registerQueue({ name: 'telemetry' }),
   ],
   controllers: [MemoryController],
-  providers: [MemoryService, MemoryOpsProcessor],
+  providers: [MemoryService, MemoryOpsProcessor, MemoryCleanupListener],
   exports: [MemoryService],
 })
 export class MemoryModule implements OnModuleInit {

--- a/apps/backend/src/memory/memory.service.ts
+++ b/apps/backend/src/memory/memory.service.ts
@@ -296,4 +296,58 @@ export class MemoryService {
       this.logger.warn(`Failed to delete memory ${memoryId}: ${err}`);
     }
   }
+
+  /**
+   * Fetch all memories for a user_id, using REST API with MCP fallback.
+   */
+  private async getAllMemories(userId: string): Promise<Array<Record<string, unknown>>> {
+    const memories = await this.getMemoriesRest(userId);
+    if (memories.length === 0) {
+      const mcpResult = await this.callMcpTool('get_memories', {
+        user_id: userId,
+        filters: { user_id: userId },
+      });
+      memories.push(...this.extractMcpMemories(mcpResult));
+    }
+    return memories;
+  }
+
+  /**
+   * Delete all personal memories for a user.
+   */
+  async deleteAllUserMemories(userId: string): Promise<number> {
+    const memories = await this.getAllMemories(userId);
+    let deleted = 0;
+    for (const mem of memories) {
+      await this.deleteMemory(String(mem.id));
+      deleted++;
+    }
+    return deleted;
+  }
+
+  /**
+   * Reassign org memories authored by a user to a new owner.
+   */
+  async reassignUserOrgMemories(
+    orgId: string,
+    fromUserId: string,
+    toUserId: string,
+  ): Promise<number> {
+    const memories = await this.getAllMemories(orgId);
+    let reassigned = 0;
+    for (const mem of memories) {
+      const metadata = (mem.metadata ?? {}) as Record<string, unknown>;
+      if (metadata.author_id !== fromUserId) continue;
+      try {
+        await this.callMcpTool('update_memory', {
+          memory_id: String(mem.id),
+          metadata: { author_id: toUserId },
+        });
+        reassigned++;
+      } catch (err) {
+        this.logger.warn(`Failed to reassign memory ${mem.id}: ${err}`);
+      }
+    }
+    return reassigned;
+  }
 }

--- a/apps/backend/src/organizations/organizations.controller.ts
+++ b/apps/backend/src/organizations/organizations.controller.ts
@@ -90,6 +90,20 @@ export class OrganizationsController {
     return this.organizationsService.addMember(id, dto.email, dto.role);
   }
 
+  // Owner/Admin only — remove a member
+  @Delete(':id/members/:userId')
+  @Roles(MembershipRole.OWNER, MembershipRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeMember(
+    @Param('id') id: string,
+    @Param('userId') userId: string,
+  ): Promise<void> {
+    const removed = await this.organizationsService.removeMember(id, userId);
+    if (!removed) {
+      throw new NotFoundException('Membership not found');
+    }
+  }
+
   // Any member can view the member list
   @Get(':id/members')
   async getMembers(

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -183,7 +183,7 @@ export class OrganizationsService {
     );
     const removed = (result.rowCount ?? 0) > 0;
     if (removed) {
-      this.eventEmitter.emit('organization.membership_changed', { organizationId: orgId });
+      this.eventEmitter.emit('organization.member_removed', { organizationId: orgId, userId });
     }
     return removed;
   }
@@ -260,6 +260,17 @@ export class OrganizationsService {
       ...DEFAULT_ORG_SETTINGS,
       ...org.settings,
     };
+  }
+
+  async getOwnerId(orgId: string): Promise<string> {
+    const result = await this.db.query<{ user_id: string }>(
+      `SELECT user_id FROM memberships WHERE organization_id = $1 AND role = 'owner' LIMIT 1`,
+      [orgId],
+    );
+    if (result.rows.length === 0) {
+      throw new NotFoundException('Organization owner not found');
+    }
+    return result.rows[0]!.user_id;
   }
 
   async getAllOrgIds(): Promise<string[]> {

--- a/apps/backend/src/queue/memory-ops.processor.ts
+++ b/apps/backend/src/queue/memory-ops.processor.ts
@@ -32,6 +32,9 @@ export class MemoryOpsProcessor extends WorkerHost {
       case 'clean-stale-drafts':
         await this.cleanStaleDrafts();
         break;
+      case 'cleanup-user-memories':
+        await this.cleanupUserMemories(job.data.userId, job.data.organizationId);
+        break;
     }
   }
 
@@ -108,6 +111,21 @@ export class MemoryOpsProcessor extends WorkerHost {
       throw new Error(`MCP tool call ${toolName} failed: ${res.status}`);
     }
     this.logger.debug(`MCP tool call ${toolName} completed`);
+  }
+
+  private async cleanupUserMemories(userId: string, organizationId: string): Promise<void> {
+    try {
+      const deleted = await this.memoryService.deleteAllUserMemories(userId);
+      this.logger.log(`Deleted ${deleted} personal memories for user ${userId}`);
+
+      const ownerId = await this.organizationsService.getOwnerId(organizationId);
+      const reassigned = await this.memoryService.reassignUserOrgMemories(organizationId, userId, ownerId);
+      if (reassigned > 0) {
+        this.logger.log(`Reassigned ${reassigned} org memories from user ${userId} to owner ${ownerId}`);
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to cleanup memories for user ${userId}: ${err}`);
+    }
   }
 
   private async cleanStaleDrafts(): Promise<void> {

--- a/apps/backend/src/queue/queue.types.ts
+++ b/apps/backend/src/queue/queue.types.ts
@@ -27,11 +27,18 @@ export interface CleanStaleDraftsJob {
   readonly type: 'clean-stale-drafts';
 }
 
+export interface CleanupUserMemoriesJob {
+  readonly type: 'cleanup-user-memories';
+  readonly userId: string;
+  readonly organizationId: string;
+}
+
 export type MemoryOpsJobData =
   | PromoteMemoryJob
   | DeleteMemoryUpstreamJob
   | McpToolCallJob
-  | CleanStaleDraftsJob;
+  | CleanStaleDraftsJob
+  | CleanupUserMemoriesJob;
 
 // ── telemetry queue ──
 


### PR DESCRIPTION
## Summary
- When a user is removed from an organization, their personal memories are now deleted and their org-authored memories are reassigned to the org owner
- Exposes `DELETE /organizations/:id/members/:userId` endpoint (was missing from the API)
- Uses existing BullMQ queue for async processing — no blocking on the HTTP request
- Event-driven: `organization.member_removed` event triggers cleanup via `MemoryCleanupListener`

## Changes
- `memory.service.ts` — `deleteAllUserMemories()`, `reassignUserOrgMemories()`, `getAllMemories()` helper
- `organizations.service.ts` — `getOwnerId()`, emit `member_removed` event
- `organizations.controller.ts` — `DELETE /:id/members/:userId` endpoint
- `queue.types.ts` — `CleanupUserMemoriesJob` type
- `memory-ops.processor.ts` — `cleanup-user-memories` job handler
- `memory-cleanup.listener.ts` (new) — Event listener
- `memory.module.ts` — Register listener

## Test plan
- [ ] Remove a member via the new endpoint, verify personal memories are deleted
- [ ] Verify org memories authored by the removed user are reassigned to org owner (not deleted)
- [ ] Verify published org memories remain intact
- [ ] Check BullMQ job logs for successful processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)