### PR TITLE
fix: swap Tool Usage and Task Velocity on dashboard

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -199,12 +199,12 @@ export default function DashboardPage() {
           {/* Charts Row */}
           <div className="grid gap-4 lg:grid-cols-2">
             <AIRatioChart data={aiData} />
-            <ToolUsageChart data={toolData} />
+            <VelocityChart data={velocityData} />
           </div>
 
-          {/* Velocity + Investment Row */}
+          {/* Tool Usage + Investment Row */}
           <div className="grid gap-4 lg:grid-cols-2">
-            <VelocityChart data={velocityData} />
+            <ToolUsageChart data={toolData} />
             <InvestmentChart data={investment} />
           </div>
 


### PR DESCRIPTION
## Summary
- Move Task Velocity chart to top row (next to AI Ratio)
- Move Tool Usage chart to second row (next to Investment Allocation)

Closes SGS-166

## Test plan
- [ ] Open `/` dashboard — Task Velocity should be in row 1, Tool Usage in row 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)