### PR TITLE
feat(plugin): add first-class update path for Tandemu skills (SGS-177)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI Teammate plugin for Claude Code",
-    "version": "1.9.7"
+    "version": "1.9.8"
   },
   "plugins": [
     {
       "name": "tandemu",
       "source": "./apps/claude-plugins",
       "description": "AI Teammate — task lifecycle, telemetry, and persistent memory",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "author": {
         "name": "Tandemu"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ tandemu/
 ### Developer setup
 Two installation paths: plugin marketplace (`/plugin marketplace add sebastiangrebe/tandemu` → `/plugin install tandemu` → `/tandemu:setup`) or `install.sh` script. Both handle OAuth, config, skills, MCP, and CLAUDE.md. The plugin approach is preferred for distribution; install.sh is kept for scripted onboarding and CI/CD.
 
+### Updating
+Updates propagate only when `plugin.json`'s `version` field changes — Claude Code's `/plugin update` compares that field, not the git SHA. `pnpm release` (via `scripts/bump-plugin-versions.mjs`) bumps both `apps/claude-plugins/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` automatically. Plugin users run `/plugin marketplace update` then `/plugin update tandemu@tandemu`; install.sh users run `./install.sh --check` then `./install.sh`. `install.sh --uninstall` remains the full-reset path. See README "Updating" section for the user-facing flow.
+
 ### Worktree-per-task
 Each task gets its own git worktree inside `.worktrees/<task-id>/`. Task files are branch-keyed: `~/.claude/tandemu-active-task-{branch-slug}.json`. Multiple tasks can run concurrently in separate worktrees and Claude Code sessions. `/morning` creates the worktree, `/finish` cleans it up.
 

--- a/README.md
+++ b/README.md
@@ -154,13 +154,35 @@ Full documentation is available at **[tandemu.dev/docs](https://tandemu.dev/docs
 - [Dashboard & Metrics](https://tandemu.dev/docs/lead/dashboard)
 - [Self-Hosting Configuration](https://tandemu.dev/docs/self-hosting/configuration)
 
+## Updating
+
+### Plugin users
+
+```bash
+# In Claude Code:
+/plugin marketplace update        # refresh the catalog (does NOT upgrade the plugin)
+/plugin update tandemu@tandemu    # upgrade the installed plugin
+```
+
+Then restart Claude Code so skills reload.
+
+### install.sh users
+
+```bash
+cd tandemu && git pull
+./install.sh --check              # see installed vs latest
+./install.sh                      # re-run to update in place (config preserved)
+```
+
+Updates only propagate when `plugin.json`'s `version` field changes. `pnpm release` bumps it automatically — if you're testing a fork, bump it by hand before pushing.
+
 ## Uninstalling
 
 ```bash
-./install.sh --uninstall
+./install.sh --uninstall          # preferred: cleans config, skills, MCP, cache
 ```
 
-For a full clean-slate reset, see [UNINSTALL.md](UNINSTALL.md).
+For a full clean-slate reset, see [UNINSTALL.md](UNINSTALL.md). The plugin can also be removed via `/plugin uninstall tandemu@tandemu` in Claude Code.
 
 ## License
 

--- a/apps/claude-plugins/.claude-plugin/plugin.json
+++ b/apps/claude-plugins/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandemu",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "AI Teammate — task lifecycle, telemetry, and persistent memory for AI-native development",
   "author": {
     "name": "Tandemu",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/sebastiangrebe/tandemu",
   "license": "MIT",
-  "keywords": ["task-management", "telemetry", "memory", "ai-teammate", "developer-tools"]
+  "keywords": [
+    "task-management",
+    "telemetry",
+    "memory",
+    "ai-teammate",
+    "developer-tools"
+  ]
 }

--- a/apps/claude-plugins/skills/setup/SKILL.md
+++ b/apps/claude-plugins/skills/setup/SKILL.md
@@ -357,6 +357,18 @@ if [ -n "$PLUGIN_ROOT" ] && [ -d "$PLUGIN_ROOT/lib" ]; then
   cp -r "$PLUGIN_ROOT/lib"/* "$HOME/.claude/lib/"
   echo "OK"
 fi
+
+# Track installed plugin version so `install.sh --check` can compare against it
+PLUGIN_MANIFEST=""
+if [ -n "$PLUGIN_ROOT" ] && [ -f "$PLUGIN_ROOT/.claude-plugin/plugin.json" ]; then
+  PLUGIN_MANIFEST="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json" ]; then
+  PLUGIN_MANIFEST="$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json"
+fi
+if [ -n "$PLUGIN_MANIFEST" ]; then
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" "$PLUGIN_MANIFEST" \
+    > "$HOME/.claude/tandemu-version.txt" 2>/dev/null || true
+fi
 ```
 
 ### 7. Write personal CLAUDE.md

--- a/install.sh
+++ b/install.sh
@@ -605,6 +605,13 @@ install_assets() {
   # Skills are distributed via the plugin marketplace — no need to copy them.
   # Users install via: /plugin marketplace add sebastiangrebe/tandemu && /plugin install tandemu
   ok "Skills available via plugin marketplace"
+
+  # Track installed plugin version for --check
+  local plugin_manifest="${skills_src}/.claude-plugin/plugin.json"
+  if [ -f "$plugin_manifest" ]; then
+    python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" "$plugin_manifest" \
+      > "$VERSION_FILE" 2>/dev/null || true
+  fi
 }
 
 # ─────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "github": {
       "release": true
     },
+    "hooks": {
+      "after:bump": "node scripts/bump-plugin-versions.mjs ${version}"
+    },
     "plugins": {
       "@release-it/bumper": {
         "out": [

--- a/scripts/bump-plugin-versions.mjs
+++ b/scripts/bump-plugin-versions.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const version = process.argv[2];
+if (!version) {
+  console.error('usage: bump-plugin-versions.mjs <version>');
+  process.exit(1);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pluginPath = resolve(repoRoot, 'apps/claude-plugins/.claude-plugin/plugin.json');
+const plugin = JSON.parse(readFileSync(pluginPath, 'utf8'));
+plugin.version = version;
+writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
+
+const marketplacePath = resolve(repoRoot, '.claude-plugin/marketplace.json');
+const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
+marketplace.metadata = { ...(marketplace.metadata ?? {}), version };
+if (Array.isArray(marketplace.plugins)) {
+  marketplace.plugins = marketplace.plugins.map((p) =>
+    p?.name === 'tandemu' ? { ...p, version } : p,
+  );
+}
+writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + '\n');
+
+console.log(`Bumped plugin manifests to ${version}`);


### PR DESCRIPTION
## Summary
- Validates and enables Claude Code's native plugin-marketplace update flow for Tandemu. `/plugin update tandemu@tandemu` now actually upgrades users, because `plugin.json` / `marketplace.json` versions are bumped automatically by `pnpm release` (via `scripts/bump-plugin-versions.mjs`) — Claude Code compares that field, not the git SHA, and silently skips updates when it's unchanged.
- Fixes the long-standing `install.sh --check` bug: the install path now persists `~/.claude/tandemu-version.txt` both from `install.sh` and from the `/tandemu:setup` skill, so the check actually reports a real comparison.
- Documents the two update paths in `README.md` + `CLAUDE.md`; keeps `install.sh --uninstall` as the clean-reset path (no changes to it).

No new `/tandemu:update` skill — relying on Claude Code's native `/plugin update` keeps the surface area small.

Plugin bumped to **1.9.8**.

Linear: https://linear.app/sgsystems/issue/SGS-177/introduce-update-method-for-skills

## Test plan
- [ ] `pnpm release --dry-run` lists `apps/claude-plugins/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` as files touched by the after:bump hook
- [ ] After merge, cut a real release (1.9.8 → 1.9.9) — confirm the release commit updates top-level version + `metadata.version` + `plugins[0].version` in `marketplace.json`
- [ ] In a fresh Claude Code session: `/plugin marketplace update` → catalog shows the new version; `/plugin update tandemu@tandemu` → upgrades; restart → `/plugin list` shows the new version
- [ ] Fresh machine via `./install.sh`: `cat ~/.claude/tandemu-version.txt` equals the plugin.json version
- [ ] Locally edit `plugin.json` to a higher version → `./install.sh --check` reports "Update available"
- [ ] `./install.sh --uninstall` still removes `~/.claude/tandemu-version.txt` (already covered by existing glob at install.sh:100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)