### PR TITLE
feat: AI adoption leaderboard on insights page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ The `GET /api/telemetry/friction-heatmap` endpoint combines both.
 - Store observations after `/finish` (coding patterns, decisions, corrections)
 
 ### Dashboard pages
-- **Dashboard** (`/`) — KPI cards (sessions, AI ratio, lines, cycle time, tool success), activity chart, AI ratio donut, tool usage bar, developer leaderboard, velocity chart, hot files, investment allocation, AI effectiveness, cost metrics
-- **Activity** (`/activity`) — Stats cards, activity chart (taller), session log table with developer names
+- **Dashboard** (`/`) — KPI cards (sessions, AI ratio, lines, cycle time, tool success), AI ratio donut, tool usage bar, velocity chart, investment allocation
+- **Activity** (`/activity`) — Stats cards, activity chart (taller), AI adoption leaderboard, hot files, AI effectiveness, session log table
+- **Insights** (`/insights`) — Productivity multiplier, capacity freed, cost per task, throughput chart, cost efficiency chart, token usage, Tandemu impact KPIs, AI adoption leaderboard (per-developer ranked by AI%)
 - **Friction Map** (`/friction-map`) — Severity cards, file-level friction list
 - **AI Memory** (`/memory`) — Memory dashboard with 4 self-loading sections (see below)
 - All pages have team + time range filters via URL params (`?range=30d&team=...`)

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Zap, Clock, DollarSign, Brain, TrendingDown, Share2, Info, Settings } from 'lucide-react';
-import { getInsightsMetrics, getMemoryStats, getTokenUsage } from '@/lib/api';
-import type { InsightsMetrics, TokenUsageEntry } from '@/lib/api';
+import { getInsightsMetrics, getMemoryStats, getTokenUsage, getDeveloperStats } from '@/lib/api';
+import type { InsightsMetrics, TokenUsageEntry, DeveloperStat } from '@/lib/api';
+import { DeveloperLeaderboard } from '@/components/charts/developer-leaderboard';
 import { TelemetryFilters, useFilterParams } from '@/components/filters/telemetry-filters';
 import { ThroughputChart, CostEfficiencyChart } from '@/components/charts/insights-chart';
 import { TokenUsageChart } from '@/components/charts/token-usage-chart';
@@ -25,6 +26,7 @@ export default function InsightsPage() {
   const [data, setData] = useState<InsightsMetrics | null>(null);
   const [orgMemoryCount, setOrgMemoryCount] = useState(0);
   const [tokenData, setTokenData] = useState<TokenUsageEntry[]>([]);
+  const [devStats, setDevStats] = useState<DeveloperStat[]>([]);
   const [loading, setLoading] = useState(true);
   const { startDate, endDate, teamId } = useFilterParams();
 
@@ -34,15 +36,17 @@ export default function InsightsPage() {
       setLoading(true);
       try {
         const f = { startDate, endDate, teamId };
-        const [insights, memStats, tokens] = await Promise.allSettled([
+        const [insights, memStats, tokens, devs] = await Promise.allSettled([
           getInsightsMetrics(f),
           getMemoryStats(),
           getTokenUsage(f),
+          getDeveloperStats(f),
         ]);
         if (cancelled) return;
         if (insights.status === 'fulfilled') setData(insights.value);
         if (memStats.status === 'fulfilled') setOrgMemoryCount(memStats.value.org);
         if (tokens.status === 'fulfilled') setTokenData(tokens.value);
+        if (devs.status === 'fulfilled') setDevStats(devs.value);
       } catch {
         // Non-critical
       } finally {
@@ -253,6 +257,15 @@ export default function InsightsPage() {
                 </CardContent>
               </Card>
             </div>
+          </div>
+
+          {/* Section 3: AI Adoption */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight">AI Adoption</h2>
+            <p className="text-sm text-muted-foreground">
+              Per-developer AI usage — who&apos;s leveraging AI and who could benefit from more adoption.
+            </p>
+            <DeveloperLeaderboard data={devStats} />
           </div>
         </>
       )}

--- a/apps/frontend/src/components/charts/developer-leaderboard.tsx
+++ b/apps/frontend/src/components/charts/developer-leaderboard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import type { DeveloperStat } from '@/lib/api';
 
 interface DeveloperLeaderboardProps {
@@ -17,15 +18,28 @@ function formatDuration(minutes: number): string {
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
+function getAdoptionTier(aiPct: number) {
+  if (aiPct >= 70) return { label: 'Champion', color: '#4ade80', textClass: 'text-emerald-400', badgeClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30' };
+  if (aiPct >= 25) return { label: 'Growing', color: '#facc15', textClass: 'text-yellow-400', badgeClass: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30' };
+  return { label: 'Getting Started', color: '#71717a', textClass: 'text-muted-foreground', badgeClass: 'bg-muted text-muted-foreground border-border' };
+}
+
 export function DeveloperLeaderboard({ data }: DeveloperLeaderboardProps) {
-  const sorted = [...data].sort((a, b) => b.sessions - a.sessions);
+  const sorted = [...data].sort((a, b) => {
+    const totalA = a.aiLines + a.manualLines;
+    const totalB = b.aiLines + b.manualLines;
+    const pctA = totalA > 0 ? a.aiLines / totalA : 0;
+    const pctB = totalB > 0 ? b.aiLines / totalB : 0;
+    if (pctB !== pctA) return pctB - pctA;
+    return totalB - totalA;
+  });
 
   if (sorted.length === 0) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Developer Activity</CardTitle>
-          <CardDescription>Per-developer session and code metrics</CardDescription>
+          <CardTitle>AI Adoption Leaderboard</CardTitle>
+          <CardDescription>Developer AI usage ranked by adoption rate</CardDescription>
         </CardHeader>
         <CardContent className="flex items-center justify-center py-12">
           <p className="text-sm text-muted-foreground">No developer data yet</p>
@@ -37,36 +51,41 @@ export function DeveloperLeaderboard({ data }: DeveloperLeaderboardProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Developer Activity</CardTitle>
-        <CardDescription>Per-developer session and code metrics</CardDescription>
+        <CardTitle>AI Adoption Leaderboard</CardTitle>
+        <CardDescription>Developer AI usage ranked by adoption rate</CardDescription>
       </CardHeader>
       <CardContent>
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-10">#</TableHead>
               <TableHead>Developer</TableHead>
               <TableHead className="text-right">Sessions</TableHead>
               <TableHead className="text-right">Active Time</TableHead>
-              <TableHead className="text-right">AI Lines</TableHead>
-              <TableHead className="text-right">Manual Lines</TableHead>
-              <TableHead className="text-right">AI %</TableHead>
+              <TableHead className="text-right">Total Lines</TableHead>
+              <TableHead>AI Adoption</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {sorted.map((dev) => {
+            {sorted.map((dev, i) => {
               const total = dev.aiLines + dev.manualLines;
               const aiPct = total > 0 ? Math.round((dev.aiLines / total) * 100) : 0;
+              const tier = getAdoptionTier(aiPct);
               return (
                 <TableRow key={dev.userId}>
+                  <TableCell className="text-muted-foreground">{i + 1}</TableCell>
                   <TableCell className="font-medium">{dev.userName || dev.userId.slice(0, 8)}</TableCell>
                   <TableCell className="text-right">{dev.sessions}</TableCell>
                   <TableCell className="text-right">{formatDuration(dev.activeMinutes)}</TableCell>
-                  <TableCell className="text-right">{dev.aiLines.toLocaleString()}</TableCell>
-                  <TableCell className="text-right">{dev.manualLines.toLocaleString()}</TableCell>
-                  <TableCell className="text-right">
-                    <span className={aiPct >= 50 ? 'text-emerald-400' : 'text-muted-foreground'}>
-                      {aiPct}%
-                    </span>
+                  <TableCell className="text-right">{total.toLocaleString()}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <div className="w-20 h-1.5 rounded-full bg-muted overflow-hidden">
+                        <div className="h-full rounded-full transition-all" style={{ width: `${aiPct}%`, backgroundColor: tier.color }} />
+                      </div>
+                      <span className={`text-sm font-medium ${tier.textClass}`}>{aiPct}%</span>
+                      <Badge variant="outline" className={tier.badgeClass}>{tier.label}</Badge>
+                    </div>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
## Summary
- Enhanced `DeveloperLeaderboard` component to rank developers by AI adoption rate (was: session count)
- Added rank column, progress bars, and tier badges (Champion ≥70%, Growing ≥25%, Getting Started <25%)
- Added the leaderboard as a new "AI Adoption" section on the `/insights` page
- Fixed CLAUDE.md dashboard page descriptions to reflect actual page contents

Closes SGS-130

## Test plan
- [ ] Open `/insights` — verify AI Adoption section appears below Tandemu Impact with leaderboard
- [ ] Open `/activity` — verify the same enhanced leaderboard renders there
- [ ] Verify empty state shows "No developer data yet" when no telemetry exists
- [ ] Check progress bars and badges render correctly with color tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)