### PR TITLE
feat: extract mechanical skill logic to backend endpoints (SGS-117)

### DIFF
--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -6,9 +6,11 @@ import { TasksService } from './tasks.service.js';
 import { GitHubGitService } from './providers/github-git.service.js';
 import { AuthModule } from '../auth/auth.module.js';
 import { TeamsModule } from '../teams/teams.module.js';
+import { forwardRef } from '@nestjs/common';
+import { TelemetryModule } from '../telemetry/telemetry.module.js';
 
 @Module({
-  imports: [AuthModule, TeamsModule],
+  imports: [AuthModule, TeamsModule, forwardRef(() => TelemetryModule)],
   controllers: [IntegrationsController, TasksController],
   providers: [IntegrationsService, TasksService, GitHubGitService],
   exports: [IntegrationsService, TasksService, GitHubGitService],

--- a/apps/backend/src/integrations/task-category.ts
+++ b/apps/backend/src/integrations/task-category.ts
@@ -1,0 +1,18 @@
+import type { TaskCategory } from '@tandemu/types';
+
+const CATEGORY_RULES: Array<{ keywords: string[]; category: TaskCategory }> = [
+  { keywords: ['bug', 'fix', 'hotfix'], category: 'bugfix' },
+  { keywords: ['feature', 'enhancement'], category: 'feature' },
+  { keywords: ['debt', 'refactor', 'chore'], category: 'tech_debt' },
+  { keywords: ['maintenance', 'ops', 'infra'], category: 'maintenance' },
+];
+
+export function inferCategory(labels: string[]): TaskCategory {
+  const normalized = labels.map((l) => l.toLowerCase());
+  for (const rule of CATEGORY_RULES) {
+    if (normalized.some((label) => rule.keywords.some((kw) => label.includes(kw)))) {
+      return rule.category;
+    }
+  }
+  return 'other';
+}

--- a/apps/backend/src/integrations/tasks.controller.ts
+++ b/apps/backend/src/integrations/tasks.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Logger,
   Param,
   Patch,
   Post,
@@ -13,11 +14,13 @@ import {
 import { TasksService } from './tasks.service.js';
 import { TeamsService } from '../teams/teams.service.js';
 import { AuthService } from '../auth/auth.service.js';
+import { TelemetryService } from '../telemetry/telemetry.service.js';
 import { JwtAuthGuard } from '../auth/auth.guard.js';
 import { OrgRequiredGuard } from '../auth/org-required.guard.js';
 import { CurrentUser } from '../auth/auth.decorator.js';
 import type { RequestUser } from '../auth/auth.decorator.js';
-import type { Task, TaskStatus, TaskPriority, IntegrationProvider } from '@tandemu/types';
+import type { Task, TaskStatus, TaskPriority, IntegrationProvider, StandupResponse, StandupMember, StandupBlocker } from '@tandemu/types';
+import { inferCategory } from './task-category.js';
 
 const PRIORITY_WEIGHT: Record<TaskPriority, number> = {
   urgent: 0,
@@ -30,10 +33,13 @@ const PRIORITY_WEIGHT: Record<TaskPriority, number> = {
 @Controller('tasks')
 @UseGuards(JwtAuthGuard, OrgRequiredGuard)
 export class TasksController {
+  private readonly logger = new Logger(TasksController.name);
+
   constructor(
     private readonly tasksService: TasksService,
     private readonly teamsService: TeamsService,
     private readonly authService: AuthService,
+    private readonly telemetryService: TelemetryService,
   ) {}
 
   @Get()
@@ -47,6 +53,7 @@ export class TasksController {
     @Query('sort') sort?: 'priority' | 'updatedAt',
     @Query('order') order?: 'asc' | 'desc',
     @Query('excludeDone') excludeDone?: string,
+    @Query('fallbackUnassigned') fallbackUnassigned?: string,
   ): Promise<Task[]> {
     // When fetching "my" tasks, use all email aliases for matching
     let assigneeEmails: string[] | undefined;
@@ -54,13 +61,37 @@ export class TasksController {
       assigneeEmails = await this.authService.getAllEmailAddresses(user.userId);
     }
 
-    const tasks = await this.tasksService.getTasks(user.organizationId, {
-      teamId,
-      assigneeEmail: mine === 'true' ? user.email : undefined,
-      assigneeEmails,
-      sprint: sprint ?? 'current',
-      excludeDone: excludeDone === 'true',
-    });
+    // Resolve team IDs — supports "all" or comma-separated
+    const teamIds = await this.resolveTeamIds(teamId, user);
+
+    // Fetch tasks (multi-team with dedup if needed)
+    let tasks: Task[];
+    if (teamIds.length > 1) {
+      const allResults = await Promise.all(
+        teamIds.map((tid) =>
+          this.tasksService.getTasks(user.organizationId, {
+            teamId: tid,
+            assigneeEmail: mine === 'true' ? user.email : undefined,
+            assigneeEmails,
+            sprint: sprint ?? 'current',
+            excludeDone: excludeDone === 'true',
+          }),
+        ),
+      );
+      const deduped = new Map<string, Task>();
+      for (const batch of allResults) {
+        for (const t of batch) deduped.set(t.id, t);
+      }
+      tasks = [...deduped.values()];
+    } else {
+      tasks = await this.tasksService.getTasks(user.organizationId, {
+        teamId: teamIds[0],
+        assigneeEmail: mine === 'true' ? user.email : undefined,
+        assigneeEmails,
+        sprint: sprint ?? 'current',
+        excludeDone: excludeDone === 'true',
+      });
+    }
 
     let filtered = tasks;
 
@@ -72,9 +103,9 @@ export class TasksController {
       filtered = filtered.filter((t) => !t.assigneeEmail);
     }
 
-    // Apply done window filter when teamId is set and excludeDone is not explicitly set
-    if (teamId && excludeDone !== 'true') {
-      const settings = await this.teamsService.getSettings(teamId);
+    // Apply done window filter when a single teamId is set and excludeDone is not explicitly set
+    if (teamIds.length === 1 && teamIds[0] && excludeDone !== 'true') {
+      const settings = await this.teamsService.getSettings(teamIds[0]);
       const windowMs = settings.doneWindowDays * 86400_000;
       const cutoff = new Date(Date.now() - windowMs);
 
@@ -86,6 +117,17 @@ export class TasksController {
       });
     }
 
+    // Fallback: if mine=true returned nothing and fallbackUnassigned is requested
+    if (mine === 'true' && fallbackUnassigned === 'true' && filtered.length === 0) {
+      const fallbackTasks = teamIds.length > 1
+        ? await this.fetchMultiTeamTasks(user.organizationId, teamIds, sprint)
+        : await this.tasksService.getTasks(user.organizationId, {
+            teamId: teamIds[0],
+            sprint: sprint ?? 'current',
+          });
+      filtered = fallbackTasks.filter((t) => !t.assigneeEmail && t.status === 'todo');
+    }
+
     // Sort
     const sortField = sort ?? 'priority';
     const sortOrder = order ?? 'desc';
@@ -93,8 +135,6 @@ export class TasksController {
     filtered.sort((a, b) => {
       let cmp: number;
       if (sortField === 'priority') {
-        // Lower weight = higher priority (urgent=0, none=4)
-        // "desc" should mean highest priority first, so keep natural order
         cmp = PRIORITY_WEIGHT[a.priority] - PRIORITY_WEIGHT[b.priority];
         return sortOrder === 'desc' ? cmp : -cmp;
       } else {
@@ -103,8 +143,199 @@ export class TasksController {
       }
     });
 
-    return filtered;
+    // Enrich with category
+    return filtered.map((t) => ({ ...t, category: inferCategory(t.labels) }));
   }
+
+  // ── Standup ── (must be before :taskId routes)
+
+  @Get('standup')
+  async getStandup(
+    @CurrentUser() user: RequestUser,
+    @Query('teamId') teamId: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ): Promise<StandupResponse> {
+    const orgId = user.organizationId;
+
+    // Fetch all data in parallel
+    const [teamInfo, members, tasks, devStats, friction] = await Promise.all([
+      this.teamsService.findOne(teamId),
+      this.teamsService.getMembers(teamId),
+      this.tasksService.getTasks(orgId, { teamId }),
+      this.telemetryService.getDeveloperStats(orgId, startDate, endDate, teamId),
+      this.telemetryService.getFrictionHeatmap(orgId, startDate, endDate, teamId),
+    ]);
+
+    // Build email → member lookup
+    const emailToMember = new Map<string, (typeof members)[0]>();
+    for (const m of members) {
+      for (const email of m.emails) {
+        emailToMember.set(email.toLowerCase(), m);
+      }
+    }
+
+    // Categorize tasks
+    const sevenDaysAgo = new Date(Date.now() - 7 * 86400_000);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400_000);
+
+    const memberTasks = new Map<string, { inProgress: Task[]; inReview: Task[]; recentlyDone: Task[] }>();
+    for (const m of members) {
+      memberTasks.set(m.id, { inProgress: [], inReview: [], recentlyDone: [] });
+    }
+
+    const otherMap = new Map<string, { assigneeName?: string; assigneeEmail?: string; tasks: Task[] }>();
+    const unassigned: Task[] = [];
+    const todoTasks: Task[] = [];
+    const stalledReviews: StandupBlocker[] = [];
+
+    for (const task of tasks) {
+      const enriched = { ...task, category: inferCategory(task.labels) };
+
+      if (!task.assigneeEmail) {
+        if (task.status === 'todo') todoTasks.push(enriched);
+        else unassigned.push(enriched);
+        continue;
+      }
+
+      const member = emailToMember.get(task.assigneeEmail.toLowerCase());
+      if (!member) {
+        // Other contributor
+        const key = task.assigneeEmail.toLowerCase();
+        const existing = otherMap.get(key);
+        if (existing) {
+          existing.tasks.push(enriched);
+        } else {
+          otherMap.set(key, { assigneeName: task.assigneeName, assigneeEmail: task.assigneeEmail, tasks: [enriched] });
+        }
+        continue;
+      }
+
+      const bucket = memberTasks.get(member.id)!;
+      switch (task.status) {
+        case 'in_progress':
+          bucket.inProgress.push(enriched);
+          break;
+        case 'in_review':
+          bucket.inReview.push(enriched);
+          if (new Date(task.updatedAt) < twoDaysAgo) {
+            stalledReviews.push({
+              type: 'stalled_review',
+              taskId: task.id,
+              title: task.title,
+              stalledDays: Math.floor((Date.now() - new Date(task.updatedAt).getTime()) / 86400_000),
+            });
+          }
+          break;
+        case 'done':
+          if (new Date(task.updatedAt) >= sevenDaysAgo) {
+            bucket.recentlyDone.push(enriched);
+          }
+          break;
+        case 'todo':
+          todoTasks.push(enriched);
+          break;
+      }
+    }
+
+    // Build dev stats lookup
+    const devStatsMap = new Map<string, (typeof devStats)[0]>();
+    for (const ds of devStats) {
+      devStatsMap.set(ds.userId, ds);
+    }
+
+    // Build friction per member
+    const frictionByUser = new Map<string, Map<string, number>>();
+    const frictionByFile = new Map<string, Set<string>>();
+    for (const f of friction) {
+      if (!f.userId) continue;
+      if (!frictionByUser.has(f.userId)) frictionByUser.set(f.userId, new Map());
+      const userFriction = frictionByUser.get(f.userId)!;
+      userFriction.set(f.repositoryPath, (userFriction.get(f.repositoryPath) ?? 0) + f.promptLoopCount + f.errorCount);
+
+      if (!frictionByFile.has(f.repositoryPath)) frictionByFile.set(f.repositoryPath, new Set());
+      frictionByFile.get(f.repositoryPath)!.add(f.userId);
+    }
+
+    // High-friction blockers (files affecting ≥2 devs)
+    const frictionBlockers: StandupBlocker[] = [];
+    for (const [filePath, devSet] of frictionByFile) {
+      if (devSet.size >= 2) {
+        let totalCount = 0;
+        for (const f of friction) {
+          if (f.repositoryPath === filePath) totalCount += f.promptLoopCount + f.errorCount;
+        }
+        frictionBlockers.push({
+          type: 'high_friction',
+          filePath,
+          frictionCount: totalCount,
+          affectedDevs: devSet.size,
+        });
+      }
+    }
+
+    // Assemble members (only include those with tasks or telemetry)
+    const standupMembers: StandupMember[] = [];
+    for (const m of members) {
+      const tasks = memberTasks.get(m.id)!;
+      const ds = devStatsMap.get(m.id);
+      const userFriction = frictionByUser.get(m.id);
+
+      const hasTasks = tasks.inProgress.length > 0 || tasks.inReview.length > 0 || tasks.recentlyDone.length > 0;
+      const hasTelemetry = ds && (ds.sessions > 0 || ds.activeMinutes > 0);
+
+      if (!hasTasks && !hasTelemetry) continue;
+
+      const frictionFiles: Array<{ path: string; count: number }> = [];
+      if (userFriction) {
+        for (const [path, count] of userFriction) {
+          frictionFiles.push({ path, count });
+        }
+        frictionFiles.sort((a, b) => b.count - a.count);
+      }
+
+      standupMembers.push({
+        id: m.id,
+        name: m.name,
+        email: m.email,
+        tasks,
+        telemetry: {
+          activeMinutes: ds ? Math.round(ds.activeMinutes) : 0,
+          sessions: ds?.sessions ?? 0,
+          aiLines: ds ? Math.round(ds.aiLines) : 0,
+          manualLines: ds ? Math.round(ds.manualLines) : 0,
+          frictionFiles,
+        },
+      });
+    }
+
+    // Summary
+    let inProgressCount = 0;
+    let inReviewCount = 0;
+    let doneThisWeekCount = 0;
+    for (const mt of memberTasks.values()) {
+      inProgressCount += mt.inProgress.length;
+      inReviewCount += mt.inReview.length;
+      doneThisWeekCount += mt.recentlyDone.length;
+    }
+
+    return {
+      team: { id: teamInfo.id, name: teamInfo.name, memberCount: members.length },
+      summary: {
+        inProgress: inProgressCount,
+        inReview: inReviewCount,
+        doneThisWeek: doneThisWeekCount,
+        todoCount: todoTasks.length,
+      },
+      members: standupMembers,
+      otherContributors: [...otherMap.values()],
+      unassigned,
+      backlog: { tasks: todoTasks.slice(0, 10), totalCount: todoTasks.length },
+      blockers: [...stalledReviews, ...frictionBlockers],
+    };
+  }
+
+  // ── Parameterized routes ──
 
   @Get(':taskId/statuses')
   async getStatuses(
@@ -149,5 +380,30 @@ export class TasksController {
     },
   ): Promise<Task> {
     return this.tasksService.createTask(user.organizationId, body);
+  }
+
+  // ── Helpers ──
+
+  private async resolveTeamIds(teamId: string | undefined, user: RequestUser): Promise<string[]> {
+    if (!teamId) return [];
+    if (teamId === 'all') {
+      const teams = await this.teamsService.findByUserId(user.organizationId, user.userId);
+      return teams.map((t) => t.id);
+    }
+    if (teamId.includes(',')) {
+      return teamId.split(',').map((id) => id.trim());
+    }
+    return [teamId];
+  }
+
+  private async fetchMultiTeamTasks(orgId: string, teamIds: string[], sprint?: string): Promise<Task[]> {
+    const allResults = await Promise.all(
+      teamIds.map((tid) => this.tasksService.getTasks(orgId, { teamId: tid, sprint: sprint ?? 'current' })),
+    );
+    const deduped = new Map<string, Task>();
+    for (const batch of allResults) {
+      for (const t of batch) deduped.set(t.id, t);
+    }
+    return [...deduped.values()];
   }
 }

--- a/apps/claude-plugins/.claude-plugin/plugin.json
+++ b/apps/claude-plugins/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandemu",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "AI Teammate — task lifecycle, telemetry, and persistent memory for AI-native development",
   "author": {
     "name": "Tandemu",

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -138,38 +138,21 @@ Set `SELECTED_TEAM_ID` from the choice. If "All teams" is selected, set `SELECTE
 
 **If `TEAM_COUNT` = 1 or 0**: use `$TANDEMU_TEAM_ID` directly. No prompt.
 
-Fetch tasks assigned to the current developer:
+Fetch tasks assigned to the current developer in a single call. The API handles multi-team dedup and unassigned fallback server-side:
 
-If `SELECTED_TEAM_ID=ALL`, fetch tasks from each team, merge, and deduplicate by task ID:
 ```bash
-# For each team ID in TANDEMU_TEAM_IDS (comma-separated), fetch and merge
-IFS=',' read -ra TEAM_IDS_ARRAY <<< "$TANDEMU_TEAM_IDS"
-for TID in "${TEAM_IDS_ARRAY[@]}"; do
-  curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$TID&mine=true&sort=priority&order=desc"
-done
-# Merge results in Python, deduplicate by task id
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&mine=true&fallbackUnassigned=true&sort=priority&order=desc"
 ```
 
-Otherwise:
-```bash
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&mine=true&sort=priority&order=desc"
-```
+Use `teamId=all` when "All teams" is selected — the backend fetches from all teams and deduplicates.
 
-The response is `{ success, data: Task[] }` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`. **The API returns tasks already sorted by priority (urgent first).** Do not re-sort — use the response order as-is.
+The response is a `Task[]` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`, `category`. **The API returns tasks already sorted by priority (urgent first).** Do not re-sort — use the response order as-is.
 
 Filter to tasks that are `todo` or `in_progress` status.
 
-If the developer has assigned tasks, proceed to Step 4 with those.
+If the result set looks like unassigned backlog tasks (no `assigneeEmail` on any), tell the developer: "No tasks are assigned to you. Here are unassigned tasks you could pick up:"
 
-If no tasks are assigned to the developer, fetch **unassigned todo tasks** (using the same `SELECTED_TEAM_ID` or all-teams logic):
-
-```bash
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&status=todo&unassigned=true&sort=priority&order=desc"
-```
-
-Tell the developer: "No tasks are assigned to you. Here are unassigned tasks you could pick up:"
-
-If both calls return empty, tell the developer: "No tasks found. Your team may not have a ticket system connected yet — ask your admin to set one up at the Tandemu dashboard (Integrations page)."
+If the response is empty, tell the developer: "No tasks found. Your team may not have a ticket system connected yet — ask your admin to set one up at the Tandemu dashboard (Integrations page)."
 
 ### 4. Let the developer pick a task
 
@@ -240,12 +223,7 @@ git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" "origin/$DEFAULT_BRANCH"
 cd "$WORKTREE_DIR"
 ```
 
-- Write the branch-keyed active task file. Infer the task category from labels:
-  - Labels containing "bug", "fix", "hotfix" → `bugfix`
-  - Labels containing "feature", "enhancement" → `feature`
-  - Labels containing "debt", "refactor", "chore" → `tech_debt`
-  - Labels containing "maintenance", "ops", "infra" → `maintenance`
-  - Default → `other`
+- Write the branch-keyed active task file. Use the `category` field from the API response (the backend infers it from labels).
 
 ```bash
 BRANCH_SLUG=$(echo "$BRANCH_NAME" | sed 's/\//-/g')
@@ -260,7 +238,7 @@ cat > "$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json" << EOF
   "repos": ["$REPO_PATH"],
   "provider": "<task.provider>",
   "url": "<task.url>",
-  "category": "<inferred category>",
+  "category": "<task.category from API response>",
   "labels": [<task.labels as JSON array>],
   "worktree": "$WORKTREE_DIR"
 }

--- a/apps/claude-plugins/skills/standup/SKILL.md
+++ b/apps/claude-plugins/skills/standup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standup
-description: Generate a team standup report. Pulls task progress from the connected ticket system via Tandemu API, combines with telemetry data (session time, AI ratio, friction), and produces a team-level summary.
+description: Generate a team standup report. Pulls pre-computed standup data from the Tandemu API (task attribution, telemetry, blockers) and formats it as a team-level summary.
 argument-hint: [--team <team-name>] [--format <slack|markdown|plain>]
 allowed-tools:
   - Bash
@@ -10,132 +10,112 @@ allowed-tools:
 
 Generate a team standup report. Options: $ARGUMENTS
 
-**Execution style:** Minimize tool call noise. Load config and fetch all API data in a single Bash call ("Fetch team data"). Keep the formatted report output as a separate step.
+**Execution style:** Minimize tool call noise. Load config and fetch standup data in a single Bash call ("Fetch standup data"). Keep the formatted report output as a separate step.
 
 ## Steps
 
-### 1. Fetch team data
+### 1. Fetch standup data
 
-Load config and fetch all data in a **single Bash call** ("Fetch team data"):
+Load config and fetch all pre-computed standup data in a **single Bash call** ("Fetch standup data"):
 
 ```bash
 # Load Tandemu config
 source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
 # Multi-team support: resolve --team argument or prompt if multiple teams
-# Parse --team from arguments
 ACTIVE_TEAM_ID="$TANDEMU_TEAM_ID"
-ACTIVE_TEAM_NAME=""
 echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
 echo "TEAM_IDS=$TANDEMU_TEAM_IDS"
 echo "TEAM_NAMES=$TANDEMU_TEAM_NAMES"
 
 # If --team is specified, resolve name to ID
-# The Claude agent will parse the argument and do the lookup from TANDEMU_TEAM_NAMES/IDS
 # If TEAM_COUNT > 1 and no --team flag, Claude should use AskUserQuestion to prompt
 
-# Use local time (not UTC) so date boundaries match the developer's day
+# Use local time so date boundaries match the developer's day
 YESTERDAY=$(date -v-1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -d "yesterday" +%Y-%m-%dT00:00:00Z)
 NOW=$(date +%Y-%m-%dT23:59:59Z)
 
-# Local time context for accurate relative dates
 echo "---LOCAL_TIME---"
-echo "TZ=$(date +%Z)"
-echo "OFFSET=$(date +%z)"
 echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
 echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
-echo "LOCAL_YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)"
 
-echo "---MEMBERS---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/organizations/$TANDEMU_ORG_ID/teams/$ACTIVE_TEAM_ID/members"
-
-echo "---TASKS---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$ACTIVE_TEAM_ID"
-
-echo "---TIMESHEETS---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/timesheets?startDate=$YESTERDAY&endDate=$NOW"
-
-echo "---AI_RATIO---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/ai-ratio"
-
-echo "---FRICTION---"
-curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/telemetry/friction-heatmap"
+echo "---STANDUP---"
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/standup?teamId=$ACTIVE_TEAM_ID&startDate=$YESTERDAY&endDate=$NOW"
 ```
 
 If the config load fails, tell the developer: "Tandemu is not configured. Run install.sh to set it up."
 
-### 2. Compile the team standup
+The standup endpoint returns pre-computed data with task attribution, telemetry, and blockers already resolved:
 
-**IMPORTANT attribution rules:**
+```typescript
+{
+  team: { id, name, memberCount },
+  summary: { inProgress, inReview, doneThisWeek, todoCount },
+  members: [{
+    id, name, email,
+    tasks: { inProgress: Task[], inReview: Task[], recentlyDone: Task[] },
+    telemetry: { activeMinutes, sessions, aiLines, manualLines, frictionFiles: [{ path, count }] },
+  }],
+  otherContributors: [{ assigneeName?, assigneeEmail?, tasks: Task[] }],
+  unassigned: Task[],
+  backlog: { tasks: Task[], totalCount: number },
+  blockers: [{ type, taskId?, title?, stalledDays?, filePath?, frictionCount?, affectedDevs? }],
+}
+```
 
-- Each task has an `assigneeEmail` field from the ticket system.
-- Each Tandemu team member has an `email` field and an `emails` array (which includes their primary email plus any aliases).
-- Match tasks to team members by checking if `task.assigneeEmail` is in `member.emails`.
-- Only show a task under a person if their `emails` array contains the task's `assigneeEmail`.
-- Tasks where `assigneeEmail` doesn't match any team member go in an "Other contributors" section (they may be assigned to people not in Tandemu yet).
-- Unassigned tasks (no `assigneeEmail`) go in the "Unassigned" section.
+### 2. Format the standup report
 
-**Task categorization (by recency, NOT by sprint):**
-
-- **Recently completed**: tasks with `status: done` AND `updatedAt` within the last 7 days.
-- **In progress**: tasks with `status: in_progress`.
-- **In review**: tasks with `status: in_review`.
-- **Todo**: tasks with `status: todo`. Show at most 10, and mention how many more exist.
-- Do NOT use the word "sprint" in the report. Use "this week" or "recently" instead.
-- Ignore tasks with `status: done` that were completed more than 7 days ago — they are not relevant to a standup.
-- **Timezone handling**: When categorizing tasks as "done today", "done yesterday", or "done this week", convert `updatedAt` timestamps to the developer's local timezone (using LOCAL_TODAY, LOCAL_YESTERDAY, and OFFSET from setup) before comparing dates. Do not compare raw UTC timestamps against local day boundaries.
+Use the pre-computed data to produce the report. Do NOT re-filter or re-attribute tasks — the backend has already done this correctly.
 
 **Report structure:**
 
 ```markdown
 ## Team Standup — <date>
-**Team**: <team name> | **Members**: <count>
+**Team**: <team.name> | **Members**: <team.memberCount>
 
 ### Summary
-- **In progress**: <count> | **In review**: <count> | **Done this week**: <count>
-- **Active sessions**: <N> members coded in the last 24h (<total hours>h)
-- **AI-assisted**: <ai_lines> AI lines / <manual_lines> manual lines
-- **Friction hotspots**: <top file paths with high prompt loops, or "None detected">
+- **In progress**: <summary.inProgress> | **In review**: <summary.inReview> | **Done this week**: <summary.doneThisWeek>
+- **Active sessions**: <count members with sessions > 0> members coded recently (<sum activeMinutes / 60>h)
+- **AI-assisted**: <sum aiLines> AI lines / <sum manualLines> manual lines
+- **Friction hotspots**: <top friction files across members, or "None detected">
 
 ### Per-Person Updates
 
-Only include team members who have tasks assigned to them OR telemetry activity.
+Only show members from the `members` array (backend already filtered to those with tasks or telemetry).
 
-**<Name>** (<email>) — <hours>h active
+**<name>** (<email>) — <activeMinutes / 60>h active
 - Working on:
   - [<task.id>] <title> (<priority>)
 - Recently completed:
   - [<task.id>] <title>
-- Friction: <files with prompt loops for this user, or omit if none>
+- Friction: <frictionFiles paths and counts, or omit if empty>
 
 ### Other Contributors
 
-Tasks assigned to people not on this Tandemu team:
+Tasks assigned to people not on this Tandemu team (from `otherContributors`):
 
 - [<task.id>] <title> — assigned to <assigneeName> (<assigneeEmail>)
 
 ### Backlog
 
-<count> tasks in backlog. Top items:
+<backlog.totalCount> tasks in backlog. Top items:
 - [<task.id>] <title> (<priority>)
-- ... (show up to 10, then "and <N> more")
+- ... (backlog.tasks has max 10; if totalCount > 10, say "and <N> more")
 
 ### Blockers
-- <tasks in_review for more than 2 days>
-- <high-friction files affecting multiple developers>
-- If no blockers detected, say "No blockers detected."
+- For `stalled_review` type: "[<taskId>] <title> in review for <stalledDays> days"
+- For `high_friction` type: "<filePath>: <frictionCount> friction events affecting <affectedDevs> developers"
+- If blockers array is empty: "No blockers detected."
 ```
 
 ### 3. Format output
 
-Default: markdown. If `--format slack`, use Slack bold markers. If `--format plain`, plain text.
+Default: markdown. If `--format slack`, use Slack bold markers (`*bold*`). If `--format plain`, plain text without markdown.
 
 ### Notes
 
-- Task data comes from the Tandemu API (proxied from the connected ticket system) — always live, never cached
-- Telemetry data (session time, AI ratio, friction) comes from ClickHouse via the Tandemu API
-- If no ticket system is connected, show telemetry-only data and note that tasks are unavailable
-- If no telemetry data exists, show task-only data
+- All task attribution, categorization, and telemetry matching is done server-side by `GET /api/tasks/standup`
+- The skill only formats the response — it does not filter, deduplicate, or match tasks to members
+- Do not mention sprints, cycles, or iteration boundaries — use "this week" or "recently" instead
 - Respect privacy — show work output, not surveillance metrics
-- NEVER attribute a task to someone unless their `emails` array contains the task's assigneeEmail
-- Do not mention sprints, cycles, or iteration boundaries — use time-based recency instead
+- If the standup endpoint fails, tell the developer and suggest checking if the ticket system is connected

--- a/packages/types/src/integrations.ts
+++ b/packages/types/src/integrations.ts
@@ -36,10 +36,12 @@ export interface Task {
   readonly provider: IntegrationProvider;
   readonly externalProjectId: string;
   readonly updatedAt: string;
+  readonly category?: TaskCategory;
 }
 
 export type TaskStatus = 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled';
 export type TaskPriority = 'urgent' | 'high' | 'medium' | 'low' | 'none';
+export type TaskCategory = 'bugfix' | 'feature' | 'tech_debt' | 'maintenance' | 'other';
 
 export interface CreateIntegrationDto {
   readonly provider: IntegrationProvider;
@@ -54,4 +56,53 @@ export interface CreateProjectMappingDto {
   readonly externalProjectId: string;
   readonly externalProjectName?: string;
   readonly config?: Record<string, unknown>;
+}
+
+// ── Standup ──
+
+export interface StandupResponse {
+  readonly team: { id: string; name: string; memberCount: number };
+  readonly summary: {
+    inProgress: number;
+    inReview: number;
+    doneThisWeek: number;
+    todoCount: number;
+  };
+  readonly members: StandupMember[];
+  readonly otherContributors: Array<{
+    assigneeName?: string;
+    assigneeEmail?: string;
+    tasks: Task[];
+  }>;
+  readonly unassigned: Task[];
+  readonly backlog: { tasks: Task[]; totalCount: number };
+  readonly blockers: StandupBlocker[];
+}
+
+export interface StandupMember {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly tasks: {
+    inProgress: Task[];
+    inReview: Task[];
+    recentlyDone: Task[];
+  };
+  readonly telemetry: {
+    activeMinutes: number;
+    sessions: number;
+    aiLines: number;
+    manualLines: number;
+    frictionFiles: Array<{ path: string; count: number }>;
+  };
+}
+
+export interface StandupBlocker {
+  readonly type: 'stalled_review' | 'high_friction';
+  readonly taskId?: string;
+  readonly title?: string;
+  readonly stalledDays?: number;
+  readonly filePath?: string;
+  readonly frictionCount?: number;
+  readonly affectedDevs?: number;
 }


### PR DESCRIPTION
## Summary
- **Enhanced `GET /api/tasks`**: supports `teamId=all` for multi-team dedup, `fallbackUnassigned=true` for automatic unassigned fallback, and returns computed `category` field from labels
- **New `GET /api/tasks/standup`** endpoint: returns pre-computed standup data (task attribution by email matching, telemetry per member, blocker detection) in a single call — replaces 5 separate API calls + all client-side business logic
- **Simplified `/morning` skill**: single API call replaces multi-team fetch loop + unassigned fallback + category inference
- **Simplified `/standup` skill**: single API call replaces 5 curl calls + attribution/categorization/blocker logic. Skill now only formats the response.

## What stays in Claude (intelligent decisions)
- Status selection (picking "In Progress" from dynamic status lists)
- Memory search/store decisions
- Branch name generation
- Report formatting and natural language

## What moved to backend (mechanical processing)
- Multi-team task dedup
- Unassigned task fallback
- Label → category inference
- Email-based task attribution
- Task recency filtering (done within 7 days)
- Blocker detection (stalled reviews, cross-dev friction)

## Test plan
- [ ] `GET /api/tasks?teamId=all&mine=true` — verify dedup across teams
- [ ] `GET /api/tasks?teamId=X&mine=true&fallbackUnassigned=true` — verify fallback when no assigned tasks
- [ ] Verify `category` field on task responses
- [ ] `GET /api/tasks/standup?teamId=X` — verify full standup data with correct attribution
- [ ] Run `/morning` and `/standup` skills end-to-end
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)