### PR TITLE
fix: redesign Cleanup Candidates card for better UX

### DIFF
--- a/apps/frontend/src/components/memory/memory-insights.tsx
+++ b/apps/frontend/src/components/memory/memory-insights.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { TrendingUp, TrendingDown, Trash2, CheckCircle } from 'lucide-react';
+import { TrendingUp, TrendingDown, Trash2, CheckCircle, ChevronRight } from 'lucide-react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
 import {
   getMemoryUsageInsights,
   type UsageInsightsResponse,
@@ -72,7 +72,7 @@ function InsightCardSkeleton() {
 export function MemoryInsights() {
   const [usageInsights, setUsageInsights] = useState<UsageInsightsResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [showCleanupDialog, setShowCleanupDialog] = useState(false);
+  const [showCleanupSheet, setShowCleanupSheet] = useState(false);
   const [deleteMemoryId, setDeleteMemoryId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -133,31 +133,41 @@ export function MemoryInsights() {
 
         {/* Cleanup Candidates */}
         {hasCleanup && usageInsights && (
-          <Card
-            className="border-orange-500/20 cursor-pointer hover:border-orange-500/40 transition-colors"
-            onClick={() => setShowCleanupDialog(true)}
-          >
+          <Card className={`border-orange-500/20${!hasTopUsed ? ' md:col-span-2' : ''}`}>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium flex items-center gap-2">
                 <TrendingDown className="h-4 w-4 text-orange-400" />
                 Cleanup Candidates
                 {usageInsights.neverAccessedCount > 0 && (
-                  <Badge variant="outline" className="text-[10px] h-4 text-orange-400 border-orange-500/30 ml-auto">{usageInsights.neverAccessedCount}</Badge>
+                  <Badge variant="outline" className="text-[10px] h-4 text-orange-400 border-orange-500/30">{usageInsights.neverAccessedCount}</Badge>
                 )}
               </CardTitle>
-              <CardDescription className="text-xs">Memories never accessed by the AI. Click to review.</CardDescription>
+              <CardDescription className="text-xs">Memories never accessed by the AI.</CardDescription>
+              <CardAction>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => setShowCleanupSheet(true)}
+                >
+                  Review
+                  <ChevronRight className="h-3 w-3 ml-1" />
+                </Button>
+              </CardAction>
             </CardHeader>
             <CardContent>
-              <div className="flex items-center gap-4 mb-3">
-                <div className="text-3xl font-bold text-orange-400">{usageInsights.neverAccessedCount}</div>
-                <p className="text-xs text-muted-foreground">
-                  memories have never been referenced in search results or context
-                </p>
-              </div>
-              <div className="space-y-1.5">
-                {(usageInsights.neverAccessed ?? usageInsights.leastUsed).slice(0, 3).map((u) => (
-                  <p key={u.memoryId} className="line-clamp-1 text-xs text-muted-foreground">{u.content}</p>
-                ))}
+              <div className="space-y-2">
+                {(usageInsights.neverAccessed ?? usageInsights.leastUsed).slice(0, 3).map((u) => {
+                  const cat = (u as unknown as { metadata?: { category?: string } }).metadata?.category ?? 'uncategorized';
+                  return (
+                    <div key={u.memoryId} className={`rounded border border-l-[3px] ${getCategoryAccent(cat)} px-2.5 py-1.5`}>
+                      <div className="flex items-center gap-1.5 mb-0.5">
+                        <Badge variant="outline" className={`text-[10px] h-4 ${getCategoryColor(cat)}`}>{cat}</Badge>
+                      </div>
+                      <p className="line-clamp-1 text-xs text-muted-foreground">{u.content}</p>
+                    </div>
+                  );
+                })}
                 {usageInsights.neverAccessedCount > 3 && (
                   <p className="text-xs text-orange-400">+{usageInsights.neverAccessedCount - 3} more</p>
                 )}
@@ -167,22 +177,22 @@ export function MemoryInsights() {
         )}
       </div>
 
-      {/* Cleanup review dialog */}
-      <Dialog open={showCleanupDialog} onOpenChange={setShowCleanupDialog}>
-        <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
+      {/* Cleanup review sheet */}
+      <Sheet open={showCleanupSheet} onOpenChange={setShowCleanupSheet}>
+        <SheetContent side="right" className="sm:!max-w-xl flex flex-col">
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
               <TrendingDown className="h-5 w-5 text-orange-400" />
               Unused Memories
               {usageInsights && usageInsights.neverAccessedCount > 0 && (
                 <Badge variant="outline" className="text-xs text-orange-400 border-orange-500/30">{usageInsights.neverAccessedCount}</Badge>
               )}
-            </DialogTitle>
-            <DialogDescription>
-              These memories have never been accessed by your AI teammate. Review and remove any that are no longer relevant to keep your knowledge base clean.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-2 mt-2 overflow-y-auto flex-1 pr-1">
+            </SheetTitle>
+            <SheetDescription>
+              These memories have never been accessed by your AI teammate. Review and remove any that are no longer relevant.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="space-y-2 overflow-y-auto flex-1 px-4 pb-4">
             {(usageInsights?.neverAccessed ?? []).map((u) => {
               const cat = (u as unknown as { metadata?: { category?: string } }).metadata?.category ?? 'uncategorized';
               return (
@@ -197,10 +207,7 @@ export function MemoryInsights() {
                     variant="outline"
                     size="sm"
                     className="shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10 h-7 text-xs"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setDeleteMemoryId(u.memoryId);
-                    }}
+                    onClick={() => setDeleteMemoryId(u.memoryId)}
                   >
                     <Trash2 className="h-3 w-3 mr-1" />
                     Delete
@@ -216,8 +223,8 @@ export function MemoryInsights() {
               </div>
             )}
           </div>
-        </DialogContent>
-      </Dialog>
+        </SheetContent>
+      </Sheet>
 
       {deleteMemoryId && (
         <DeleteMemoryDialog


### PR DESCRIPTION
## Summary
- Replaced cramped Dialog with full-height right-sliding Sheet (`sm:!max-w-xl`) for reviewing unused memories
- Added explicit "Review →" CTA button via `CardAction` instead of relying on subtle whole-card click
- Compacted card body with category-colored preview list matching "Most Referenced" card style
- Fixed single-card layout: Cleanup Candidates spans full width (`md:col-span-2`) when alone in the row

Closes SGS-168

## Test plan
- [ ] Open `/memory` page — Cleanup Candidates card should show "Review" button in header
- [ ] Click "Review" — Sheet slides in from right with full memory list and delete buttons
- [ ] Verify card preview shows up to 3 memories with category badges and colored borders
- [ ] Test with no "Most Referenced" data — card should span full width
- [ ] Test delete flow from Sheet — memory is removed, list refreshes
- [ ] Test empty state — Sheet shows "All clean!" when no unused memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)