### PR TITLE
feat: invoice email notifications and history for org owners

### DIFF
--- a/apps/backend/src/email/email.listener.ts
+++ b/apps/backend/src/email/email.listener.ts
@@ -14,6 +14,7 @@ import type {
   TeamMemberAddedEvent,
   IntegrationConnectedEvent,
   EmailAliasAddedEvent,
+  InvoicePaidEvent,
 } from './email.types.js';
 
 @Injectable()
@@ -66,6 +67,17 @@ export class EmailListener {
       [teamId],
     );
     return result.rows[0]?.organization_id ?? '';
+  }
+
+  private async resolveOwnerEmail(orgId: string): Promise<string | null> {
+    const result = await this.db.query<{ email: string }>(
+      `SELECT u.email FROM users u
+       INNER JOIN memberships m ON m.user_id = u.id
+       WHERE m.organization_id = $1 AND m.role = 'owner'
+       LIMIT 1`,
+      [orgId],
+    );
+    return result.rows[0]?.email ?? null;
   }
 
   private async resolveAdminEmails(orgId: string): Promise<string[]> {
@@ -221,6 +233,31 @@ export class EmailListener {
       to: user.email,
       userName: user.name,
       aliasEmail: payload.aliasEmail,
+    });
+  }
+
+  @OnEvent('invoice.paid')
+  async handleInvoicePaid(payload: InvoicePaidEvent): Promise<void> {
+    if (!this.enabled) return;
+    const [ownerEmail, orgName] = await Promise.all([
+      this.resolveOwnerEmail(payload.organizationId),
+      this.resolveOrgName(payload.organizationId),
+    ]);
+    if (!ownerEmail) return;
+
+    const amount = (payload.amountPaid / 100).toFixed(2);
+    const currency = payload.currency.toUpperCase();
+    const start = new Date(payload.periodStart * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const end = new Date(payload.periodEnd * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    this.enqueue('invoice-paid', {
+      type: 'invoice-paid',
+      to: ownerEmail,
+      organizationName: orgName,
+      amountFormatted: `${currency} ${amount}`,
+      periodLabel: `${start} – ${end}`,
+      invoiceUrl: payload.invoiceUrl,
+      frontendUrl: this.frontendUrl,
     });
   }
 }

--- a/apps/backend/src/email/email.processor.ts
+++ b/apps/backend/src/email/email.processor.ts
@@ -11,6 +11,7 @@ import { renderMemberRemovedOrg } from './templates/member-removed-org.js';
 import { renderMemberAddedTeam } from './templates/member-added-team.js';
 import { renderIntegrationConnected } from './templates/integration-connected.js';
 import { renderEmailAliasAdded } from './templates/email-alias-added.js';
+import { renderInvoicePaid } from './templates/invoice-paid.js';
 
 @Processor('email')
 export class EmailProcessor extends WorkerHost {
@@ -85,6 +86,14 @@ export class EmailProcessor extends WorkerHost {
           job.data.to,
           'Email alias added to your account',
           renderEmailAliasAdded(job.data),
+        );
+        break;
+
+      case 'invoice-paid':
+        await this.emailService.send(
+          job.data.to,
+          `Invoice paid for ${job.data.organizationName}`,
+          renderInvoicePaid(job.data),
         );
         break;
 

--- a/apps/backend/src/email/email.types.ts
+++ b/apps/backend/src/email/email.types.ts
@@ -51,3 +51,12 @@ export interface EmailAliasAddedEvent {
   userId: string;
   aliasEmail: string;
 }
+
+export interface InvoicePaidEvent {
+  organizationId: string;
+  invoiceUrl: string;
+  amountPaid: number;
+  currency: string;
+  periodStart: number;
+  periodEnd: number;
+}

--- a/apps/backend/src/email/templates/invoice-paid.ts
+++ b/apps/backend/src/email/templates/invoice-paid.ts
@@ -1,0 +1,36 @@
+import { emailLayout } from './layout.js';
+
+export function renderInvoicePaid(data: {
+  organizationName: string;
+  amountFormatted: string;
+  periodLabel: string;
+  invoiceUrl: string;
+  frontendUrl: string;
+}): string {
+  return emailLayout(`
+    <h2 style="margin:0 0 16px; font-size:22px; color:#111827;">Invoice Paid</h2>
+    <p style="margin:0 0 12px; font-size:15px; color:#374151; line-height:1.6;">
+      Your subscription invoice for <strong>${data.organizationName}</strong> has been paid.
+    </p>
+    <table style="width:100%; border-collapse:collapse; margin:16px 0;">
+      <tr>
+        <td style="padding:8px 0; font-size:14px; color:#6b7280;">Amount</td>
+        <td style="padding:8px 0; font-size:14px; color:#111827; text-align:right; font-weight:600;">${data.amountFormatted}</td>
+      </tr>
+      <tr>
+        <td style="padding:8px 0; font-size:14px; color:#6b7280; border-top:1px solid #e5e7eb;">Period</td>
+        <td style="padding:8px 0; font-size:14px; color:#111827; text-align:right; border-top:1px solid #e5e7eb;">${data.periodLabel}</td>
+      </tr>
+    </table>
+    <p style="margin:24px 0;">
+      <a href="${data.invoiceUrl}"
+         style="display:inline-block; padding:12px 24px; background:#6366f1; color:#ffffff; text-decoration:none; border-radius:6px; font-weight:600; font-size:14px;">
+        View Invoice
+      </a>
+    </p>
+    <p style="margin:0; font-size:13px; color:#6b7280;">
+      You can also manage your subscription from the
+      <a href="${data.frontendUrl}/settings" style="color:#6366f1; text-decoration:none;">Settings</a> page.
+    </p>
+  `);
+}

--- a/apps/backend/src/queue/queue.types.ts
+++ b/apps/backend/src/queue/queue.types.ts
@@ -141,6 +141,16 @@ export interface EmailAliasAddedEmailJob {
   readonly aliasEmail: string;
 }
 
+export interface InvoicePaidEmailJob {
+  readonly type: 'invoice-paid';
+  readonly to: string;
+  readonly organizationName: string;
+  readonly amountFormatted: string;
+  readonly periodLabel: string;
+  readonly invoiceUrl: string;
+  readonly frontendUrl: string;
+}
+
 export type EmailJobData =
   | InviteCreatedEmailJob
   | InviteAcceptedEmailJob
@@ -149,4 +159,5 @@ export type EmailJobData =
   | MemberRemovedOrgEmailJob
   | MemberAddedTeamEmailJob
   | IntegrationConnectedEmailJob
-  | EmailAliasAddedEmailJob;
+  | EmailAliasAddedEmailJob
+  | InvoicePaidEmailJob;

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -19,7 +19,9 @@ import {
   getTeams,
   createCheckout,
   createBillingPortal,
+  getInvoices,
 } from '@/lib/api';
+import type { Invoice } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 import type { Organization, Membership, Invite, Team } from '@tandemu/types';
 
@@ -44,7 +46,7 @@ function RoleBadge({ role }: { role: string }) {
 }
 
 export default function SettingsPage() {
-  const { currentOrg: authOrg } = useAuth();
+  const { currentOrg: authOrg, user: authUser } = useAuth();
   const [org, setOrg] = useState<Organization | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -66,6 +68,9 @@ export default function SettingsPage() {
   // Memory settings
   const [editDraftRetention, setEditDraftRetention] = useState(30);
   const [savingMemory, setSavingMemory] = useState(false);
+
+  // Invoices (OWNER only)
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
 
   // Invite dialog
   const [showInviteDialog, setShowInviteDialog] = useState(false);
@@ -89,6 +94,11 @@ export default function SettingsPage() {
       setMembers(memberList);
       setInvitesList(invites);
       setTeams(teamList);
+
+      // Load invoices for OWNER only
+      if (process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' && activeOrg.planTier !== 'FREE') {
+        getInvoices().then(setInvoices).catch(() => {});
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to load settings');
     }
@@ -396,6 +406,68 @@ export default function SettingsPage() {
                 Manage Billing
               </Button>
             )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Invoice History — OWNER only, paid plans only */}
+      {org && process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' && org.planTier !== 'FREE' && authUser?.role === 'OWNER' && invoices.length > 0 && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CreditCard className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <CardTitle>Invoices</CardTitle>
+                <CardDescription>Your recent billing history.</CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Period</TableHead>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Invoice</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {invoices.map((inv) => (
+                  <TableRow key={inv.id}>
+                    <TableCell className="text-sm">
+                      {new Date(inv.createdAt * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {new Date(inv.periodStart * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                      {' – '}
+                      {new Date(inv.periodEnd * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                    </TableCell>
+                    <TableCell className="text-sm font-medium">
+                      {inv.currency.toUpperCase()} {(inv.amountPaid / 100).toFixed(2)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={inv.status === 'paid' ? 'default' : 'secondary'} className="text-xs">
+                        {inv.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {inv.hostedInvoiceUrl && (
+                        <a
+                          href={inv.hostedInvoiceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-primary hover:underline"
+                        >
+                          View
+                        </a>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           </CardContent>
         </Card>
       )}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -566,6 +566,21 @@ export async function createBillingPortal(data: {
   });
 }
 
+export interface Invoice {
+  id: string;
+  amountPaid: number;
+  currency: string;
+  status: string;
+  hostedInvoiceUrl: string | null;
+  periodStart: number;
+  periodEnd: number;
+  createdAt: number;
+}
+
+export async function getInvoices(): Promise<Invoice[]> {
+  return fetchApi<Invoice[]>("/api/billing/invoices");
+}
+
 // ---- Memory ----
 
 export type MemoryScope = 'personal' | 'org';


### PR DESCRIPTION
## Summary
- Handles `invoice.payment_succeeded` Stripe webhook → sends email with invoice link to **org owner only**
- Adds `GET /api/billing/invoices` endpoint (OWNER-gated) returning last 12 invoices from Stripe
- Adds invoice history table on settings page (OWNER only, paid plans only) with date, period, amount, status, and link to Stripe hosted invoice

**Note:** The SaaS billing service changes (webhook handler + `listInvoices()`) are in tandemu-platform and need to be committed there separately.

## Test plan
- [ ] Trigger test invoice in Stripe dashboard → verify webhook fires and email sent to org owner
- [ ] Verify non-owner users don't see invoice section on settings page
- [ ] Verify `GET /api/billing/invoices` returns 403 for non-OWNER roles
- [ ] `pnpm --filter @tandemu/backend run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)