### PR TITLE
feat: add email notification system via Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,9 @@ JWT_SECRET=change-me-in-production
 # SENTRY_ORG=
 # SENTRY_PROJECT_FRONTEND=
 
+# Email (SaaS only — leave empty for OSS)
+# RESEND_API_KEY=
+# EMAIL_FROM=Tandemu <notifications@tandemu.com>
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,6 +33,7 @@
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",
+    "resend": "^4.0.0",
     "rxjs": "^7.8.0"
   },
   "devDependencies": {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { IntegrationsModule } from './integrations/integrations.module.js';
 import { MemoryModule } from './memory/memory.module.js';
 import { SetupModule } from './setup/setup.module.js';
 import { QueueModule } from './queue/queue.module.js';
+import { EmailModule } from './email/email.module.js';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { QueueModule } from './queue/queue.module.js';
     MemoryModule,
     SetupModule,
     QueueModule,
+    EmailModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -4,9 +4,11 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { DatabaseService } from '../database/database.service.js';
+import type { UserRegisteredEvent, EmailAliasAddedEvent } from '../email/email.types.js';
 
 interface AuthResponse {
   accessToken: string;
@@ -31,6 +33,7 @@ export class AuthService {
   constructor(
     private readonly db: DatabaseService,
     private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
   ) {
     this.jwtSecret = this.configService.get<string>('jwt.secret', 'change-me-in-production');
   }
@@ -68,6 +71,7 @@ export class AuthService {
 
       let organizationId = '';
       let role = 'MEMBER';
+      const autoAcceptedOrgIds: string[] = [];
 
       for (const invite of pendingInvites.rows) {
         await client.query(
@@ -78,6 +82,7 @@ export class AuthService {
           `INSERT INTO memberships (user_id, organization_id, role) VALUES ($1, $2, $3)`,
           [user.id, invite.organization_id, invite.role],
         );
+        autoAcceptedOrgIds.push(invite.organization_id);
         // Use the first accepted invite's org as the default
         if (organizationId === '') {
           organizationId = invite.organization_id;
@@ -85,10 +90,17 @@ export class AuthService {
         }
       }
 
-      return user;
+      return { user, autoAcceptedOrgIds };
     });
 
-    return this.generateAuthResponse(result.id, result.email, result.name);
+    this.eventEmitter.emit('user.registered', {
+      userId: result.user.id,
+      email,
+      name,
+      autoAcceptedOrgIds: result.autoAcceptedOrgIds,
+    } satisfies UserRegisteredEvent);
+
+    return this.generateAuthResponse(result.user.id, result.user.email, result.user.name);
   }
 
   async login(email: string, password: string): Promise<AuthResponse> {
@@ -287,6 +299,7 @@ export class AuthService {
         [email],
       );
 
+      const autoAcceptedOrgIds: string[] = [];
       for (const invite of pendingInvites.rows) {
         await client.query(
           `UPDATE invites SET status = 'accepted' WHERE id = $1`,
@@ -302,12 +315,20 @@ export class AuthService {
             [invite.team_id, user.id],
           );
         }
+        autoAcceptedOrgIds.push(invite.organization_id);
       }
 
-      return user;
+      return { user, autoAcceptedOrgIds };
     });
 
-    return this.generateAuthResponse(result.id, result.email, result.name);
+    this.eventEmitter.emit('user.registered', {
+      userId: result.user.id,
+      email,
+      name,
+      autoAcceptedOrgIds: result.autoAcceptedOrgIds,
+    } satisfies UserRegisteredEvent);
+
+    return this.generateAuthResponse(result.user.id, result.user.email, result.user.name);
   }
 
   // --- Email aliases ---
@@ -344,6 +365,10 @@ export class AuthService {
       [userId, email.toLowerCase().trim()],
     );
     const r = result.rows[0]!;
+    this.eventEmitter.emit('email_alias.added', {
+      userId,
+      aliasEmail: r.email,
+    } satisfies EmailAliasAddedEvent);
     return { id: r.id, email: r.email, isPrimary: r.is_primary, createdAt: r.created_at.toISOString() };
   }
 

--- a/apps/backend/src/config/configuration.ts
+++ b/apps/backend/src/config/configuration.ts
@@ -31,6 +31,11 @@ export interface AppConfig {
     dsn: string;
     environment: string;
   };
+  email: {
+    resendApiKey: string;
+    fromAddress: string;
+    enabled: boolean;
+  };
   oauth: {
     appUrl: string;
     frontendUrl: string;
@@ -48,6 +53,7 @@ export interface AppConfig {
 }
 
 export default (): AppConfig => {
+  const resendApiKey = process.env['RESEND_API_KEY'] ?? '';
   const googleClientId = process.env['GOOGLE_CLIENT_ID'] ?? '';
   const googleClientSecret = process.env['GOOGLE_CLIENT_SECRET'] ?? '';
   const githubClientId = process.env['GITHUB_CLIENT_ID'] ?? '';
@@ -81,6 +87,11 @@ export default (): AppConfig => {
     },
     encryption: {
       key: process.env['ENCRYPTION_KEY'] ?? '',
+    },
+    email: {
+      resendApiKey,
+      fromAddress: process.env['EMAIL_FROM'] ?? 'Tandemu <notifications@tandemu.com>',
+      enabled: !!resendApiKey,
     },
     sentry: {
       dsn: process.env['SENTRY_BACKEND_DSN'] ?? '',

--- a/apps/backend/src/email/email.listener.ts
+++ b/apps/backend/src/email/email.listener.ts
@@ -1,0 +1,226 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Queue } from 'bullmq';
+import { DatabaseService } from '../database/database.service.js';
+import type { EmailJobData } from '../queue/queue.types.js';
+import type {
+  InviteCreatedEvent,
+  InviteAcceptedEvent,
+  UserRegisteredEvent,
+  OrgMemberAddedEvent,
+  OrgMemberRemovedEvent,
+  TeamMemberAddedEvent,
+  IntegrationConnectedEvent,
+  EmailAliasAddedEvent,
+} from './email.types.js';
+
+@Injectable()
+export class EmailListener {
+  private readonly logger = new Logger(EmailListener.name);
+  private readonly enabled: boolean;
+  private readonly frontendUrl: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly db: DatabaseService,
+    @InjectQueue('email') private readonly emailQueue: Queue<EmailJobData>,
+  ) {
+    this.enabled = this.configService.get<boolean>('email.enabled', false);
+    this.frontendUrl = this.configService.get<string>('oauth.frontendUrl', 'http://localhost:3000');
+    if (this.enabled) {
+      this.logger.log('Email notifications enabled');
+    }
+  }
+
+  // ── Helpers ──
+
+  private async resolveUser(userId: string): Promise<{ email: string; name: string }> {
+    const result = await this.db.query<{ email: string; name: string }>(
+      'SELECT email, name FROM users WHERE id = $1',
+      [userId],
+    );
+    return result.rows[0] ?? { email: '', name: 'Unknown' };
+  }
+
+  private async resolveOrgName(orgId: string): Promise<string> {
+    const result = await this.db.query<{ name: string }>(
+      'SELECT name FROM organizations WHERE id = $1',
+      [orgId],
+    );
+    return result.rows[0]?.name ?? 'Unknown Organization';
+  }
+
+  private async resolveTeamName(teamId: string): Promise<string> {
+    const result = await this.db.query<{ name: string }>(
+      'SELECT name FROM teams WHERE id = $1',
+      [teamId],
+    );
+    return result.rows[0]?.name ?? 'Unknown Team';
+  }
+
+  private async resolveTeamOrgId(teamId: string): Promise<string> {
+    const result = await this.db.query<{ organization_id: string }>(
+      'SELECT organization_id FROM teams WHERE id = $1',
+      [teamId],
+    );
+    return result.rows[0]?.organization_id ?? '';
+  }
+
+  private async resolveAdminEmails(orgId: string): Promise<string[]> {
+    const result = await this.db.query<{ email: string }>(
+      `SELECT u.email FROM users u
+       INNER JOIN memberships m ON m.user_id = u.id
+       WHERE m.organization_id = $1 AND m.role IN ('owner', 'admin')`,
+      [orgId],
+    );
+    return result.rows.map((r) => r.email);
+  }
+
+  private enqueue(jobName: string, data: EmailJobData): void {
+    this.emailQueue.add(jobName, data).catch((err) => {
+      this.logger.error(`Failed to enqueue email job ${jobName}`, err);
+    });
+  }
+
+  // ── Event Handlers ──
+
+  @OnEvent('invite.created')
+  async handleInviteCreated(payload: InviteCreatedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [inviter, orgName] = await Promise.all([
+      this.resolveUser(payload.invitedBy),
+      this.resolveOrgName(payload.organizationId),
+    ]);
+    this.enqueue('invite-created', {
+      type: 'invite-created',
+      to: payload.email,
+      inviterName: inviter.name,
+      organizationName: orgName,
+      role: payload.role,
+      frontendUrl: this.frontendUrl,
+      inviteId: payload.inviteId,
+    });
+  }
+
+  @OnEvent('invite.accepted')
+  async handleInviteAccepted(payload: InviteAcceptedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [inviter, acceptor, orgName] = await Promise.all([
+      this.resolveUser(payload.invitedBy),
+      this.resolveUser(payload.acceptedByUserId),
+      this.resolveOrgName(payload.organizationId),
+    ]);
+    this.enqueue('invite-accepted', {
+      type: 'invite-accepted',
+      to: inviter.email,
+      acceptedByName: acceptor.name,
+      organizationName: orgName,
+    });
+  }
+
+  @OnEvent('user.registered')
+  async handleUserRegistered(payload: UserRegisteredEvent): Promise<void> {
+    if (!this.enabled) return;
+    const orgs: Array<{ name: string; role: string }> = [];
+    for (const orgId of payload.autoAcceptedOrgIds) {
+      const [orgName, membership] = await Promise.all([
+        this.resolveOrgName(orgId),
+        this.db.query<{ role: string }>(
+          'SELECT role FROM memberships WHERE user_id = $1 AND organization_id = $2',
+          [payload.userId, orgId],
+        ),
+      ]);
+      orgs.push({ name: orgName, role: (membership.rows[0]?.role ?? 'member').toUpperCase() });
+    }
+    this.enqueue('welcome', {
+      type: 'welcome',
+      to: payload.email,
+      userName: payload.name,
+      autoAcceptedOrgs: orgs,
+      frontendUrl: this.frontendUrl,
+    });
+  }
+
+  @OnEvent('organization.member_added')
+  async handleMemberAddedOrg(payload: OrgMemberAddedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [user, orgName] = await Promise.all([
+      this.resolveUser(payload.userId),
+      this.resolveOrgName(payload.organizationId),
+    ]);
+    this.enqueue('member-added-org', {
+      type: 'member-added-org',
+      to: user.email,
+      memberName: user.name,
+      organizationName: orgName,
+      role: payload.role.toUpperCase(),
+      frontendUrl: this.frontendUrl,
+    });
+  }
+
+  @OnEvent('organization.member_removed')
+  async handleMemberRemovedOrg(payload: OrgMemberRemovedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [user, orgName] = await Promise.all([
+      this.resolveUser(payload.userId),
+      this.resolveOrgName(payload.organizationId),
+    ]);
+    this.enqueue('member-removed-org', {
+      type: 'member-removed-org',
+      to: user.email,
+      memberName: user.name,
+      organizationName: orgName,
+    });
+  }
+
+  @OnEvent('team.member_added')
+  async handleMemberAddedTeam(payload: TeamMemberAddedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const orgId = payload.organizationId || await this.resolveTeamOrgId(payload.teamId);
+    const [user, teamName, orgName] = await Promise.all([
+      this.resolveUser(payload.userId),
+      this.resolveTeamName(payload.teamId),
+      this.resolveOrgName(orgId),
+    ]);
+    this.enqueue('member-added-team', {
+      type: 'member-added-team',
+      to: user.email,
+      memberName: user.name,
+      teamName,
+      organizationName: orgName,
+    });
+  }
+
+  @OnEvent('integration.connected')
+  async handleIntegrationConnected(payload: IntegrationConnectedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [connector, orgName, adminEmails] = await Promise.all([
+      this.resolveUser(payload.connectedByUserId),
+      this.resolveOrgName(payload.organizationId),
+      this.resolveAdminEmails(payload.organizationId),
+    ]);
+    if (adminEmails.length === 0) return;
+    this.enqueue('integration-connected', {
+      type: 'integration-connected',
+      to: adminEmails,
+      provider: payload.provider,
+      organizationName: orgName,
+      connectedByName: connector.name,
+      frontendUrl: this.frontendUrl,
+    });
+  }
+
+  @OnEvent('email_alias.added')
+  async handleEmailAliasAdded(payload: EmailAliasAddedEvent): Promise<void> {
+    if (!this.enabled) return;
+    const user = await this.resolveUser(payload.userId);
+    this.enqueue('email-alias-added', {
+      type: 'email-alias-added',
+      to: user.email,
+      userName: user.name,
+      aliasEmail: payload.aliasEmail,
+    });
+  }
+}

--- a/apps/backend/src/email/email.module.ts
+++ b/apps/backend/src/email/email.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { EmailService } from './email.service.js';
+import { EmailListener } from './email.listener.js';
+import { EmailProcessor } from './email.processor.js';
+
+@Module({
+  imports: [
+    BullModule.registerQueue({ name: 'email' }),
+  ],
+  providers: [EmailService, EmailListener, EmailProcessor],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/apps/backend/src/email/email.processor.ts
+++ b/apps/backend/src/email/email.processor.ts
@@ -1,0 +1,95 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import type { Job } from 'bullmq';
+import { EmailService } from './email.service.js';
+import type { EmailJobData } from '../queue/queue.types.js';
+import { renderInviteCreated } from './templates/invite-created.js';
+import { renderInviteAccepted } from './templates/invite-accepted.js';
+import { renderWelcome } from './templates/welcome.js';
+import { renderMemberAddedOrg } from './templates/member-added-org.js';
+import { renderMemberRemovedOrg } from './templates/member-removed-org.js';
+import { renderMemberAddedTeam } from './templates/member-added-team.js';
+import { renderIntegrationConnected } from './templates/integration-connected.js';
+import { renderEmailAliasAdded } from './templates/email-alias-added.js';
+
+@Processor('email')
+export class EmailProcessor extends WorkerHost {
+  private readonly logger = new Logger(EmailProcessor.name);
+
+  constructor(private readonly emailService: EmailService) {
+    super();
+  }
+
+  async process(job: Job<EmailJobData>): Promise<void> {
+    this.logger.log(`Processing email job: ${job.data.type}`);
+
+    switch (job.data.type) {
+      case 'invite-created':
+        await this.emailService.send(
+          job.data.to,
+          `You've been invited to ${job.data.organizationName}`,
+          renderInviteCreated(job.data),
+        );
+        break;
+
+      case 'invite-accepted':
+        await this.emailService.send(
+          job.data.to,
+          `${job.data.acceptedByName} accepted your invite`,
+          renderInviteAccepted(job.data),
+        );
+        break;
+
+      case 'welcome':
+        await this.emailService.send(
+          job.data.to,
+          'Welcome to Tandemu',
+          renderWelcome(job.data),
+        );
+        break;
+
+      case 'member-added-org':
+        await this.emailService.send(
+          job.data.to,
+          `You've been added to ${job.data.organizationName}`,
+          renderMemberAddedOrg(job.data),
+        );
+        break;
+
+      case 'member-removed-org':
+        await this.emailService.send(
+          job.data.to,
+          `You've been removed from ${job.data.organizationName}`,
+          renderMemberRemovedOrg(job.data),
+        );
+        break;
+
+      case 'member-added-team':
+        await this.emailService.send(
+          job.data.to,
+          `You've been added to ${job.data.teamName}`,
+          renderMemberAddedTeam(job.data),
+        );
+        break;
+
+      case 'integration-connected':
+        await this.emailService.send(
+          job.data.to,
+          `${job.data.provider} connected to ${job.data.organizationName}`,
+          renderIntegrationConnected(job.data),
+        );
+        break;
+
+      case 'email-alias-added':
+        await this.emailService.send(
+          job.data.to,
+          'Email alias added to your account',
+          renderEmailAliasAdded(job.data),
+        );
+        break;
+
+      default:
+        this.logger.warn(`Unknown email job type: ${(job.data as { type: string }).type}`);
+    }
+  }
+}

--- a/apps/backend/src/email/email.service.ts
+++ b/apps/backend/src/email/email.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+  private readonly resend: Resend | null;
+  private readonly from: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('email.resendApiKey', '');
+    this.from = this.configService.get<string>('email.fromAddress', 'Tandemu <notifications@tandemu.com>');
+    this.resend = apiKey ? new Resend(apiKey) : null;
+  }
+
+  async send(to: string | string[], subject: string, html: string): Promise<void> {
+    if (!this.resend) return;
+
+    const recipients = Array.isArray(to) ? to : [to];
+    try {
+      await this.resend.emails.send({
+        from: this.from,
+        to: recipients,
+        subject,
+        html,
+      });
+      this.logger.log(`Email sent to ${recipients.join(', ')}: ${subject}`);
+    } catch (error) {
+      this.logger.error(`Failed to send email to ${recipients.join(', ')}: ${subject}`, error);
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/email/email.types.ts
+++ b/apps/backend/src/email/email.types.ts
@@ -1,0 +1,53 @@
+// ── Event payloads (emitted by services, consumed by listener) ──
+
+export interface InviteCreatedEvent {
+  inviteId: string;
+  email: string;
+  organizationId: string;
+  invitedBy: string;
+  role: string;
+  teamId?: string;
+}
+
+export interface InviteAcceptedEvent {
+  inviteId: string;
+  invitedBy: string;
+  acceptedByUserId: string;
+  organizationId: string;
+}
+
+export interface UserRegisteredEvent {
+  userId: string;
+  email: string;
+  name: string;
+  autoAcceptedOrgIds: string[];
+}
+
+export interface OrgMemberAddedEvent {
+  organizationId: string;
+  userId: string;
+  email: string;
+  role: string;
+}
+
+export interface OrgMemberRemovedEvent {
+  organizationId: string;
+  userId: string;
+}
+
+export interface TeamMemberAddedEvent {
+  teamId: string;
+  userId: string;
+  organizationId: string;
+}
+
+export interface IntegrationConnectedEvent {
+  organizationId: string;
+  provider: string;
+  connectedByUserId: string;
+}
+
+export interface EmailAliasAddedEvent {
+  userId: string;
+  aliasEmail: string;
+}

--- a/apps/backend/src/email/templates/email-alias-added.ts
+++ b/apps/backend/src/email/templates/email-alias-added.ts
@@ -1,0 +1,17 @@
+import { emailLayout } from './layout.js';
+
+export function renderEmailAliasAdded(data: {
+  userName: string;
+  aliasEmail: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Email Alias Added</h2>
+    <p style="margin:0 0 12px; font-size:15px; color:#374151; line-height:1.6;">
+      Hi <strong>${data.userName}</strong>, the email address
+      <strong>${data.aliasEmail}</strong> has been added to your Tandemu account.
+    </p>
+    <p style="margin:0; font-size:13px; color:#6b7280;">
+      Tasks and commits linked to this email will now be attributed to you.
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/integration-connected.ts
+++ b/apps/backend/src/email/templates/integration-connected.ts
@@ -1,0 +1,22 @@
+import { emailLayout } from './layout.js';
+
+export function renderIntegrationConnected(data: {
+  provider: string;
+  organizationName: string;
+  connectedByName: string;
+  frontendUrl: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Integration Connected</h2>
+    <p style="margin:0 0 12px; font-size:15px; color:#374151; line-height:1.6;">
+      <strong>${data.connectedByName}</strong> connected <strong>${data.provider}</strong>
+      to <strong>${data.organizationName}</strong>.
+    </p>
+    <p style="margin:24px 0;">
+      <a href="${data.frontendUrl}/settings/integrations"
+         style="display:inline-block; padding:12px 24px; background:#6366f1; color:#ffffff; text-decoration:none; border-radius:6px; font-weight:600; font-size:14px;">
+        View Integrations
+      </a>
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/invite-accepted.ts
+++ b/apps/backend/src/email/templates/invite-accepted.ts
@@ -1,0 +1,14 @@
+import { emailLayout } from './layout.js';
+
+export function renderInviteAccepted(data: {
+  acceptedByName: string;
+  organizationName: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Invite Accepted</h2>
+    <p style="margin:0; font-size:15px; color:#374151; line-height:1.6;">
+      <strong>${data.acceptedByName}</strong> accepted your invite and joined
+      <strong>${data.organizationName}</strong>.
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/invite-created.ts
+++ b/apps/backend/src/email/templates/invite-created.ts
@@ -1,0 +1,26 @@
+import { emailLayout } from './layout.js';
+
+export function renderInviteCreated(data: {
+  inviterName: string;
+  organizationName: string;
+  role: string;
+  frontendUrl: string;
+  inviteId: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">You've been invited!</h2>
+    <p style="margin:0 0 12px; font-size:15px; color:#374151; line-height:1.6;">
+      <strong>${data.inviterName}</strong> invited you to join
+      <strong>${data.organizationName}</strong> as <strong>${data.role}</strong>.
+    </p>
+    <p style="margin:24px 0;">
+      <a href="${data.frontendUrl}/invites/${data.inviteId}"
+         style="display:inline-block; padding:12px 24px; background:#6366f1; color:#ffffff; text-decoration:none; border-radius:6px; font-weight:600; font-size:14px;">
+        Accept Invite
+      </a>
+    </p>
+    <p style="margin:0; font-size:13px; color:#6b7280;">
+      If you don't have a Tandemu account, you'll be asked to create one first.
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/layout.ts
+++ b/apps/backend/src/email/templates/layout.ts
@@ -1,0 +1,36 @@
+const BRAND_COLOR = '#6366f1';
+
+export function emailLayout(content: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0; padding:0; background:#f9fafb; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb; padding:32px 16px;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; overflow:hidden;">
+        <tr>
+          <td style="background:${BRAND_COLOR}; padding:24px 32px;">
+            <span style="font-size:20px; font-weight:700; color:#ffffff; letter-spacing:-0.5px;">Tandemu</span>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px;">
+            ${content}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:16px 32px; border-top:1px solid #e5e7eb;">
+            <p style="margin:0; font-size:12px; color:#9ca3af;">
+              This is a transactional email from Tandemu. You received it because of an action in your organization.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/apps/backend/src/email/templates/member-added-org.ts
+++ b/apps/backend/src/email/templates/member-added-org.ts
@@ -1,0 +1,22 @@
+import { emailLayout } from './layout.js';
+
+export function renderMemberAddedOrg(data: {
+  memberName: string;
+  organizationName: string;
+  role: string;
+  frontendUrl: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">You've been added to an organization</h2>
+    <p style="margin:0; font-size:15px; color:#374151; line-height:1.6;">
+      Hi <strong>${data.memberName}</strong>, you've been added to
+      <strong>${data.organizationName}</strong> as <strong>${data.role}</strong>.
+    </p>
+    <p style="margin:24px 0;">
+      <a href="${data.frontendUrl}"
+         style="display:inline-block; padding:12px 24px; background:#6366f1; color:#ffffff; text-decoration:none; border-radius:6px; font-weight:600; font-size:14px;">
+        Open Dashboard
+      </a>
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/member-added-team.ts
+++ b/apps/backend/src/email/templates/member-added-team.ts
@@ -1,0 +1,15 @@
+import { emailLayout } from './layout.js';
+
+export function renderMemberAddedTeam(data: {
+  memberName: string;
+  teamName: string;
+  organizationName: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Added to a team</h2>
+    <p style="margin:0; font-size:15px; color:#374151; line-height:1.6;">
+      Hi <strong>${data.memberName}</strong>, you've been added to the
+      <strong>${data.teamName}</strong> team in <strong>${data.organizationName}</strong>.
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/member-removed-org.ts
+++ b/apps/backend/src/email/templates/member-removed-org.ts
@@ -1,0 +1,17 @@
+import { emailLayout } from './layout.js';
+
+export function renderMemberRemovedOrg(data: {
+  memberName: string;
+  organizationName: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Organization Access Removed</h2>
+    <p style="margin:0; font-size:15px; color:#374151; line-height:1.6;">
+      Hi <strong>${data.memberName}</strong>, your access to
+      <strong>${data.organizationName}</strong> has been removed.
+    </p>
+    <p style="margin:16px 0 0; font-size:13px; color:#6b7280;">
+      If you believe this was a mistake, please contact your organization's administrator.
+    </p>
+  `);
+}

--- a/apps/backend/src/email/templates/welcome.ts
+++ b/apps/backend/src/email/templates/welcome.ts
@@ -1,0 +1,31 @@
+import { emailLayout } from './layout.js';
+
+export function renderWelcome(data: {
+  userName: string;
+  autoAcceptedOrgs: Array<{ name: string; role: string }>;
+  frontendUrl: string;
+}): string {
+  const orgList = data.autoAcceptedOrgs.length > 0
+    ? `
+      <p style="margin:16px 0 8px; font-size:15px; color:#374151;">
+        You've automatically joined:
+      </p>
+      <ul style="margin:0 0 16px; padding-left:20px; color:#374151; font-size:14px; line-height:1.8;">
+        ${data.autoAcceptedOrgs.map((o) => `<li><strong>${o.name}</strong> as ${o.role}</li>`).join('')}
+      </ul>`
+    : '';
+
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Welcome to Tandemu!</h2>
+    <p style="margin:0 0 12px; font-size:15px; color:#374151; line-height:1.6;">
+      Hi <strong>${data.userName}</strong>, your account is ready.
+    </p>
+    ${orgList}
+    <p style="margin:24px 0;">
+      <a href="${data.frontendUrl}"
+         style="display:inline-block; padding:12px 24px; background:#6366f1; color:#ffffff; text-decoration:none; border-radius:6px; font-weight:600; font-size:14px;">
+        Open Dashboard
+      </a>
+    </p>
+  `);
+}

--- a/apps/backend/src/integrations/integrations.controller.ts
+++ b/apps/backend/src/integrations/integrations.controller.ts
@@ -11,9 +11,11 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { IntegrationsService } from './integrations.service.js';
 import { TasksService } from './tasks.service.js';
 import { getProvider } from './providers/index.js';
+import type { IntegrationConnectedEvent } from '../email/email.types.js';
 import { JwtAuthGuard } from '../auth/auth.guard.js';
 import { RolesGuard } from '../auth/roles.guard.js';
 import { OrgRequiredGuard } from '../auth/org-required.guard.js';
@@ -32,6 +34,7 @@ export class IntegrationsController {
   constructor(
     private readonly integrationsService: IntegrationsService,
     private readonly tasksService: TasksService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   // Owner/Admin only — connect a ticket system
@@ -42,7 +45,13 @@ export class IntegrationsController {
     @CurrentUser() user: RequestUser,
     @Body() dto: CreateIntegrationDto,
   ) {
-    return this.integrationsService.create(user.organizationId, dto);
+    const result = await this.integrationsService.create(user.organizationId, dto);
+    this.eventEmitter.emit('integration.connected', {
+      organizationId: user.organizationId,
+      provider: dto.provider,
+      connectedByUserId: user.userId,
+    } satisfies IntegrationConnectedEvent);
+    return result;
   }
 
   // All members can view connected integrations

--- a/apps/backend/src/invites/invites.service.ts
+++ b/apps/backend/src/invites/invites.service.ts
@@ -4,12 +4,17 @@ import {
   ConflictException,
   ForbiddenException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DatabaseService } from '../database/database.service.js';
 import type { Invite, MembershipRole } from '@tandemu/types';
+import type { InviteCreatedEvent, InviteAcceptedEvent } from '../email/email.types.js';
 
 @Injectable()
 export class InvitesService {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
 
   async create(orgId: string, email: string, role: MembershipRole, invitedBy: string, teamId?: string): Promise<Invite> {
     // Check if user already exists and is already a member
@@ -47,7 +52,16 @@ export class InvitesService {
       [email, orgId, role.toLowerCase(), invitedBy, teamId ?? null],
     );
 
-    return this.mapInvite(result.rows[0]!);
+    const invite = this.mapInvite(result.rows[0]!);
+    this.eventEmitter.emit('invite.created', {
+      inviteId: invite.id,
+      email,
+      organizationId: orgId,
+      invitedBy,
+      role: invite.role,
+      teamId,
+    } satisfies InviteCreatedEvent);
+    return invite;
   }
 
   async findAllForOrg(orgId: string): Promise<Invite[]> {
@@ -141,6 +155,12 @@ export class InvitesService {
       return updatedInvite.rows[0]!;
     });
 
+    this.eventEmitter.emit('invite.accepted', {
+      inviteId,
+      invitedBy: invite.invited_by,
+      acceptedByUserId: userId,
+      organizationId: invite.organization_id,
+    } satisfies InviteAcceptedEvent);
     return this.mapInvite(result);
   }
 

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -222,6 +222,7 @@ export class OrganizationsService {
     );
 
     const row = result.rows[0]!;
+    this.eventEmitter.emit('organization.member_added', { organizationId: orgId, userId, email, role });
     this.eventEmitter.emit('organization.membership_changed', { organizationId: orgId });
     return {
       id: row.id,

--- a/apps/backend/src/queue/queue.module.ts
+++ b/apps/backend/src/queue/queue.module.ts
@@ -31,6 +31,15 @@ import { ConfigService } from '@nestjs/config';
           removeOnFail: { age: 86400 },
         },
       },
+      {
+        name: 'email',
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 2000 },
+          removeOnComplete: { age: 3600 },
+          removeOnFail: { age: 604800 },
+        },
+      },
     ),
   ],
   exports: [BullModule],

--- a/apps/backend/src/queue/queue.types.ts
+++ b/apps/backend/src/queue/queue.types.ts
@@ -73,3 +73,80 @@ export type TelemetryJobData =
   | OtlpTraceJob
   | OtlpMetricsJob
   | GitSelfHealJob;
+
+// ── email queue ──
+
+export interface InviteCreatedEmailJob {
+  readonly type: 'invite-created';
+  readonly to: string;
+  readonly inviterName: string;
+  readonly organizationName: string;
+  readonly role: string;
+  readonly frontendUrl: string;
+  readonly inviteId: string;
+}
+
+export interface InviteAcceptedEmailJob {
+  readonly type: 'invite-accepted';
+  readonly to: string;
+  readonly acceptedByName: string;
+  readonly organizationName: string;
+}
+
+export interface WelcomeEmailJob {
+  readonly type: 'welcome';
+  readonly to: string;
+  readonly userName: string;
+  readonly autoAcceptedOrgs: Array<{ name: string; role: string }>;
+  readonly frontendUrl: string;
+}
+
+export interface MemberAddedOrgEmailJob {
+  readonly type: 'member-added-org';
+  readonly to: string;
+  readonly memberName: string;
+  readonly organizationName: string;
+  readonly role: string;
+  readonly frontendUrl: string;
+}
+
+export interface MemberRemovedOrgEmailJob {
+  readonly type: 'member-removed-org';
+  readonly to: string;
+  readonly memberName: string;
+  readonly organizationName: string;
+}
+
+export interface MemberAddedTeamEmailJob {
+  readonly type: 'member-added-team';
+  readonly to: string;
+  readonly memberName: string;
+  readonly teamName: string;
+  readonly organizationName: string;
+}
+
+export interface IntegrationConnectedEmailJob {
+  readonly type: 'integration-connected';
+  readonly to: string[];
+  readonly provider: string;
+  readonly organizationName: string;
+  readonly connectedByName: string;
+  readonly frontendUrl: string;
+}
+
+export interface EmailAliasAddedEmailJob {
+  readonly type: 'email-alias-added';
+  readonly to: string;
+  readonly userName: string;
+  readonly aliasEmail: string;
+}
+
+export type EmailJobData =
+  | InviteCreatedEmailJob
+  | InviteAcceptedEmailJob
+  | WelcomeEmailJob
+  | MemberAddedOrgEmailJob
+  | MemberRemovedOrgEmailJob
+  | MemberAddedTeamEmailJob
+  | IntegrationConnectedEmailJob
+  | EmailAliasAddedEmailJob;

--- a/apps/backend/src/teams/teams.service.ts
+++ b/apps/backend/src/teams/teams.service.ts
@@ -3,8 +3,10 @@ import {
   NotFoundException,
   ConflictException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DatabaseService } from '../database/database.service.js';
 import type { Team, TeamSettings, CreateTeamDto, UpdateTeamDto } from '@tandemu/types';
+import type { TeamMemberAddedEvent } from '../email/email.types.js';
 
 const DEFAULT_TEAM_SETTINGS: Required<TeamSettings> = {
   doneWindowDays: 14,
@@ -12,7 +14,10 @@ const DEFAULT_TEAM_SETTINGS: Required<TeamSettings> = {
 
 @Injectable()
 export class TeamsService {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
 
   async create(orgId: string, dto: CreateTeamDto): Promise<Team> {
     const result = await this.db.query<TeamRow>(
@@ -145,6 +150,11 @@ export class TeamsService {
     );
 
     const row = result.rows[0]!;
+    this.eventEmitter.emit('team.member_added', {
+      teamId,
+      userId,
+      organizationId: orgId,
+    } satisfies TeamMemberAddedEvent);
     return {
       id: row.id,
       teamId: row.team_id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2
+      resend:
+        specifier: ^4.0.0
+        version: 4.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rxjs:
         specifier: ^7.8.0
         version: 7.8.2
@@ -2563,6 +2566,13 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/render@1.1.2':
+    resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
     peerDependencies:
@@ -2737,6 +2747,9 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@sentry-internal/browser-utils@10.46.0':
     resolution: {integrity: sha512-WB1gBT9G13V02ekZ6NpUhoI1aGHV2eNfjEPthkU2bGBvFpQKnstwzjg7waIRGR7cu+YSW2Q6UI6aQLgBeOPD1g==}
@@ -3811,6 +3824,19 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
     engines: {node: '>=12'}
@@ -3957,6 +3983,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -4100,6 +4130,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4340,6 +4373,13 @@ packages:
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
+
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -4622,6 +4662,9 @@ packages:
         optional: true
       ws:
         optional: true
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   libphonenumber-js@1.12.40:
     resolution: {integrity: sha512-HKGs7GowShNls3Zh+7DTr6wYpPk5jC78l508yQQY3e8ZgJChM3A9JZghmMJZuK+5bogSfuTafpjksGSR3aMIEg==}
@@ -5113,6 +5156,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5169,6 +5215,9 @@ packages:
 
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -5271,6 +5320,11 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5354,6 +5408,9 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -5452,6 +5509,10 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  resend@4.8.0:
+    resolution: {integrity: sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -5510,6 +5571,9 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -8408,6 +8472,14 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/render@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-promise-suspense: 0.3.4
+
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
@@ -8530,6 +8602,11 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@sentry-internal/browser-utils@10.46.0':
     dependencies:
@@ -9659,6 +9736,24 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv-expand@10.0.0: {}
 
   dotenv@16.4.5: {}
@@ -9723,6 +9818,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -9988,6 +10085,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-deep-equal@2.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.0: {}
@@ -10243,6 +10342,21 @@ snapshots:
   headers-polyfill@4.0.3: {}
 
   hono@4.12.8: {}
+
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-errors@2.0.1:
     dependencies:
@@ -10524,6 +10638,8 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.0)
       openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       ws: 8.19.0
+
+  leac@0.6.0: {}
 
   libphonenumber-js@1.12.40: {}
 
@@ -10985,6 +11101,11 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   parseurl@1.3.3: {}
 
   passport-google-oauth20@2.0.0:
@@ -11031,6 +11152,8 @@ snapshots:
   path-to-regexp@8.3.0: {}
 
   pause@0.0.1: {}
+
+  peberminta@0.9.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -11128,6 +11251,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  prettier@3.8.1: {}
 
   pretty-format@29.7.0:
     dependencies:
@@ -11284,6 +11409,10 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-promise-suspense@0.3.4:
+    dependencies:
+      fast-deep-equal: 2.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -11399,6 +11528,13 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  resend@4.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@react-email/render': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -11483,6 +11619,10 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## Summary
- Adds transactional email notifications for 8 important actions: invite sent/accepted, user registration, org/team membership changes, integration connections, email alias additions
- Uses Resend as email provider with BullMQ queue for reliable delivery (3 retries, exponential backoff)
- SaaS-only gating: entire system is a no-op when `RESEND_API_KEY` is not configured

## Architecture
```
Service emits event → EmailListener catches → resolves names from DB → enqueues to BullMQ 'email' queue → EmailProcessor renders HTML template → sends via Resend
```

## New files
- `apps/backend/src/email/` — module, service, listener, processor, types, 8 HTML templates

## Modified files
- Event emissions added to: InvitesService, AuthService, OrganizationsService, TeamsService, IntegrationsController
- Config: added `email` section with `RESEND_API_KEY` and `EMAIL_FROM`
- Queue: registered `email` queue with retry config

## Test plan
- [ ] Set `RESEND_API_KEY` to test key, create an invite → verify email delivered in Resend logs
- [ ] Accept invite → verify inviter gets notification
- [ ] Register new user with pending invite → verify welcome email with auto-accepted orgs
- [ ] Remove `RESEND_API_KEY` → verify no errors (graceful no-op)
- [ ] `pnpm --filter @tandemu/backend run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)