### PR TITLE
fix: cross-shell compatibility for skills, hooks, and libs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI Teammate plugin for Claude Code",
-    "version": "1.9.4"
+    "version": "1.9.5"
   },
   "plugins": [
     {
       "name": "tandemu",
       "source": "./apps/claude-plugins",
       "description": "AI Teammate — task lifecycle, telemetry, and persistent memory",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "author": {
         "name": "Tandemu"
       }

--- a/apps/claude-plugins/.claude-plugin/plugin.json
+++ b/apps/claude-plugins/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandemu",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "AI Teammate — task lifecycle, telemetry, and persistent memory for AI-native development",
   "author": {
     "name": "Tandemu",

--- a/apps/claude-plugins/hooks/pre-session.sh
+++ b/apps/claude-plugins/hooks/pre-session.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PLUGIN_DIR="$(dirname "${SCRIPT_DIR}")"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
 
@@ -52,7 +52,7 @@ fi
 export TANDEMU_TELEMETRY_ENABLED="${TELEMETRY_ENABLED}"
 export TANDEMU_TELEMETRY_ENDPOINT="${TELEMETRY_ENDPOINT:-https://telemetry.tandemu.dev:4317}"
 export TANDEMU_ORG_ID="${ORG_ID}"
-export TANDEMU_SESSION_ID="${TANDEMU_SESSION_ID:-$(uuidgen 2>/dev/null || date +%s)}"
+export TANDEMU_SESSION_ID="${TANDEMU_SESSION_ID:-$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || date +%s)}"
 export TANDEMU_SESSION_START="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 echo ""

--- a/apps/claude-plugins/lib/tandemu-env.sh
+++ b/apps/claude-plugins/lib/tandemu-env.sh
@@ -2,7 +2,7 @@
 # Shared Tandemu config loader — source this from skills to get env vars.
 # Usage: source "$(dirname "$0")/../lib/tandemu-env.sh"
 
-_TANDEMU_CONFIG=$(cat ~/.claude/tandemu.json 2>/dev/null)
+_TANDEMU_CONFIG=$(cat "$HOME/.claude/tandemu.json" 2>/dev/null)
 if [ -z "$_TANDEMU_CONFIG" ]; then
   echo "ERROR: Tandemu not configured. Run /tandemu:setup or install.sh to set up." >&2
   return 1 2>/dev/null || exit 1

--- a/apps/claude-plugins/lib/tandemu-session-start.sh
+++ b/apps/claude-plugins/lib/tandemu-session-start.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Load config
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || exit 0
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || exit 0
 
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
 START_MARKER="<!-- tandemu:personality:start -->"
@@ -52,15 +52,16 @@ fi
 if echo "$EXISTING" | grep -qF "$START_MARKER"; then
   # Replace existing section using python for reliable multiline replacement
   python3 -c "
-import re, sys
-existing = open('$CLAUDE_MD').read()
+import re, sys, os
+claude_md = os.path.expandvars('$CLAUDE_MD').replace('\\\\', '/')
+existing = open(claude_md).read()
 pattern = re.escape('$START_MARKER') + r'.*?' + re.escape('$END_MARKER')
 replacement = sys.stdin.read().strip()
 updated = re.sub(pattern, replacement, existing, flags=re.DOTALL)
 # Remove empty lines left behind if replacement is empty
 if not replacement:
     updated = re.sub(r'\n{3,}', '\n\n', updated)
-open('$CLAUDE_MD', 'w').write(updated)
+open(claude_md, 'w').write(updated)
 " <<EOF
 $NEW_BLOCK
 EOF
@@ -82,7 +83,7 @@ if [ -n "$REPO_NAME" ]; then
     echo "$INDEX"
 
     # Also persist to project memory dir
-    PROJECT_DIR=$(pwd | sed "s/\//-/g")
+    PROJECT_DIR=$(pwd | sed 's/[\/:\\]/-/g')
     MEMORY_DIR="$HOME/.claude/projects/${PROJECT_DIR}/memory"
     mkdir -p "$MEMORY_DIR"
     echo "$INDEX" > "$MEMORY_DIR/tandemu-index.md"

--- a/apps/claude-plugins/skills/create/SKILL.md
+++ b/apps/claude-plugins/skills/create/SKILL.md
@@ -14,7 +14,7 @@ Create a new task in the team's ticket system. Use when you discover work that n
 ### 1. Setup
 
 ```bash
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"

--- a/apps/claude-plugins/skills/finish/SKILL.md
+++ b/apps/claude-plugins/skills/finish/SKILL.md
@@ -87,7 +87,7 @@ Load config and active task in a **single Bash call** ("Prepare telemetry"):
 
 ```bash
 # Load Tandemu config
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"

--- a/apps/claude-plugins/skills/morning/SKILL.md
+++ b/apps/claude-plugins/skills/morning/SKILL.md
@@ -20,9 +20,11 @@ Help the developer start their work session by picking a task.
 
 ### 0. Greet personally (memory)
 
-Before anything else, search memories for the developer's personal context — their name, what they were working on recently, any preferences. Use this to greet them personally.
+**Do NOT greet the developer until Step 1 has completed.** You need `LOCAL_NOW` from the setup output to determine the correct time-of-day greeting. Run Step 1 first, then greet.
 
-Use the `LOCAL_NOW` from the setup step (Step 1) to determine the time-of-day greeting. Extract the hour from the output (format: `2026-04-01 21:20 +04`):
+Search memories for the developer's personal context — their name, what they were working on recently, any preferences. Use this to greet them personally.
+
+Use the `LOCAL_NOW` from the Step 1 output to determine the time-of-day greeting. Extract the hour from the output (format: `2026-04-01 21:20 +04`):
 - Hour < 12 → "Morning"
 - Hour 12–17 → "Afternoon"
 - Hour > 17 → "Evening"
@@ -40,7 +42,7 @@ Run all setup reads in a **single Bash call**:
 
 ```bash
 # Load Tandemu config
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
@@ -71,13 +73,11 @@ cat "$TASK_FILE" 2>/dev/null || echo "NONE"
 
 # Collect task IDs from ALL active task files (other sessions/worktrees)
 echo "---OTHER_ACTIVE_TASKS---"
-for f in "$HOME"/.claude/tandemu-active-task-*.json 2>/dev/null; do
-  [ -f "$f" ] || continue
-  # Skip the current branch's task file
+find "$HOME/.claude" -maxdepth 1 -name 'tandemu-active-task-*.json' 2>/dev/null | while read -r f; do
   [ "$f" = "$TASK_FILE" ] && continue
   TASK_ID=$(python3 -c "import json; print(json.load(open('$f')).get('taskId',''))" 2>/dev/null)
   [ -n "$TASK_ID" ] && echo "$TASK_ID"
-done || true
+done
 
 # Check if we're inside a worktree
 echo "---WORKTREE---"
@@ -105,7 +105,7 @@ echo "LOCAL_YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' 
 
 # Refresh memory index for this repo
 REPO_NAME=$(basename "$REPO" 2>/dev/null || echo "unknown")
-PROJECT_DIR=$(pwd | sed 's/\//-/g')
+PROJECT_DIR=$(pwd | sed 's/[\/:\\]/-/g')
 MEMORY_DIR="$HOME/.claude/projects/${PROJECT_DIR}/memory"
 echo "---MEMORY_INDEX---"
 INDEX=$(curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/memory/index?repo=$REPO_NAME" 2>/dev/null)
@@ -207,17 +207,17 @@ Once the developer picks a task (either a leaf subtask from drill-down, or a tas
 
 #### 5a. Check for uncommitted changes
 
-Use the git status output from the setup call. If it showed uncommitted changes, use AskUserQuestion:
-- Question: "You have uncommitted changes. What should I do before switching branches?"
+Use the git status output from the setup call. If it showed uncommitted changes, use AskUserQuestion. Detect the current branch name from setup and use it in the message:
+- Question: "You have uncommitted changes on **<current branch>**. These won't affect your new worktree, but you may want to save them."
 - Header: "Changes"
 - Options:
-  - Label: "Commit on current branch", Description: "Stage and commit changes with a conventional commit message before switching"
-  - Label: "Stash for later", Description: "Stash changes — you can restore them later with git stash pop"
-  - Label: "Bring to new branch", Description: "Carry uncommitted changes into the new feature branch"
+  - Label: "Commit on current branch", Description: "Stage and commit changes on <current branch> before proceeding"
+  - Label: "Stash for later", Description: "Stash changes — restore later with git stash pop"
+  - Label: "Leave them", Description: "Keep changes in working tree, proceed to worktree"
 
 If **Commit**: help write a commit message based on the diff, stage and commit, then proceed.
 If **Stash**: run `git stash push -m "WIP before <task.id>"`, then proceed.
-If **Bring to new branch**: do nothing — changes will carry over when creating the branch.
+If **Leave them**: do nothing — proceed directly to worktree creation.
 
 If the working tree is clean, skip this step.
 

--- a/apps/claude-plugins/skills/pause/SKILL.md
+++ b/apps/claude-plugins/skills/pause/SKILL.md
@@ -19,7 +19,7 @@ Run all setup reads in a **single Bash call** ("Setup"):
 
 ```bash
 # Load Tandemu config
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"

--- a/apps/claude-plugins/skills/setup/SKILL.md
+++ b/apps/claude-plugins/skills/setup/SKILL.md
@@ -17,8 +17,8 @@ Set up Tandemu for the current developer. This skill handles authentication, con
 ### 1. Check prerequisites
 
 ```bash
-command -v python3 &>/dev/null && echo "OK" || echo "MISSING: python3"
-command -v curl &>/dev/null && echo "OK" || echo "MISSING: curl"
+command -v python3 >/dev/null 2>&1 && echo "OK" || echo "MISSING: python3"
+command -v curl >/dev/null 2>&1 && echo "OK" || echo "MISSING: curl"
 ```
 
 If any are missing, tell the developer what to install and stop.
@@ -37,7 +37,7 @@ If **Self-hosted**: ask for the URL, strip trailing slash.
 
 Verify the instance is reachable:
 ```bash
-curl -sf "${API_URL}/api/health" &>/dev/null && echo "OK" || echo "UNREACHABLE"
+curl -sf "${API_URL}/api/health" >/dev/null 2>&1 && echo "OK" || echo "UNREACHABLE"
 ```
 
 ### 3. Authenticate via OAuth
@@ -56,12 +56,12 @@ Tell the developer: "Open this URL in your browser to authorize: <AUTH_URL>"
 
 Open the browser automatically:
 ```bash
-open "$AUTH_URL" 2>/dev/null || xdg-open "$AUTH_URL" 2>/dev/null || true
+open "$AUTH_URL" 2>/dev/null || xdg-open "$AUTH_URL" 2>/dev/null || cmd.exe /c start "$AUTH_URL" 2>/dev/null || true
 ```
 
 Poll for authorization (max 150 retries, 2 seconds apart):
 ```bash
-for i in $(seq 1 150); do
+i=0; while [ "$i" -lt 150 ]; do i=$((i + 1))
   POLL=$(curl -sf "${API_URL}/api/auth/cli/status?code=${CODE}" 2>/dev/null)
   STATUS=$(echo "$POLL" | python3 -c "import json,sys; d=json.load(sys.stdin); d=d.get('data',d); print(d.get('status','pending'))" 2>/dev/null || echo "pending")
   if [ "$STATUS" = "authorized" ]; then
@@ -161,7 +161,7 @@ else:
 #### 5a. tandemu.json
 
 ```bash
-mkdir -p ~/.claude
+mkdir -p "$HOME/.claude"
 python3 << PYEOF
 import json
 
@@ -243,6 +243,11 @@ tandemu_perms = [
     f"Bash(rm {home}/.claude/tandemu*)",
     f"Bash(rm -f {home}/.claude/tandemu*)",
     f"Bash(curl*{api_url}*)",
+    f"Bash(curl*-X POST*{api_url}*)",
+    f"Bash(curl*-X PATCH*{api_url}*)",
+    "Bash(curl*$TANDEMU_API*)",
+    "Bash(curl*-X POST*$TANDEMU_API*)",
+    "Bash(curl*-X PATCH*$TANDEMU_API*)",
     "mcp__tandemu-memory",
 ]
 for p in tandemu_perms:
@@ -348,8 +353,8 @@ if [ -z "$PLUGIN_ROOT" ]; then
 fi
 
 if [ -n "$PLUGIN_ROOT" ] && [ -d "$PLUGIN_ROOT/lib" ]; then
-  mkdir -p ~/.claude/lib
-  cp -r "$PLUGIN_ROOT/lib"/* ~/.claude/lib/
+  mkdir -p "$HOME/.claude"/lib
+  cp -r "$PLUGIN_ROOT/lib"/* "$HOME/.claude/lib/"
   echo "OK"
 fi
 ```
@@ -359,7 +364,7 @@ fi
 Write a `~/.claude/CLAUDE.md` that tells Claude the developer's actual name. The plugin's CLAUDE.md uses `{{DEV_NAME}}` as a placeholder — this file provides the real value:
 
 ```bash
-cat > ~/.claude/CLAUDE.md << EOF
+cat > "$HOME/.claude/CLAUDE.md" << EOF
 # Developer Context
 The developer's name is ${USER_NAME}. Use it naturally in conversation.
 EOF

--- a/apps/claude-plugins/skills/standup/SKILL.md
+++ b/apps/claude-plugins/skills/standup/SKILL.md
@@ -20,7 +20,7 @@ Load config and fetch all pre-computed standup data in a **single Bash call** ("
 
 ```bash
 # Load Tandemu config
-source ~/.claude/lib/tandemu-env.sh 2>/dev/null || source "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
 # Multi-team support: resolve --team argument or prompt if multiple teams
 ACTIVE_TEAM_ID="$TANDEMU_TEAM_ID"


### PR DESCRIPTION
## Summary
- Fix bash/zsh/Windows compatibility across all skills, hooks, and shared libs
- Replace bash-isms (`source`, `&>`, `BASH_SOURCE`, `seq`) with POSIX equivalents
- Add Windows Git Bash support: `$HOME` instead of `~`, path separator handling, `cmd.exe` browser fallback, `python3 uuid` fallback
- Fix `/morning` zsh parse error on `for` loop with redirect
- Fix `/morning` greeting using wrong time-of-day (greeted before checking local time)
- Fix `/morning` uncommitted changes prompt to explain worktree behavior
- Add `$TANDEMU_API` variable-form curl permissions for OSS self-hosted support
- Bump plugin to v1.9.5

## Test plan
- [ ] Start a new session on macOS (zsh) — verify SessionStart hook runs clean
- [ ] Run `/morning` — verify greeting uses correct time-of-day
- [ ] Run `/morning` with uncommitted changes — verify prompt mentions current branch and worktree context
- [ ] Verify curl commands to API don't prompt for permission
- [ ] Test on Linux (bash) if available
- [ ] Test on Windows Git Bash if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)