### PR TITLE
fix: show loading skeleton when switching memory scope

### DIFF
--- a/apps/frontend/src/components/memory/memory-browser.tsx
+++ b/apps/frontend/src/components/memory/memory-browser.tsx
@@ -338,7 +338,7 @@ export function MemoryBrowser() {
       )}
 
       {/* Memory list */}
-      {loading && memories.length === 0 ? (
+      {loading ? (
         <div className="space-y-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="rounded-lg border border-l-[3px] p-3 space-y-2">


### PR DESCRIPTION
## Summary
- Show skeleton loading state when switching between Personal/Organization scope in the memory browser
- Previously skeletons only appeared on initial load (when memories array was empty), not on scope switches

Closes SGS-169

## Test plan
- [ ] Open `/memory` — switch between Personal and Organization scope
- [ ] Skeleton cards should appear briefly while memories reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)