### PR TITLE
feat: GitHub OAuth integration for one-click setup

### DIFF
--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -28,6 +28,6 @@ import { GithubOAuthService } from './strategies/github.strategy.js';
       inject: [AuthService, ConfigService],
     },
   ],
-  exports: [AuthService, CliAuthService, JwtAuthGuard],
+  exports: [AuthService, CliAuthService, JwtAuthGuard, GithubOAuthService],
 })
 export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -146,7 +146,23 @@ export class AuthService {
     }
   }
 
-  async getMe(userId: string): Promise<{ id: string; email: string; name: string; avatarUrl: string | null; createdAt: string; updatedAt: string }> {
+  async getOAuthProviderUserId(userId: string, provider: string): Promise<string | null> {
+    const result = await this.db.query<{ provider_user_id: string }>(
+      'SELECT provider_user_id FROM oauth_accounts WHERE user_id = $1 AND provider = $2',
+      [userId, provider],
+    );
+    return result.rows[0]?.provider_user_id ?? null;
+  }
+
+  async getOAuthProviders(userId: string): Promise<string[]> {
+    const result = await this.db.query<{ provider: string }>(
+      'SELECT DISTINCT provider FROM oauth_accounts WHERE user_id = $1',
+      [userId],
+    );
+    return result.rows.map((r) => r.provider);
+  }
+
+  async getMe(userId: string): Promise<{ id: string; email: string; name: string; avatarUrl: string | null; createdAt: string; updatedAt: string; oauthProviders: string[] }> {
     const result = await this.db.query<{
       id: string;
       email: string;
@@ -164,6 +180,7 @@ export class AuthService {
     }
 
     const user = result.rows[0]!;
+    const oauthProviders = await this.getOAuthProviders(userId);
     return {
       id: user.id,
       email: user.email,
@@ -171,6 +188,7 @@ export class AuthService {
       avatarUrl: user.avatar_url,
       createdAt: user.created_at.toISOString(),
       updatedAt: user.updated_at.toISOString(),
+      oauthProviders,
     };
   }
 

--- a/apps/backend/src/auth/strategies/github.strategy.ts
+++ b/apps/backend/src/auth/strategies/github.strategy.ts
@@ -28,6 +28,7 @@ export class GithubOAuthService {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly callbackUrl: string;
+  private readonly integrationCallbackUrl: string;
 
   constructor(
     private readonly authService: AuthService,
@@ -37,6 +38,7 @@ export class GithubOAuthService {
     this.clientId = configService.get<string>('oauth.github.clientId')!;
     this.clientSecret = configService.get<string>('oauth.github.clientSecret')!;
     this.callbackUrl = `${appUrl}/api/auth/github/callback`;
+    this.integrationCallbackUrl = `${appUrl}/api/integrations/github/oauth/callback`;
   }
 
   getAuthorizationUrl(state: string): string {
@@ -47,6 +49,52 @@ export class GithubOAuthService {
       state,
     });
     return `https://github.com/login/oauth/authorize?${params.toString()}`;
+  }
+
+  getIntegrationAuthorizationUrl(state: string): string {
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      redirect_uri: this.integrationCallbackUrl,
+      scope: 'repo,user:email',
+      state,
+    });
+    return `https://github.com/login/oauth/authorize?${params.toString()}`;
+  }
+
+  async exchangeCodeForToken(code: string): Promise<{ accessToken: string; githubUserId: string }> {
+    const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+        redirect_uri: this.integrationCallbackUrl,
+      }),
+    });
+
+    const tokenData = (await tokenRes.json()) as GithubTokenResponse;
+    if (tokenData.error || !tokenData.access_token) {
+      throw new Error(tokenData.error_description ?? tokenData.error ?? 'Failed to obtain access token');
+    }
+
+    const userRes = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `token ${tokenData.access_token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'Tandemu',
+      },
+    });
+
+    if (!userRes.ok) {
+      throw new Error('Failed to fetch GitHub user profile');
+    }
+
+    const user = (await userRes.json()) as GithubUser;
+    return { accessToken: tokenData.access_token, githubUserId: String(user.id) };
   }
 
   async exchangeCodeAndAuthenticate(code: string): Promise<{

--- a/apps/backend/src/integrations/integration-oauth.controller.ts
+++ b/apps/backend/src/integrations/integration-oauth.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Logger,
+  Query,
+  Res,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes } from 'crypto';
+import type { Response } from 'express';
+import { GithubOAuthService } from '../auth/strategies/github.strategy.js';
+import { IntegrationsService } from './integrations.service.js';
+import { AuthService } from '../auth/auth.service.js';
+
+interface OAuthState {
+  createdAt: number;
+  orgId: string;
+  userId: string;
+  returnUrl: string;
+}
+
+@Controller('integrations/github/oauth')
+export class IntegrationOAuthController {
+  private readonly logger = new Logger(IntegrationOAuthController.name);
+  private readonly frontendUrl: string;
+  private readonly githubEnabled: boolean;
+  private readonly states = new Map<string, OAuthState>();
+
+  constructor(
+    private readonly githubOAuthService: GithubOAuthService,
+    private readonly integrationsService: IntegrationsService,
+    private readonly authService: AuthService,
+    configService: ConfigService,
+  ) {
+    this.frontendUrl = configService.get<string>('oauth.frontendUrl', 'http://localhost:3000');
+    this.githubEnabled = configService.get<boolean>('oauth.github.enabled', false);
+
+    // Clean up expired states every 5 minutes
+    setInterval(() => {
+      const now = Date.now();
+      for (const [state, data] of this.states) {
+        if (now - data.createdAt > 10 * 60 * 1000) this.states.delete(state);
+      }
+    }, 5 * 60 * 1000);
+  }
+
+  @Get()
+  async initiate(
+    @Query('token') token: string,
+    @Query('return_url') returnUrl: string | undefined,
+    @Res() res: Response,
+  ) {
+    if (!this.githubEnabled) {
+      throw new InternalServerErrorException('GitHub OAuth is not configured');
+    }
+
+    if (!token) {
+      throw new UnauthorizedException('Missing authentication token');
+    }
+
+    // Validate JWT and extract user context
+    const user = await this.authService.validateToken(token);
+    if (!user || !user.organizationId) {
+      throw new UnauthorizedException('Invalid token or no organization context');
+    }
+
+    const state = randomBytes(16).toString('hex');
+    this.states.set(state, {
+      createdAt: Date.now(),
+      orgId: user.organizationId,
+      userId: user.userId,
+      returnUrl: returnUrl || '/integrations',
+    });
+
+    res.redirect(this.githubOAuthService.getIntegrationAuthorizationUrl(state));
+  }
+
+  @Get('callback')
+  async callback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res: Response,
+  ) {
+    const stateData = state ? this.states.get(state) : undefined;
+    if (!stateData) {
+      throw new InternalServerErrorException('Invalid or expired OAuth state');
+    }
+    this.states.delete(state);
+
+    if (!code) {
+      throw new InternalServerErrorException('No authorization code received');
+    }
+
+    try {
+      // Exchange code for token and verify identity
+      const { accessToken, githubUserId } = await this.githubOAuthService.exchangeCodeForToken(code);
+
+      // Verify the GitHub user matches the logged-in user's linked account
+      const linkedGithubId = await this.authService.getOAuthProviderUserId(stateData.userId, 'github');
+      if (linkedGithubId && linkedGithubId !== githubUserId) {
+        this.logger.warn(
+          `GitHub user mismatch: expected ${linkedGithubId}, got ${githubUserId} for user ${stateData.userId}`,
+        );
+        const redirectUrl = new URL(stateData.returnUrl, this.frontendUrl);
+        redirectUrl.searchParams.set('github', 'error');
+        redirectUrl.searchParams.set('error', 'account_mismatch');
+        res.redirect(redirectUrl.toString());
+        return;
+      }
+
+      // Create or update the GitHub integration
+      await this.integrationsService.createOrUpdate(stateData.orgId, {
+        provider: 'github',
+        accessToken,
+      });
+
+      const redirectUrl = new URL(stateData.returnUrl, this.frontendUrl);
+      redirectUrl.searchParams.set('github', 'connected');
+      res.redirect(redirectUrl.toString());
+    } catch (error) {
+      this.logger.error(`GitHub integration OAuth failed: ${error}`);
+      const redirectUrl = new URL(stateData.returnUrl, this.frontendUrl);
+      redirectUrl.searchParams.set('github', 'error');
+      res.redirect(redirectUrl.toString());
+    }
+  }
+}

--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -1,5 +1,6 @@
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { IntegrationsController } from './integrations.controller.js';
+import { IntegrationOAuthController } from './integration-oauth.controller.js';
 import { TasksController } from './tasks.controller.js';
 import { IntegrationsService } from './integrations.service.js';
 import { TasksService } from './tasks.service.js';
@@ -11,7 +12,7 @@ import { TelemetryModule } from '../telemetry/telemetry.module.js';
 
 @Module({
   imports: [AuthModule, TeamsModule, forwardRef(() => TelemetryModule)],
-  controllers: [IntegrationsController, TasksController],
+  controllers: [IntegrationsController, IntegrationOAuthController, TasksController],
   providers: [IntegrationsService, TasksService, GitHubGitService],
   exports: [IntegrationsService, TasksService, GitHubGitService],
 })

--- a/apps/backend/src/integrations/integrations.service.ts
+++ b/apps/backend/src/integrations/integrations.service.ts
@@ -132,6 +132,32 @@ export class IntegrationsService {
     }
   }
 
+  async createOrUpdate(orgId: string, dto: CreateIntegrationDto): Promise<Integration> {
+    const encryptedToken = this.encryptToken(dto.accessToken);
+    const encryptedRefresh = dto.refreshToken ? this.encryptToken(dto.refreshToken) : null;
+
+    const result = await this.db.query<IntegrationRow>(
+      `INSERT INTO integrations (organization_id, provider, access_token, refresh_token, external_workspace_id, external_workspace_name, encryption_key_version)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (organization_id, provider)
+       DO UPDATE SET access_token = EXCLUDED.access_token, refresh_token = EXCLUDED.refresh_token,
+                     external_workspace_id = COALESCE(EXCLUDED.external_workspace_id, integrations.external_workspace_id),
+                     external_workspace_name = COALESCE(EXCLUDED.external_workspace_name, integrations.external_workspace_name),
+                     encryption_key_version = EXCLUDED.encryption_key_version, updated_at = now()
+       RETURNING *`,
+      [
+        orgId,
+        dto.provider,
+        encryptedToken,
+        encryptedRefresh,
+        dto.externalWorkspaceId ?? null,
+        dto.externalWorkspaceName ?? null,
+        this.keyVersion,
+      ],
+    );
+    return mapIntegration(result.rows[0]!);
+  }
+
   async findAll(orgId: string): Promise<Array<Integration & { maskedToken: string }>> {
     const result = await this.db.query<IntegrationRow>(
       `SELECT * FROM integrations WHERE organization_id = $1`,

--- a/apps/frontend/src/app/integrations/page.tsx
+++ b/apps/frontend/src/app/integrations/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -50,6 +51,7 @@ import {
   deleteProjectMapping,
   getTeams,
   getSubProjects,
+  getGitHubOAuthIntegrationUrl,
 } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 import type { Integration, IntegrationProjectMapping } from '@/lib/api';
@@ -141,11 +143,36 @@ function getProviderMeta(providerId: string) {
   return PROVIDERS.find((p) => p.id === providerId);
 }
 
-export default function IntegrationsPage() {
-  const { currentOrg: authOrg } = useAuth();
+function IntegrationsPageInner() {
+  const { currentOrg: authOrg, user } = useAuth();
+  const searchParams = useSearchParams();
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+
+  // Handle GitHub OAuth callback
+  const oauthHandled = useRef(false);
+  useEffect(() => {
+    if (oauthHandled.current) return;
+    const githubStatus = searchParams.get('github');
+    if (githubStatus) {
+      oauthHandled.current = true;
+      if (githubStatus === 'connected') {
+        toast.success('GitHub connected successfully via OAuth.');
+      } else if (githubStatus === 'error') {
+        const errorType = searchParams.get('error');
+        toast.error(
+          errorType === 'account_mismatch'
+            ? 'GitHub account mismatch. Use the same GitHub account you signed up with.'
+            : 'Failed to connect GitHub. Please try again or use manual setup.',
+        );
+      }
+      // Clean URL
+      window.history.replaceState({}, '', '/integrations');
+    }
+  }, [searchParams]);
+
+  const hasGitHubOAuth = user?.oauthProviders?.includes('github') ?? false;
 
   // Org + teams for mappings
   const [orgId, setOrgId] = useState<string | null>(null);
@@ -554,19 +581,46 @@ export default function IntegrationsPage() {
                       )}
                     </div>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setConnectProvider(provider.id);
-                      setConnectToken('');
-                      setConnectWorkspace('');
-                      setShowToken(false);
-                    }}
-                  >
-                    <Plug className="h-3.5 w-3.5 mr-2" />
-                    Connect
-                  </Button>
+                  {provider.id === 'github' && hasGitHubOAuth ? (
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => {
+                          window.location.href = getGitHubOAuthIntegrationUrl('/integrations');
+                        }}
+                      >
+                        <SiGithub size={14} className="mr-2" />
+                        Connect with GitHub
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => {
+                          setConnectProvider(provider.id);
+                          setConnectToken('');
+                          setConnectWorkspace('');
+                          setShowToken(false);
+                        }}
+                        className="text-xs text-muted-foreground"
+                      >
+                        Manual setup
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setConnectProvider(provider.id);
+                        setConnectToken('');
+                        setConnectWorkspace('');
+                        setShowToken(false);
+                      }}
+                    >
+                      <Plug className="h-3.5 w-3.5 mr-2" />
+                      Connect
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>
@@ -855,5 +909,21 @@ export default function IntegrationsPage() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+export default function IntegrationsPage() {
+  return (
+    <Suspense fallback={
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Integrations</h1>
+          <p className="text-muted-foreground">Connect your ticket system and map projects to teams.</p>
+        </div>
+        <IntegrationsSkeleton />
+      </div>
+    }>
+      <IntegrationsPageInner />
+    </Suspense>
   );
 }

--- a/apps/frontend/src/app/setup/page.tsx
+++ b/apps/frontend/src/app/setup/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 import { LoadingScreen } from '@/components/loading-screen';
 import {
   createOrganization,
   createInvite,
   createTeam,
+  createIntegration,
   switchOrg,
+  getGitHubOAuthIntegrationUrl,
 } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -21,6 +24,14 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
   LayoutDashboard,
   Clock,
   Flame,
@@ -33,7 +44,14 @@ import {
   Mail,
   Trash2,
   ChevronsUpDown,
+  Check,
+  Eye,
+  EyeOff,
+  ExternalLink,
+  Info,
 } from 'lucide-react';
+import { SiGithub, SiJira, SiLinear, SiClickup, SiAsana } from '@icons-pack/react-simple-icons';
+import Image from 'next/image';
 import { toast } from 'sonner';
 
 function generateSlug(name: string): string {
@@ -60,7 +78,82 @@ const STEPS = [
   { description: 'Set up your workspace' },
   { description: 'Create your teams' },
   { description: 'Invite your team' },
+  { description: 'Connect your tools' },
 ];
+
+const SETUP_PROVIDERS = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Issue tracking and PR history',
+    icon: SiGithub,
+    workspaceLabel: 'Organization',
+    workspacePlaceholder: 'my-org (leave blank for personal repos)',
+    workspaceRequired: false,
+    helpText: 'Create a personal access token at github.com/settings/tokens with repo scope.',
+    helpUrl: 'https://github.com/settings/tokens',
+    supportsOAuth: true,
+  },
+  {
+    id: 'jira',
+    name: 'Jira',
+    description: 'Sync issues and sprints',
+    icon: SiJira,
+    iconColor: '#2684FF',
+    workspaceLabel: 'Site URL',
+    workspacePlaceholder: 'mycompany.atlassian.net',
+    workspaceRequired: true,
+    helpText: 'Create an API token at id.atlassian.net/manage-profile/security/api-tokens.',
+    helpUrl: 'https://id.atlassian.net/manage-profile/security/api-tokens',
+  },
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Import issues and projects',
+    icon: SiLinear,
+    iconColor: '#5E6AD2',
+    workspaceLabel: 'Workspace',
+    workspacePlaceholder: 'Derived from token (leave blank)',
+    workspaceRequired: false,
+    helpText: 'Create a personal API key at linear.app/settings/api',
+    helpUrl: 'https://linear.app/settings/api',
+  },
+  {
+    id: 'clickup',
+    name: 'ClickUp',
+    description: 'Connect tasks and spaces',
+    icon: SiClickup,
+    iconColor: '#7B68EE',
+    workspaceLabel: 'Workspace ID',
+    workspacePlaceholder: 'Auto-detected from token',
+    workspaceRequired: false,
+    helpText: 'Create a personal API token at app.clickup.com/settings/apps',
+    helpUrl: 'https://app.clickup.com/settings/apps',
+  },
+  {
+    id: 'asana',
+    name: 'Asana',
+    description: 'Sync tasks and projects',
+    icon: SiAsana,
+    iconColor: '#F06A6A',
+    workspaceLabel: 'Workspace GID',
+    workspacePlaceholder: 'Your Asana workspace GID',
+    workspaceRequired: true,
+    helpText: 'Create a personal access token at app.asana.com/0/developer-console',
+    helpUrl: 'https://app.asana.com/0/developer-console',
+  },
+  {
+    id: 'monday',
+    name: 'Monday.com',
+    description: 'Connect boards and items',
+    iconImage: '/monday.svg',
+    workspaceLabel: 'Workspace',
+    workspacePlaceholder: 'Not required (leave blank)',
+    workspaceRequired: false,
+    helpText: 'Create an API token in your Monday.com admin panel under Developers',
+    helpUrl: 'https://monday.com/developers/apps',
+  },
+] as const;
 
 const sidebarNav = [
   { label: 'Dashboard', icon: LayoutDashboard },
@@ -265,12 +358,76 @@ function InvitesPreview({
   );
 }
 
+// --- Preview: Integrations ---
+
+function IntegrationsPreview({ connectedProviders }: { connectedProviders: string[] }) {
+  return (
+    <div className="h-[540px] rounded-xl border border-border bg-background shadow-lg overflow-hidden flex flex-col">
+      <div className="px-5 py-4 border-b border-border">
+        <p className="text-sm font-semibold">Integrations</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{connectedProviders.length} connected</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2">
+        {SETUP_PROVIDERS.map((provider) => {
+          const isConnected = connectedProviders.includes(provider.id);
+          return (
+            <div key={provider.id} className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-muted/50 transition-colors">
+              <div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
+                {'iconImage' in provider ? (
+                  <Image src={provider.iconImage} alt={provider.name} width={16} height={16} />
+                ) : (
+                  <provider.icon size={16} color={'iconColor' in provider ? provider.iconColor : undefined} />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{provider.name}</p>
+                <p className="text-xs text-muted-foreground truncate">{provider.description}</p>
+              </div>
+              {isConnected ? (
+                <div className="flex items-center gap-1 text-xs text-green-500">
+                  <Check className="h-3.5 w-3.5" />
+                  Connected
+                </div>
+              ) : (
+                <span className="text-xs text-muted-foreground">Not connected</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 // --- Main ---
 
-export default function SetupPage() {
+function SetupPageInner() {
   const { user, isLoading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
 
   const [step, setStep] = useState(0);
+
+  // Handle GitHub OAuth return on setup page
+  const oauthHandled = useRef(false);
+  useEffect(() => {
+    if (oauthHandled.current) return;
+    const githubStatus = searchParams.get('github');
+    const stepParam = searchParams.get('step');
+    if (githubStatus && stepParam === '3') {
+      oauthHandled.current = true;
+      if (githubStatus === 'connected') {
+        setStep(3);
+        setOrgCreated(true);
+        setConnectedProviders((prev) => prev.includes('github') ? prev : [...prev, 'github']);
+        toast.success('GitHub connected successfully!');
+      } else {
+        setStep(3);
+        setOrgCreated(true);
+        toast.error('Failed to connect GitHub. Try manual setup.');
+      }
+      window.history.replaceState({}, '', '/setup');
+    }
+  }, [searchParams]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Step 1: Organization
@@ -288,6 +445,18 @@ export default function SetupPage() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState('MEMBER');
   const [inviteTeamId, setInviteTeamId] = useState('none');
+
+  // Step 4: Integrations
+  const [connectedProviders, setConnectedProviders] = useState<string[]>([]);
+  const [setupConnectProvider, setSetupConnectProvider] = useState<string | null>(null);
+  const [setupConnectToken, setSetupConnectToken] = useState('');
+  const [setupConnectWorkspace, setSetupConnectWorkspace] = useState('');
+  const [setupShowToken, setSetupShowToken] = useState(false);
+  const [setupConnecting, setSetupConnecting] = useState(false);
+  const [setupConnectError, setSetupConnectError] = useState('');
+  const [orgCreated, setOrgCreated] = useState(false);
+
+  const hasGitHubOAuth = user?.oauthProviders?.includes('github') ?? false;
 
   const handleOrgNameChange = (value: string) => {
     setOrgName(value);
@@ -336,12 +505,12 @@ export default function SetupPage() {
     try {
       // 1. Create org
       const org = await createOrganization({ name: orgName.trim(), slug: orgSlug.trim() });
-      const orgId = org.id;
+      const newOrgId = org.id;
 
       // 2. Switch org context to get OWNER token before creating teams/invites
-      const { accessToken } = await switchOrg(orgId);
+      const { accessToken } = await switchOrg(newOrgId);
       localStorage.setItem('tandemu_token', accessToken);
-      localStorage.setItem('tandemu_current_org', orgId);
+      localStorage.setItem('tandemu_current_org', newOrgId);
 
       // 3. Create teams
       const teamIdMap: Record<string, string> = {};
@@ -349,7 +518,7 @@ export default function SetupPage() {
 
       for (let i = 0; i < teams.length; i++) {
         try {
-          const team = await createTeam(orgId, { name: teams[i].name, description: teams[i].description || undefined });
+          const team = await createTeam(newOrgId, { name: teams[i].name, description: teams[i].description || undefined });
           teamIdMap[`team-${i}`] = team.id;
         } catch (err) {
           errors.push(`Team "${teams[i].name}": ${err instanceof Error ? err.message : 'failed'}`);
@@ -360,7 +529,7 @@ export default function SetupPage() {
       for (const inv of invites) {
         try {
           const realTeamId = inv.teamId !== 'none' ? teamIdMap[inv.teamId] : undefined;
-          await createInvite(orgId, { email: inv.email, role: inv.role, teamId: realTeamId });
+          await createInvite(newOrgId, { email: inv.email, role: inv.role, teamId: realTeamId });
         } catch (err) {
           errors.push(`Invite "${inv.email}": ${err instanceof Error ? err.message : 'failed'}`);
         }
@@ -370,12 +539,44 @@ export default function SetupPage() {
         toast.error(`Setup completed with errors:\n${errors.join('\n')}`);
       }
 
-      window.location.href = '/';
+      // Move to step 4 instead of redirecting
+      setOrgCreated(true);
+      setStep(3);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Setup failed. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleSetupConnect = async () => {
+    if (!setupConnectProvider || !setupConnectToken.trim()) return;
+    const provider = SETUP_PROVIDERS.find((p) => p.id === setupConnectProvider);
+    setSetupConnecting(true);
+    setSetupConnectError('');
+    try {
+      await createIntegration({
+        provider: setupConnectProvider,
+        accessToken: setupConnectToken.trim(),
+        externalWorkspaceId: setupConnectWorkspace.trim() || undefined,
+        externalWorkspaceName: setupConnectWorkspace.trim() || undefined,
+      });
+      setConnectedProviders((prev) => [...prev, setupConnectProvider!]);
+      setSetupConnectProvider(null);
+      setSetupConnectToken('');
+      setSetupConnectWorkspace('');
+      setSetupShowToken(false);
+      setSetupConnectError('');
+      toast.success(`${provider?.name ?? setupConnectProvider} connected!`);
+    } catch (err) {
+      setSetupConnectError(err instanceof Error ? err.message : 'Failed to connect');
+    } finally {
+      setSetupConnecting(false);
+    }
+  };
+
+  const handleFinish = () => {
+    window.location.href = '/';
   };
 
   if (authLoading) {
@@ -513,10 +714,86 @@ export default function SetupPage() {
               </div>
             )}
 
+            {/* Step 4: Connect your tools */}
+            {step === 3 && (
+              <div className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  Connect your ticket system to sync tasks. You can also do this later from the Integrations page.
+                </p>
+                <div className="space-y-2">
+                  {SETUP_PROVIDERS.map((provider) => {
+                    const isConnected = connectedProviders.includes(provider.id);
+                    return (
+                      <div
+                        key={provider.id}
+                        className="flex items-center gap-3 rounded-lg border border-border px-4 py-3"
+                      >
+                        <div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
+                          {'iconImage' in provider ? (
+                            <Image src={provider.iconImage} alt={provider.name} width={16} height={16} />
+                          ) : (
+                            <provider.icon size={16} color={'iconColor' in provider ? provider.iconColor : undefined} />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium">{provider.name}</p>
+                          <p className="text-xs text-muted-foreground">{provider.description}</p>
+                        </div>
+                        {isConnected ? (
+                          <div className="flex items-center gap-1 text-xs text-green-500 font-medium">
+                            <Check className="h-3.5 w-3.5" />
+                            Connected
+                          </div>
+                        ) : provider.id === 'github' && hasGitHubOAuth ? (
+                          <div className="flex items-center gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => {
+                                window.location.href = getGitHubOAuthIntegrationUrl('/setup?step=3&github=connected');
+                              }}
+                            >
+                              <SiGithub size={14} className="mr-1.5" />
+                              Connect
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-xs text-muted-foreground"
+                              onClick={() => {
+                                setSetupConnectProvider(provider.id);
+                                setSetupConnectToken('');
+                                setSetupConnectWorkspace('');
+                                setSetupShowToken(false);
+                              }}
+                            >
+                              Manual
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setSetupConnectProvider(provider.id);
+                              setSetupConnectToken('');
+                              setSetupConnectWorkspace('');
+                              setSetupShowToken(false);
+                            }}
+                          >
+                            Connect
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
             {/* Navigation */}
             <Separator className="mt-8 mb-6" />
             <div className="flex items-center gap-3">
-              {step > 0 && (
+              {step > 0 && step < 3 && (
                 <Button variant="outline" onClick={() => setStep(step - 1)} disabled={isSubmitting}>Back</Button>
               )}
               <div className="flex-1" />
@@ -529,7 +806,7 @@ export default function SetupPage() {
                     Continue
                   </Button>
                 </>
-              ) : (
+              ) : step === 2 ? (
                 <Button onClick={handleComplete} disabled={isSubmitting}>
                   {isSubmitting ? (
                     <>
@@ -537,9 +814,18 @@ export default function SetupPage() {
                       Setting up...
                     </>
                   ) : (
-                    'Complete Setup'
+                    'Continue'
                   )}
                 </Button>
+              ) : (
+                <>
+                  <Button variant="ghost" onClick={handleFinish}>
+                    Skip
+                  </Button>
+                  <Button onClick={handleFinish}>
+                    {connectedProviders.length > 0 ? 'Finish Setup' : 'Go to Dashboard'}
+                  </Button>
+                </>
               )}
             </div>
           </div>
@@ -551,9 +837,134 @@ export default function SetupPage() {
             {step === 0 && <DashboardPreview orgName={orgName} userName={user.name} />}
             {step === 1 && <TeamsPreview teams={teams} onRemove={removeTeam} />}
             {step === 2 && <InvitesPreview invites={invites} user={user} teams={teams} onRemove={removeInvite} />}
+            {step === 3 && <IntegrationsPreview connectedProviders={connectedProviders} />}
           </div>
         </div>
       </div>
+
+      {/* Manual Connect Dialog (Step 4) */}
+      <Dialog open={!!setupConnectProvider} onOpenChange={(open) => {
+        if (!open) {
+          setSetupConnectProvider(null);
+          setSetupConnectError('');
+        }
+      }}>
+        <DialogContent>
+          {setupConnectProvider && (() => {
+            const provider = SETUP_PROVIDERS.find((p) => p.id === setupConnectProvider);
+            if (!provider) return null;
+            return (
+              <>
+                <DialogHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center justify-center rounded-lg border bg-muted p-2">
+                      {'iconImage' in provider ? (
+                        <Image src={provider.iconImage} alt={provider.name} width={24} height={24} />
+                      ) : (
+                        <provider.icon size={24} color={'iconColor' in provider ? provider.iconColor : undefined} />
+                      )}
+                    </div>
+                    <div>
+                      <DialogTitle>Connect {provider.name}</DialogTitle>
+                      <DialogDescription>
+                        Provide your API credentials to connect.
+                      </DialogDescription>
+                    </div>
+                  </div>
+                </DialogHeader>
+                <div className="flex flex-col gap-4 py-4">
+                  <div className="flex gap-3 rounded-lg border bg-muted/50 p-3">
+                    <Info className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
+                    <div className="text-sm text-muted-foreground">
+                      <p>{provider.helpText}</p>
+                      <a
+                        href={provider.helpUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-primary hover:underline mt-1"
+                      >
+                        Open settings
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+
+                  {setupConnectError && (
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                      {setupConnectError}
+                    </div>
+                  )}
+
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">API Token</label>
+                    <div className="relative">
+                      <Input
+                        type={setupShowToken ? 'text' : 'password'}
+                        value={setupConnectToken}
+                        onChange={(e) => setSetupConnectToken(e.target.value)}
+                        placeholder="Paste your token here"
+                        className="pr-10"
+                        autoComplete="off"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setSetupShowToken(!setupShowToken)}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {setupShowToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">
+                      {provider.workspaceLabel}
+                      {!provider.workspaceRequired && (
+                        <span className="text-muted-foreground font-normal ml-1">(optional)</span>
+                      )}
+                    </label>
+                    <Input
+                      value={setupConnectWorkspace}
+                      onChange={(e) => setSetupConnectWorkspace(e.target.value)}
+                      placeholder={provider.workspacePlaceholder}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setSetupConnectProvider(null)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleSetupConnect}
+                    disabled={
+                      setupConnecting ||
+                      !setupConnectToken.trim() ||
+                      (provider.workspaceRequired && !setupConnectWorkspace.trim())
+                    }
+                  >
+                    {setupConnecting ? (
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    ) : (
+                      <>
+                        <Plug className="h-4 w-4 mr-2" />
+                        Connect
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </>
+            );
+          })()}
+        </DialogContent>
+      </Dialog>
     </div>
+  );
+}
+
+export default function SetupPage() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <SetupPageInner />
+    </Suspense>
   );
 }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -91,6 +91,7 @@ export interface AuthUser {
   email: string;
   name: string;
   role?: string;
+  oauthProviders?: string[];
 }
 
 export async function apiLogin(email: string, password: string): Promise<AuthResponse> {
@@ -457,6 +458,14 @@ export async function createIntegration(data: {
     method: "POST",
     body: JSON.stringify(data),
   });
+}
+
+export function getGitHubOAuthIntegrationUrl(returnUrl = '/integrations'): string {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('tandemu_token') : null;
+  const url = new URL(`${API_URL}/api/integrations/github/oauth`);
+  if (token) url.searchParams.set('token', token);
+  url.searchParams.set('return_url', returnUrl);
+  return url.toString();
 }
 
 export async function deleteIntegration(provider: string): Promise<void> {

--- a/apps/frontend/src/lib/auth.tsx
+++ b/apps/frontend/src/lib/auth.tsx
@@ -10,6 +10,7 @@ interface AuthUser {
   email: string;
   name: string;
   role?: string;
+  oauthProviders?: string[];
 }
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- Add a new integration OAuth flow that lets users connect GitHub with `repo` scope via a single OAuth click, instead of manually creating a PAT
- Add step 4 "Connect your tools" to the setup wizard showing all providers in a vertical list, with GitHub offering both OAuth and manual options
- Update the integrations page with "Connect with GitHub" (OAuth) + "Manual setup" buttons for GitHub-signed-up users

## Changes
**Backend:**
- New `IntegrationOAuthController` with `GET /api/integrations/github/oauth` (initiate) and callback endpoints
- `GithubOAuthService` gains `getIntegrationAuthorizationUrl()` and `exchangeCodeForToken()` methods
- `IntegrationsService.createOrUpdate()` upsert method for re-authorization
- `AuthService.getMe()` now returns `oauthProviders` array

**Frontend:**
- Integrations page: GitHub card shows OAuth button + manual fallback, handles `?github=connected` callback
- Setup wizard: New step 4 with vertical provider list, inline connect dialogs, OAuth for GitHub
- Both pages wrapped in `Suspense` for `useSearchParams()` compatibility

## Test plan
- [ ] Sign up via GitHub OAuth, complete setup wizard through step 4, click "Connect with GitHub" → verify integration created
- [ ] Existing user: go to /integrations → click "Connect with GitHub" → authorize → verify redirect + integration
- [ ] Re-authorization: connect GitHub again → verify token updated (not duplicated)
- [ ] Manual fallback: click "Manual setup" → paste PAT → verify integration created
- [ ] Non-GitHub signup user: verify step 4 shows manual connect only for all providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)