### PR TITLE
feat: add subtask support across all task providers

### DIFF
--- a/apps/backend/src/integrations/providers/asana.provider.ts
+++ b/apps/backend/src/integrations/providers/asana.provider.ts
@@ -8,6 +8,7 @@ import type {
   TaskProvider,
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
+  TaskProviderFetchSubtasksParams,
   TaskProviderUpdateParams,
   TaskProviderCreateParams,
   ExternalProject,
@@ -87,6 +88,8 @@ interface AsanaTask {
   tags: Array<{ name: string }>;
   modified_at: string;
   permalink_url: string;
+  parent?: { gid: string } | null;
+  num_subtasks?: number;
 }
 
 interface AsanaSection {
@@ -115,10 +118,13 @@ function mapTask(task: AsanaTask, externalProjectId: string): Task {
     provider: 'asana',
     externalProjectId,
     updatedAt: task.modified_at,
+    parentId: task.parent?.gid ?? undefined,
+    hasSubtasks: (task.num_subtasks ?? 0) > 0,
+    subtaskCount: task.num_subtasks ?? 0,
   };
 }
 
-const TASK_OPT_FIELDS = 'gid,name,notes,completed,assignee,assignee.email,assignee.name,memberships.project.gid,memberships.project.name,memberships.section.gid,memberships.section.name,custom_fields,tags.name,modified_at,permalink_url';
+const TASK_OPT_FIELDS = 'gid,name,notes,completed,assignee,assignee.email,assignee.name,memberships.project.gid,memberships.project.name,memberships.section.gid,memberships.section.name,custom_fields,tags.name,modified_at,permalink_url,parent,num_subtasks';
 
 export class AsanaProvider implements TaskProvider {
   async fetchTasks(params: TaskProviderFetchParams): Promise<Task[]> {
@@ -332,5 +338,20 @@ export class AsanaProvider implements TaskProvider {
     } catch {
       return [];
     }
+  }
+
+  async fetchSubtasks(params: TaskProviderFetchSubtasksParams): Promise<Task[]> {
+    const { accessToken, taskId } = params;
+
+    const subtasks = await asanaFetch<AsanaTask[]>(
+      `/tasks/${taskId}/subtasks?opt_fields=${TASK_OPT_FIELDS}`,
+      accessToken,
+    );
+
+    // Subtasks may belong to a project via memberships; use the first project GID if available
+    return subtasks.map((task) => {
+      const projectGid = task.memberships?.[0]?.project?.gid ?? '';
+      return mapTask(task, projectGid);
+    });
   }
 }

--- a/apps/backend/src/integrations/providers/clickup.provider.ts
+++ b/apps/backend/src/integrations/providers/clickup.provider.ts
@@ -8,6 +8,7 @@ import type {
   TaskProvider,
   TaskProviderFetchParams,
   TaskProviderFetchProjectsParams,
+  TaskProviderFetchSubtasksParams,
   TaskProviderUpdateParams,
   TaskProviderCreateParams,
   ExternalProject,
@@ -71,6 +72,7 @@ interface ClickUpTask {
   date_updated: string;
   list: { id: string; name: string };
   sprint_id?: string;
+  parent?: string | null;
 }
 
 interface ClickUpTasksResponse {
@@ -106,7 +108,22 @@ function mapTask(task: ClickUpTask, externalProjectId: string): Task {
     provider: 'clickup',
     externalProjectId,
     updatedAt: new Date(parseInt(task.date_updated, 10)).toISOString(),
+    parentId: task.parent ?? undefined,
   };
+}
+
+function enrichSubtaskCounts(tasks: Task[]): Task[] {
+  const childCounts = new Map<string, number>();
+  for (const t of tasks) {
+    if (t.parentId) {
+      childCounts.set(t.parentId, (childCounts.get(t.parentId) ?? 0) + 1);
+    }
+  }
+  return tasks.map((t) => ({
+    ...t,
+    hasSubtasks: (childCounts.get(t.id) ?? 0) > 0,
+    subtaskCount: childCounts.get(t.id) ?? 0,
+  }));
 }
 
 export class ClickUpProvider implements TaskProvider {
@@ -156,7 +173,8 @@ export class ClickUpProvider implements TaskProvider {
       );
     }
 
-    return allTasks.map((task) => mapTask(task, externalProjectId));
+    const mapped = allTasks.map((task) => mapTask(task, externalProjectId));
+    return enrichSubtaskCounts(mapped);
   }
 
   async getTaskStatuses(params: { accessToken: string; taskId: string; config: Record<string, unknown> }): Promise<ProviderStatus[]> {
@@ -243,6 +261,21 @@ export class ClickUpProvider implements TaskProvider {
     }
     const task = (await res.json()) as ClickUpTask;
     return mapTask(task, externalProjectId);
+  }
+
+  async fetchSubtasks(params: TaskProviderFetchSubtasksParams): Promise<Task[]> {
+    const { accessToken, taskId } = params;
+
+    const task = await clickupFetch<ClickUpTask & { subtasks?: ClickUpTask[] }>(
+      `${CLICKUP_API}/task/${taskId}?include_subtasks=true`,
+      accessToken,
+    );
+
+    const subtasks = task.subtasks ?? [];
+    // Use the parent task's list as the externalProjectId context
+    const externalProjectId = task.list.id;
+    const mapped = subtasks.map((st) => mapTask(st, externalProjectId));
+    return enrichSubtaskCounts(mapped);
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/jira.provider.ts
+++ b/apps/backend/src/integrations/providers/jira.provider.ts
@@ -10,6 +10,7 @@ import type {
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
   TaskProviderCreateParams,
+  TaskProviderFetchSubtasksParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -69,6 +70,8 @@ interface JiraIssue {
     labels: string[];
     sprint?: { name: string };
     updated: string;
+    parent?: { key: string };
+    subtasks?: Array<{ key: string }>;
   };
 }
 
@@ -113,27 +116,11 @@ export class JiraProvider implements TaskProvider {
       jql += ' AND statusCategory != "Done"';
     }
 
-    const url = `${baseUrl}/search?jql=${encodeURIComponent(jql)}&maxResults=100&fields=summary,description,status,priority,assignee,labels,sprint,updated`;
+    const url = `${baseUrl}/search?jql=${encodeURIComponent(jql)}&maxResults=100&fields=summary,description,status,priority,assignee,labels,sprint,updated,subtasks,parent`;
 
     const data = await jiraFetch<JiraSearchResponse>(url, accessToken);
 
-    return data.issues.map((issue): Task => ({
-      id: issue.key,
-      title: issue.fields.summary,
-      description: issue.fields.description
-        ? JSON.stringify(issue.fields.description)
-        : undefined,
-      status: mapStatus(issue.fields.status.name),
-      priority: mapPriority(issue.fields.priority?.name),
-      assigneeName: issue.fields.assignee?.displayName,
-      assigneeEmail: issue.fields.assignee?.emailAddress,
-      labels: issue.fields.labels,
-      sprint: issue.fields.sprint?.name,
-      url: `https://${siteId}.atlassian.net/browse/${issue.key}`,
-      provider: 'jira',
-      externalProjectId,
-      updatedAt: issue.fields.updated,
-    }));
+    return data.issues.map((issue) => this.mapTask(issue, siteId, externalProjectId));
   }
 
   async getTaskStatuses(params: { accessToken: string; taskId: string; config: Record<string, unknown> }): Promise<ProviderStatus[]> {
@@ -280,6 +267,48 @@ export class JiraProvider implements TaskProvider {
       externalProjectId,
       updatedAt: new Date().toISOString(),
     };
+  }
+
+  private mapTask(issue: JiraIssue, siteId: string, externalProjectId: string): Task {
+    return {
+      id: issue.key,
+      title: issue.fields.summary,
+      description: issue.fields.description
+        ? JSON.stringify(issue.fields.description)
+        : undefined,
+      status: mapStatus(issue.fields.status.name),
+      priority: mapPriority(issue.fields.priority?.name),
+      assigneeName: issue.fields.assignee?.displayName,
+      assigneeEmail: issue.fields.assignee?.emailAddress,
+      labels: issue.fields.labels,
+      sprint: issue.fields.sprint?.name,
+      url: `https://${siteId}.atlassian.net/browse/${issue.key}`,
+      provider: 'jira',
+      externalProjectId,
+      updatedAt: issue.fields.updated,
+      parentId: issue.fields.parent?.key ?? undefined,
+      hasSubtasks: (issue.fields.subtasks?.length ?? 0) > 0,
+      subtaskCount: issue.fields.subtasks?.length ?? 0,
+    };
+  }
+
+  async fetchSubtasks(params: TaskProviderFetchSubtasksParams): Promise<Task[]> {
+    const { accessToken, taskId, config } = params;
+    const siteId = config.siteId as string | undefined;
+    if (!siteId) {
+      throw new BadGatewayException('Jira integration requires a siteId in config');
+    }
+
+    const baseUrl = `https://${siteId}.atlassian.net/rest/api/3`;
+    const jql = `parent=${taskId}`;
+    const url = `${baseUrl}/search?jql=${encodeURIComponent(jql)}&maxResults=100&fields=summary,description,status,priority,assignee,labels,sprint,updated,subtasks,parent`;
+
+    const data = await jiraFetch<JiraSearchResponse>(url, accessToken);
+
+    // Derive project key from the parent taskId (e.g., "PROJ-123" → "PROJ")
+    const externalProjectId = taskId.split('-')[0] ?? taskId;
+
+    return data.issues.map((issue) => this.mapTask(issue, siteId, externalProjectId));
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/linear.provider.ts
+++ b/apps/backend/src/integrations/providers/linear.provider.ts
@@ -10,6 +10,7 @@ import type {
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
   TaskProviderCreateParams,
+  TaskProviderFetchSubtasksParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -79,6 +80,8 @@ interface LinearIssueNode {
   assignee: { name: string; email: string } | null;
   labels: { nodes: Array<{ name: string }> };
   cycle: { name: string | null; number: number } | null;
+  parent?: { identifier: string } | null;
+  children?: { nodes: Array<{ identifier: string }> };
   url: string;
   updatedAt: string;
 }
@@ -137,6 +140,8 @@ export class LinearProvider implements TaskProvider {
             assignee { name email }
             labels { nodes { name } }
             cycle { name number }
+            parent { identifier }
+            children { nodes { identifier } }
             url
             updatedAt
           }
@@ -162,6 +167,9 @@ export class LinearProvider implements TaskProvider {
       provider: 'linear',
       externalProjectId,
       updatedAt: issue.updatedAt,
+      parentId: issue.parent?.identifier ?? undefined,
+      hasSubtasks: (issue.children?.nodes?.length ?? 0) > 0,
+      subtaskCount: issue.children?.nodes?.length ?? 0,
     }));
   }
 
@@ -317,6 +325,76 @@ export class LinearProvider implements TaskProvider {
       externalProjectId,
       updatedAt: issue.updatedAt,
     };
+  }
+
+  async fetchSubtasks(params: TaskProviderFetchSubtasksParams): Promise<Task[]> {
+    const { accessToken, taskId } = params;
+
+    const match = taskId.match(/^([A-Z]+)-(\d+)$/);
+    if (!match) return [];
+
+    const [, teamKey, numberStr] = match;
+    const number = parseInt(numberStr, 10);
+
+    const data = await linearFetch<{
+      issues: {
+        nodes: Array<{
+          children: {
+            nodes: LinearIssueNode[];
+          };
+          team: { id: string };
+        }>;
+      };
+    }>(accessToken, `
+      query {
+        issues(filter: { number: { eq: ${number} }, team: { key: { eq: "${teamKey}" } } }, first: 1) {
+          nodes {
+            team { id }
+            children {
+              nodes {
+                identifier
+                title
+                description
+                state { name }
+                priority
+                assignee { name email }
+                labels { nodes { name } }
+                cycle { name number }
+                parent { identifier }
+                children { nodes { identifier } }
+                url
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const parentIssue = data.issues.nodes[0];
+    if (!parentIssue) return [];
+
+    const externalProjectId = parentIssue.team.id;
+    return parentIssue.children.nodes.map((issue): Task => ({
+      id: issue.identifier,
+      title: issue.title,
+      description: issue.description ?? undefined,
+      status: mapStatus(issue.state.name),
+      priority: mapPriority(issue.priority),
+      assigneeName: issue.assignee?.name,
+      assigneeEmail: issue.assignee?.email,
+      labels: issue.labels.nodes.map((l) => l.name),
+      sprint: issue.cycle
+        ? issue.cycle.name ?? `Cycle ${issue.cycle.number}`
+        : undefined,
+      url: issue.url,
+      provider: 'linear',
+      externalProjectId,
+      updatedAt: issue.updatedAt,
+      parentId: issue.parent?.identifier ?? undefined,
+      hasSubtasks: (issue.children?.nodes?.length ?? 0) > 0,
+      subtaskCount: issue.children?.nodes?.length ?? 0,
+    }));
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/monday.provider.ts
+++ b/apps/backend/src/integrations/providers/monday.provider.ts
@@ -10,6 +10,7 @@ import type {
   TaskProviderFetchProjectsParams,
   TaskProviderUpdateParams,
   TaskProviderCreateParams,
+  TaskProviderFetchSubtasksParams,
   ExternalProject,
   ProviderStatus,
 } from './task-provider.interface.js';
@@ -84,6 +85,8 @@ interface MondayItem {
   group: { id: string; title: string };
   updated_at: string;
   url: string;
+  parent_item?: { id: string } | null;
+  subitems_page?: { items: Array<{ id: string }> };
 }
 
 interface MondayUser {
@@ -163,6 +166,8 @@ export class MondayProvider implements TaskProvider {
               group { id title }
               updated_at
               url
+              parent_item { id }
+              subitems_page(limit: 10) { items { id } }
             }
           }
         }
@@ -225,6 +230,9 @@ export class MondayProvider implements TaskProvider {
       provider: 'monday',
       externalProjectId,
       updatedAt: item.updated_at,
+      parentId: item.parent_item?.id ?? undefined,
+      hasSubtasks: (item.subitems_page?.items?.length ?? 0) > 0,
+      subtaskCount: item.subitems_page?.items?.length ?? 0,
     };
   }
 
@@ -387,6 +395,67 @@ export class MondayProvider implements TaskProvider {
       externalProjectId,
       updatedAt: new Date().toISOString(),
     };
+  }
+
+  async fetchSubtasks(params: TaskProviderFetchSubtasksParams): Promise<Task[]> {
+    const { accessToken, taskId } = params;
+
+    const data = await mondayQuery<{
+      items: Array<{
+        board: { id: string };
+        subitems_page: { items: MondayItem[] };
+      }>;
+    }>(
+      accessToken,
+      `query ($itemId: [ID!]!) {
+        items(ids: $itemId) {
+          board { id }
+          subitems_page(limit: 100) {
+            items {
+              id
+              name
+              column_values {
+                id
+                title
+                text
+                type
+                value
+              }
+              group { id title }
+              updated_at
+            }
+          }
+        }
+      }`,
+      { itemId: [taskId] },
+    );
+
+    const item = data.items[0];
+    if (!item) return [];
+
+    const boardId = item.board.id;
+
+    // Resolve assignees for subitems
+    let userMap: Map<number, MondayUser> | undefined;
+    const allAssigneeIds = new Set<number>();
+    item.subitems_page.items.forEach((sub) =>
+      getAssigneeIds(sub).forEach((id) => allAssigneeIds.add(id)),
+    );
+    if (allAssigneeIds.size > 0) {
+      userMap = await this.fetchUserMap(accessToken);
+    }
+
+    return item.subitems_page.items.map((sub) => {
+      const assigneeIds = getAssigneeIds(sub);
+      const assignee = assigneeIds.length > 0 && userMap ? userMap.get(assigneeIds[0]) : undefined;
+      // Monday doesn't support sub-subitems
+      return {
+        ...this.mapItem(sub, boardId, assignee),
+        parentId: taskId,
+        hasSubtasks: false,
+        subtaskCount: 0,
+      };
+    });
   }
 
   async fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]> {

--- a/apps/backend/src/integrations/providers/task-provider.interface.ts
+++ b/apps/backend/src/integrations/providers/task-provider.interface.ts
@@ -48,6 +48,12 @@ export interface TaskProviderCreateParams {
   config: Record<string, unknown>;
 }
 
+export interface TaskProviderFetchSubtasksParams {
+  accessToken: string;
+  taskId: string;
+  config: Record<string, unknown>;
+}
+
 export interface TaskProvider {
   fetchTasks(params: TaskProviderFetchParams): Promise<Task[]>;
   fetchProjects(params: TaskProviderFetchProjectsParams): Promise<ExternalProject[]>;
@@ -56,4 +62,6 @@ export interface TaskProvider {
   createTask(params: TaskProviderCreateParams): Promise<Task>;
   /** Optional: fetch sub-projects within a project (e.g. Linear projects in a team, ClickUp lists in a folder) */
   fetchSubProjects?(accessToken: string, projectId: string, config?: Record<string, unknown>): Promise<ExternalProject[]>;
+  /** Optional: fetch direct subtasks/children of a task */
+  fetchSubtasks?(params: TaskProviderFetchSubtasksParams): Promise<Task[]>;
 }

--- a/apps/backend/src/integrations/tasks.controller.ts
+++ b/apps/backend/src/integrations/tasks.controller.ts
@@ -54,6 +54,7 @@ export class TasksController {
     @Query('order') order?: 'asc' | 'desc',
     @Query('excludeDone') excludeDone?: string,
     @Query('fallbackUnassigned') fallbackUnassigned?: string,
+    @Query('includeSubtasks') includeSubtasks?: string,
   ): Promise<Task[]> {
     // When fetching "my" tasks, use all email aliases for matching
     let assigneeEmails: string[] | undefined;
@@ -75,6 +76,7 @@ export class TasksController {
             assigneeEmails,
             sprint: sprint ?? 'current',
             excludeDone: excludeDone === 'true',
+            includeSubtasks: includeSubtasks === 'true',
           }),
         ),
       );
@@ -90,6 +92,7 @@ export class TasksController {
         assigneeEmails,
         sprint: sprint ?? 'current',
         excludeDone: excludeDone === 'true',
+        includeSubtasks: includeSubtasks === 'true',
       });
     }
 
@@ -162,7 +165,7 @@ export class TasksController {
     const [teamInfo, members, tasks, devStats, friction] = await Promise.all([
       this.teamsService.findOne(teamId),
       this.teamsService.getMembers(teamId),
-      this.tasksService.getTasks(orgId, { teamId }),
+      this.tasksService.getTasks(orgId, { teamId, includeSubtasks: true }),
       this.telemetryService.getDeveloperStats(orgId, startDate, endDate, teamId),
       this.telemetryService.getFrictionHeatmap(orgId, startDate, endDate, teamId),
     ]);
@@ -336,6 +339,15 @@ export class TasksController {
   }
 
   // ── Parameterized routes ──
+
+  @Get(':taskId/subtasks')
+  async getSubtasks(
+    @CurrentUser() user: RequestUser,
+    @Param('taskId') taskId: string,
+    @Query('provider') provider: IntegrationProvider,
+  ): Promise<Task[]> {
+    return this.tasksService.getSubtasks(user.organizationId, taskId, provider);
+  }
 
   @Get(':taskId/statuses')
   async getStatuses(

--- a/apps/backend/src/integrations/tasks.service.ts
+++ b/apps/backend/src/integrations/tasks.service.ts
@@ -10,6 +10,7 @@ export interface GetTasksParams {
   assigneeEmails?: string[];
   sprint?: string;
   excludeDone?: boolean;
+  includeSubtasks?: boolean;
 }
 
 @Injectable()
@@ -57,7 +58,28 @@ export class TasksService {
     }
 
     const results = await Promise.all(fetchPromises);
-    return results.flat();
+    const all = results.flat();
+
+    // Filter out subtasks from the top-level list unless explicitly requested
+    if (params.includeSubtasks) {
+      return all;
+    }
+    return all.filter((t) => !t.parentId);
+  }
+
+  async getSubtasks(orgId: string, taskId: string, provider: IntegrationProvider): Promise<Task[]> {
+    const integration = await this.integrationsService.findOne(orgId, provider);
+    const taskProvider = getProvider(provider);
+
+    if (!taskProvider.fetchSubtasks) {
+      return [];
+    }
+
+    return taskProvider.fetchSubtasks({
+      accessToken: integration.access_token,
+      taskId,
+      config: integration.config,
+    });
   }
 
   async getTaskStatuses(orgId: string, taskId: string, provider: IntegrationProvider) {

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -156,7 +156,7 @@ curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamI
 
 Use `teamId=all` when "All teams" is selected — the backend fetches from all teams and deduplicates.
 
-The response is a `Task[]` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`, `category`. **The API returns tasks already sorted by priority (urgent first).** Do not re-sort — use the response order as-is.
+The response is a `Task[]` where each task has: `id`, `title`, `description`, `status`, `priority`, `assigneeName`, `assigneeEmail`, `labels`, `url`, `provider`, `category`, `parentId`, `hasSubtasks`, `subtaskCount`. **The API returns tasks already sorted by priority (urgent first).** Do not re-sort — use the response order as-is. Tasks with `parentId` set are filtered out by default — you'll only see root-level tasks.
 
 Filter to tasks that are `todo` or `in_progress` status. **Then exclude any task IDs listed in `---OTHER_ACTIVE_TASKS---` from the setup output** — those are already being worked on in another session/worktree and should not be offered again.
 
@@ -176,9 +176,29 @@ Use AskUserQuestion to present the tasks as a selectable list:
 
 If there are more than 4 tasks, show the top 4 and mention how many more exist.
 
+### 4a. Subtask drill-down
+
+After the developer picks a task, check if `hasSubtasks` is `true` on the selected task. If so, fetch the subtasks:
+
+```bash
+curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/subtasks?provider=<task.provider>"
+```
+
+This returns a `Task[]` of direct children. Present them with AskUserQuestion:
+- Question: "**<parent title>** has <subtaskCount> subtasks. Pick one to work on:"
+- Header: "Subtasks"
+- Options: up to 4 subtasks (same format: title, "ID · priority · provider"), plus one final option:
+  - Label: "Work on parent directly", Description: "Skip subtasks and work on <parent title> itself"
+
+If the developer picks a subtask that itself has `hasSubtasks: true`, **repeat the drill-down** (recurse). Continue until reaching a leaf task or the developer chooses "Work on parent directly". **Cap at 5 levels deep** as a safety guard — if you reach level 5, just proceed with that task.
+
+Track the drill-down path as a `parentChain` array (list of task IDs from root to chosen task). Store this in the active task file later (Step 5b).
+
+If `hasSubtasks` is `false` on the selected task, skip this step entirely.
+
 ### 5. Set up the chosen task
 
-Once the developer picks a task:
+Once the developer picks a task (either a leaf subtask from drill-down, or a task they chose "Work on parent directly" for, or a task with no subtasks):
 
 #### 5a. Check for uncommitted changes
 
@@ -250,7 +270,8 @@ cat > "$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json" << EOF
   "url": "<task.url>",
   "category": "<task.category from API response>",
   "labels": [<task.labels as JSON array>],
-  "worktree": "$WORKTREE_DIR"
+  "worktree": "$WORKTREE_DIR",
+  "parentChain": [<array of task IDs from root to chosen task, from Step 4a drill-down — empty array if no drill-down occurred>]
 }
 EOF
 ```

--- a/packages/types/src/integrations.ts
+++ b/packages/types/src/integrations.ts
@@ -37,6 +37,9 @@ export interface Task {
   readonly externalProjectId: string;
   readonly updatedAt: string;
   readonly category?: TaskCategory;
+  readonly parentId?: string;           // external ID of parent task
+  readonly hasSubtasks?: boolean;       // true if task has direct children
+  readonly subtaskCount?: number;       // number of direct children
 }
 
 export type TaskStatus = 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled';


### PR DESCRIPTION
## Summary
- Add `parentId`, `hasSubtasks`, `subtaskCount` to the unified `Task` type for hierarchy support
- Implement `fetchSubtasks()` in Linear (GraphQL children), Jira (JQL parent query), ClickUp (existing `&subtasks=true`), Asana (`/subtasks` endpoint), and Monday (subitems query)
- New `GET /api/tasks/:taskId/subtasks?provider=` endpoint for on-demand subtask fetching
- Top-level task list filters out subtasks by default; standup preserves flat behavior via `includeSubtasks=true`
- `/morning` skill now supports recursive drill-down into subtasks with "Work on parent directly" escape at each level

## Test plan
- [ ] Fetch tasks from Linear — verify parent tasks show `hasSubtasks: true`, subtasks filtered from top-level
- [ ] Call `GET /api/tasks/:id/subtasks?provider=linear` — verify children returned with full Task data
- [ ] Standup endpoint still returns all tasks including subtasks (flat)
- [ ] `/morning` drill-down: pick a parent → see subtasks → pick leaf or "Work on parent directly"
- [ ] Type-check: `npx tsc --noEmit` passes in backend with zero errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)