### PR TITLE
fix: filter out done/cancelled subtasks

### DIFF
--- a/apps/backend/src/integrations/tasks.service.ts
+++ b/apps/backend/src/integrations/tasks.service.ts
@@ -75,11 +75,13 @@ export class TasksService {
       return [];
     }
 
-    return taskProvider.fetchSubtasks({
+    const subtasks = await taskProvider.fetchSubtasks({
       accessToken: integration.access_token,
       taskId,
       config: integration.config,
     });
+
+    return subtasks.filter((t) => t.status !== 'done' && t.status !== 'cancelled');
   }
 
   async getTaskStatuses(orgId: string, taskId: string, provider: IntegrationProvider) {


### PR DESCRIPTION
## Summary
- Filter out `done` and `cancelled` subtasks in `tasksService.getSubtasks()` before returning to the client
- Single-point fix at the service layer so all providers (Linear, Jira, ClickUp, Asana, Monday) benefit
- The `/morning` skill's subtask drill-down now only shows open subtasks

Closes SGS-164

## Test plan
- [ ] Create a task with subtasks in Linear, mark some as done
- [ ] `GET /api/tasks/:id/subtasks` should only return open subtasks
- [ ] `/morning` drill-down should not show completed subtasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)