### PR TITLE
feat: show ⌘K shortcut hint in header search input

### DIFF
--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -318,6 +318,9 @@ export function Header() {
             >
               <Search className="h-4 w-4 shrink-0 opacity-50" />
               <span className="flex-1 text-left">Search...</span>
+              <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:flex">
+                <span className="text-xs">⌘</span>K
+              </kbd>
             </button>
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary
- Adds a `⌘K` keyboard shortcut badge inside the header search button so users discover the command palette shortcut

## Test plan
- [ ] Verify the ⌘K badge appears in the header search button on desktop viewports
- [ ] Verify it's hidden on mobile (sm:flex)
- [ ] Verify clicking the search button still opens the command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)