### PR TITLE
fix: validate org slug availability during onboarding

### DIFF
--- a/apps/backend/src/organizations/organizations.controller.ts
+++ b/apps/backend/src/organizations/organizations.controller.ts
@@ -49,6 +49,15 @@ export class OrganizationsController {
     return this.organizationsService.findAll(user.userId);
   }
 
+  // Any authenticated user can check slug availability
+  @Get('check-slug/:slug')
+  async checkSlug(
+    @Param('slug') slug: string,
+  ): Promise<{ available: boolean }> {
+    const available = await this.organizationsService.isSlugAvailable(slug);
+    return { available };
+  }
+
   // Any member can view org details
   @Get(':id')
   async findById(

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -29,36 +29,51 @@ export class OrganizationsService {
   ) {}
 
   async create(dto: CreateOrganizationDto, userId: string): Promise<Organization> {
-    const result = await this.db.withTransaction(async (client) => {
-      const orgResult = await client.query<{
-        id: string;
-        name: string;
-        slug: string;
-        stripe_customer_id: string | null;
-        stripe_subscription_id: string | null;
-        plan_tier: string;
-        subscription_status: string;
-        settings: Record<string, unknown>;
-        created_at: Date;
-        updated_at: Date;
-      }>(
-        `INSERT INTO organizations (name, slug, plan_tier)
-         VALUES ($1, $2, $3)
-         RETURNING *`,
-        [dto.name, dto.slug, (dto.planTier ?? 'free').toLowerCase()],
-      );
-      const org = orgResult.rows[0]!;
+    try {
+      const result = await this.db.withTransaction(async (client) => {
+        const orgResult = await client.query<{
+          id: string;
+          name: string;
+          slug: string;
+          stripe_customer_id: string | null;
+          stripe_subscription_id: string | null;
+          plan_tier: string;
+          subscription_status: string;
+          settings: Record<string, unknown>;
+          created_at: Date;
+          updated_at: Date;
+        }>(
+          `INSERT INTO organizations (name, slug, plan_tier)
+           VALUES ($1, $2, $3)
+           RETURNING *`,
+          [dto.name, dto.slug, (dto.planTier ?? 'free').toLowerCase()],
+        );
+        const org = orgResult.rows[0]!;
 
-      // Create membership for the creating user
-      await client.query(
-        `INSERT INTO memberships (user_id, organization_id, role) VALUES ($1, $2, $3)`,
-        [userId, org.id, 'owner'],
-      );
+        // Create membership for the creating user
+        await client.query(
+          `INSERT INTO memberships (user_id, organization_id, role) VALUES ($1, $2, $3)`,
+          [userId, org.id, 'owner'],
+        );
 
-      return org;
-    });
+        return org;
+      });
 
-    return this.mapOrg(result);
+      return this.mapOrg(result);
+    } catch (error: unknown) {
+      if (error instanceof Error && 'code' in error && (error as { code: string }).code === '23505') {
+        throw new ConflictException('An organization with this slug already exists');
+      }
+      throw error;
+    }
+  }
+
+  async isSlugAvailable(slug: string): Promise<boolean> {
+    const result = await this.db.query(
+      'SELECT 1 FROM organizations WHERE slug = $1 LIMIT 1',
+      [slug],
+    );
+    return result.rows.length === 0;
   }
 
   async findAll(userId: string): Promise<Organization[]> {

--- a/apps/frontend/src/app/setup/page.tsx
+++ b/apps/frontend/src/app/setup/page.tsx
@@ -11,6 +11,7 @@ import {
   createIntegration,
   switchOrg,
   getGitHubOAuthIntegrationUrl,
+  checkSlugAvailability,
 } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -434,6 +435,34 @@ function SetupPageInner() {
   const [orgName, setOrgName] = useState('');
   const [orgSlug, setOrgSlug] = useState('');
   const [slugEdited, setSlugEdited] = useState(false);
+  const [slugAvailable, setSlugAvailable] = useState<boolean | null>(null);
+  const [slugChecking, setSlugChecking] = useState(false);
+  const slugCheckTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounced slug availability check
+  useEffect(() => {
+    if (slugCheckTimer.current) clearTimeout(slugCheckTimer.current);
+    setSlugAvailable(null);
+
+    const slug = orgSlug.trim();
+    if (slug.length < 2) return;
+
+    setSlugChecking(true);
+    slugCheckTimer.current = setTimeout(async () => {
+      try {
+        const available = await checkSlugAvailability(slug);
+        setSlugAvailable(available);
+      } catch {
+        setSlugAvailable(null);
+      } finally {
+        setSlugChecking(false);
+      }
+    }, 300);
+
+    return () => {
+      if (slugCheckTimer.current) clearTimeout(slugCheckTimer.current);
+    };
+  }, [orgSlug]);
 
   // Step 2: Teams
   const [teams, setTeams] = useState<TeamEntry[]>([]);
@@ -496,9 +525,9 @@ function SetupPageInner() {
   const removeInvite = (index: number) => setInvites(invites.filter((_, i) => i !== index));
 
   const canProceed = useCallback(() => {
-    if (step === 0) return orgName.trim().length > 0 && orgSlug.trim().length > 0;
+    if (step === 0) return orgName.trim().length > 0 && orgSlug.trim().length >= 2 && slugAvailable === true && !slugChecking;
     return true;
-  }, [step, orgName, orgSlug]);
+  }, [step, orgName, orgSlug, slugAvailable, slugChecking]);
 
   const handleComplete = async () => {
     setIsSubmitting(true);
@@ -621,9 +650,21 @@ function SetupPageInner() {
                     onChange={(e) => handleSlugChange(e.target.value)}
                     placeholder="acme-inc"
                   />
-                  <p className="text-xs text-muted-foreground">
-                    Used in URLs. Lowercase letters, numbers, and hyphens only.
-                  </p>
+                  {orgSlug.trim().length >= 2 && slugAvailable === false && (
+                    <p className="text-xs text-destructive">
+                      This slug is already taken. Please choose a different one.
+                    </p>
+                  )}
+                  {orgSlug.trim().length >= 2 && slugAvailable === true && (
+                    <p className="text-xs text-green-600 dark:text-green-400">
+                      Slug is available.
+                    </p>
+                  )}
+                  {(orgSlug.trim().length < 2 || slugAvailable === null) && (
+                    <p className="text-xs text-muted-foreground">
+                      Used in URLs. Lowercase letters, numbers, and hyphens only.
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -152,6 +152,11 @@ export async function getOrganizations(): Promise<Organization[]> {
   return fetchApi<Organization[]>("/api/organizations");
 }
 
+export async function checkSlugAvailability(slug: string): Promise<boolean> {
+  const result = await fetchApi<{ available: boolean }>(`/api/organizations/check-slug/${encodeURIComponent(slug)}`);
+  return result.available;
+}
+
 export async function getOrganization(id: string): Promise<Organization> {
   return fetchApi<Organization>(`/api/organizations/${id}`);
 }


### PR DESCRIPTION
## Summary
- Add `GET /organizations/check-slug/:slug` endpoint to check slug availability
- Catch Postgres duplicate key constraint (`23505`) in org creation and return `409 Conflict` instead of `500 Internal Server Error`
- Add debounced (300ms) slug validation on the setup wizard's first step with inline feedback (available/taken)
- Block "Continue" button when slug is taken or being checked

Closes SGS-174

## Test plan
- [ ] Register a new user, enter a slug that already exists — verify inline "taken" message and disabled Continue button
- [ ] Enter a unique slug — verify "available" message and enabled Continue button
- [ ] Complete onboarding with a unique slug — verify org creation succeeds
- [ ] Attempt to create org with duplicate slug via API — verify 409 Conflict response

🤖 Generated with [Claude Code](https://claude.com/claude-code)