### PR TITLE
feat: add remove member button on org settings page

### DIFF
--- a/apps/backend/src/organizations/organizations.controller.ts
+++ b/apps/backend/src/organizations/organizations.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   HttpCode,
   HttpStatus,
@@ -95,9 +96,13 @@ export class OrganizationsController {
   @Roles(MembershipRole.OWNER, MembershipRole.ADMIN)
   @HttpCode(HttpStatus.NO_CONTENT)
   async removeMember(
+    @CurrentUser() user: RequestUser,
     @Param('id') id: string,
     @Param('userId') userId: string,
   ): Promise<void> {
+    if (userId === user.userId) {
+      throw new ForbiddenException('Cannot remove yourself from the organization');
+    }
     const removed = await this.organizationsService.removeMember(id, userId);
     if (!removed) {
       throw new NotFoundException('Membership not found');

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  ForbiddenException,
   NotFoundException,
   ConflictException,
 } from '@nestjs/common';
@@ -177,6 +178,13 @@ export class OrganizationsService {
   }
 
   async removeMember(orgId: string, userId: string): Promise<boolean> {
+    const membership = await this.db.query<{ role: string }>(
+      'SELECT role FROM memberships WHERE organization_id = $1 AND user_id = $2',
+      [orgId, userId],
+    );
+    if (membership.rows.length > 0 && membership.rows[0]!.role.toUpperCase() === 'OWNER') {
+      throw new ForbiddenException('Cannot remove the organization owner');
+    }
     const result = await this.db.query(
       'DELETE FROM memberships WHERE organization_id = $1 AND user_id = $2',
       [orgId, userId],

--- a/apps/backend/src/teams/teams-cleanup.listener.ts
+++ b/apps/backend/src/teams/teams-cleanup.listener.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { DatabaseService } from '../database/database.service.js';
+
+@Injectable()
+export class TeamsCleanupListener {
+  private readonly logger = new Logger(TeamsCleanupListener.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  @OnEvent('organization.member_removed')
+  async handleMemberRemoved(payload: { organizationId: string; userId: string }): Promise<void> {
+    this.logger.log(`Removing user ${payload.userId} from all teams in org ${payload.organizationId}`);
+    const result = await this.db.query(
+      `DELETE FROM team_members
+       WHERE user_id = $1
+         AND team_id IN (SELECT id FROM teams WHERE organization_id = $2)`,
+      [payload.userId, payload.organizationId],
+    );
+    this.logger.log(`Removed ${result.rowCount ?? 0} team membership(s)`);
+  }
+}

--- a/apps/backend/src/teams/teams.module.ts
+++ b/apps/backend/src/teams/teams.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TeamsController } from './teams.controller.js';
 import { TeamsService } from './teams.service.js';
+import { TeamsCleanupListener } from './teams-cleanup.listener.js';
 import { AuthModule } from '../auth/auth.module.js';
 
 @Module({
   imports: [AuthModule],
   controllers: [TeamsController],
-  providers: [TeamsService],
+  providers: [TeamsService, TeamsCleanupListener],
   exports: [TeamsService],
 })
 export class TeamsModule {}

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -7,13 +7,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Building2, Users, Save, Plus, CreditCard, Lightbulb, Brain } from 'lucide-react';
+import { Building2, Users, Save, Plus, CreditCard, Lightbulb, Brain, Trash2 } from 'lucide-react';
 import { SettingsSkeleton } from '@/components/ui/skeleton-helpers';
 import { InviteDialog } from '@/components/invite-dialog';
+import { RemoveMemberDialog } from '@/components/remove-member-dialog';
 import { toast } from 'sonner';
 import {
   updateOrganization,
   getMembers,
+  removeMember,
   getInvites,
   cancelInvite,
   getTeams,
@@ -46,7 +48,7 @@ function RoleBadge({ role }: { role: string }) {
 }
 
 export default function SettingsPage() {
-  const { currentOrg: authOrg, user: authUser } = useAuth();
+  const { currentOrg: authOrg, user: authUser, isAdmin } = useAuth();
   const [org, setOrg] = useState<Organization | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -59,6 +61,7 @@ export default function SettingsPage() {
   const [members, setMembers] = useState<Membership[]>([]);
   const [invitesList, setInvitesList] = useState<Invite[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
+  const [removingMember, setRemovingMember] = useState<{ id: string; name: string } | null>(null);
 
   // ROI settings
   const [editHourlyRate, setEditHourlyRate] = useState(75);
@@ -522,7 +525,8 @@ export default function SettingsPage() {
                   <TableRow>
                     <TableHead>Name</TableHead>
                     <TableHead>Email</TableHead>
-                    <TableHead className="text-right">Role</TableHead>
+                    <TableHead className={isAdmin ? '' : 'text-right'}>Role</TableHead>
+                    {isAdmin && <TableHead className="text-right">Actions</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -530,9 +534,23 @@ export default function SettingsPage() {
                     <TableRow key={m.id}>
                       <TableCell className="font-medium">{m.name}</TableCell>
                       <TableCell className="text-muted-foreground">{m.email}</TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className={isAdmin ? '' : 'text-right'}>
                         <RoleBadge role={m.role} />
                       </TableCell>
+                      {isAdmin && (
+                        <TableCell className="text-right">
+                          {m.role !== 'OWNER' && m.id !== authUser?.id && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setRemovingMember({ id: m.id, name: m.name })}
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          )}
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))}
                 </TableBody>
@@ -603,6 +621,21 @@ export default function SettingsPage() {
           orgId={org.id}
           teams={teams}
           onInvitesSent={setInvitesList}
+        />
+      )}
+
+      {/* Remove Member Dialog */}
+      {org && removingMember && (
+        <RemoveMemberDialog
+          open={!!removingMember}
+          onOpenChange={(open) => { if (!open) setRemovingMember(null); }}
+          orgId={org.id}
+          memberId={removingMember.id}
+          memberName={removingMember.name}
+          onRemoved={() => {
+            setMembers(members.filter((m: any) => m.id !== removingMember.id));
+            setRemovingMember(null);
+          }}
         />
       )}
     </div>

--- a/apps/frontend/src/components/remove-member-dialog.tsx
+++ b/apps/frontend/src/components/remove-member-dialog.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { removeMember } from '@/lib/api';
+
+interface RemoveMemberDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  memberId: string;
+  memberName: string;
+  onRemoved: () => void;
+}
+
+export function RemoveMemberDialog({ open, onOpenChange, orgId, memberId, memberName, onRemoved }: RemoveMemberDialogProps) {
+  const [removing, setRemoving] = useState(false);
+
+  const handleRemove = async () => {
+    setRemoving(true);
+    try {
+      await removeMember(orgId, memberId);
+      onOpenChange(false);
+      onRemoved();
+      toast.success(`${memberName} has been removed.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove member');
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove Member</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to remove <span className="font-medium text-foreground">{memberName}</span>? They will be removed from all teams in this organization.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <div className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+            <AlertTriangle className="h-4 w-4 mt-0.5 text-destructive flex-shrink-0" />
+            <p className="text-sm text-destructive">This action cannot be undone.</p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button variant="destructive" onClick={handleRemove} disabled={removing}>
+            {removing ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              'Remove Member'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -160,6 +160,12 @@ export async function getMembers(orgId: string): Promise<Membership[]> {
   return fetchApi<Membership[]>(`/api/organizations/${orgId}/members`);
 }
 
+export async function removeMember(orgId: string, userId: string): Promise<void> {
+  return fetchApi<void>(`/api/organizations/${orgId}/members/${userId}`, {
+    method: 'DELETE',
+  });
+}
+
 // ---- Telemetry ----
 
 export interface TelemetryFilter {


### PR DESCRIPTION
## Summary
- Add a remove member button to the organization settings page (SGS-158)
- Backend: event listener cascades member removal to all org teams, guards prevent self-removal and owner removal
- Frontend: confirmation dialog, admin-only visibility, optimistic UI update

## Test plan
- [ ] As OWNER: verify remove buttons appear on non-owner members
- [ ] Click remove → confirmation dialog → member disappears from list
- [ ] Verify removed member is also removed from all org teams
- [ ] As MEMBER: verify no remove buttons are visible
- [ ] API: `DELETE /organizations/:id/members/:userId` with self or owner → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)