### PR TITLE
fix: align settings card footers in 2-column grid

### DIFF
--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -235,7 +235,7 @@ function SettingsPageContent() {
       {/* ROI & Memory Settings */}
       {org && (
         <div className="grid gap-6 lg:grid-cols-2">
-        <Card>
+        <Card className="flex flex-col">
           <CardHeader>
             <div className="flex items-center gap-2">
               <Lightbulb className="h-5 w-5 text-muted-foreground" />
@@ -303,7 +303,7 @@ function SettingsPageContent() {
           </CardFooter>
         </Card>
 
-        <Card>
+        <Card className="flex flex-col">
           <CardHeader>
             <div className="flex items-center gap-2">
               <Brain className="h-5 w-5 text-muted-foreground" />
@@ -313,7 +313,7 @@ function SettingsPageContent() {
               </div>
             </div>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="flex-1 space-y-4">
             <div className="max-w-xs space-y-2">
               <label className="text-sm font-medium">Draft Retention (days)</label>
               <Input


### PR DESCRIPTION
## Summary
- Add `flex flex-col` to both settings cards so they stretch to equal height in the grid
- Add `flex-1` to Memory Settings `CardContent` to push its footer to the bottom
- Fixes the misaligned Save button on the right card

Closes SGS-172

## Test plan
- [ ] Open `/settings` — both card footers should align at the same vertical position
- [ ] Resize window to test responsive behavior (single column on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)