### PR TITLE
feat: review-latency metrics (TTFR, TTM, reviewer load, AI/human split)

### DIFF
--- a/apps/backend/src/integrations/providers/github-git.service.ts
+++ b/apps/backend/src/integrations/providers/github-git.service.ts
@@ -37,6 +37,13 @@ export interface GitDeploymentData {
   statusUpdatedAt: string;
 }
 
+export interface GitPRReviewData {
+  id: number;
+  reviewer: string;
+  state: string;
+  submittedAt: string;
+}
+
 interface GitHubCommitResponse {
   sha: string;
   commit: {
@@ -55,6 +62,13 @@ interface GitHubPRResponse {
   html_url: string;
   user: { login: string } | null;
   labels: Array<{ name: string }>;
+}
+
+interface GitHubReviewResponse {
+  id: number;
+  user: { login: string } | null;
+  state: string;
+  submitted_at: string | null;
 }
 
 interface GitHubDeploymentResponse {
@@ -162,6 +176,30 @@ export class GitHubGitService {
     } catch (error) {
       this.logger.warn(`Failed to fetch PRs for ${owner}/${repo} (token may lack repo access): ${error}`);
       Sentry.captureException(error, { tags: { operation: 'provider-github-fetch-prs' }, extra: { owner, repo } });
+      return [];
+    }
+  }
+
+  async fetchPRReviews(
+    token: string,
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ): Promise<GitPRReviewData[]> {
+    const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}/reviews?per_page=100`;
+    try {
+      const reviews = await githubFetch<GitHubReviewResponse[]>(url, token);
+      return reviews
+        .filter((r) => r.submitted_at && r.user?.login)
+        .map((r) => ({
+          id: r.id,
+          reviewer: r.user!.login,
+          state: r.state,
+          submittedAt: r.submitted_at!,
+        }));
+    } catch (error) {
+      this.logger.warn(`Failed to fetch reviews for ${owner}/${repo}#${prNumber}: ${error}`);
+      Sentry.captureException(error, { tags: { operation: 'provider-github-fetch-pr-reviews' }, extra: { owner, repo, prNumber } });
       return [];
     }
   }

--- a/apps/backend/src/queue/github-sync.processor.ts
+++ b/apps/backend/src/queue/github-sync.processor.ts
@@ -51,6 +51,21 @@ export class GitHubSyncProcessor extends SentryProcessor {
 
     this.logger.log(`Synced ${prs.length} merged PRs for ${repo}`);
 
+    // Sync PR reviews for the fetched PRs (review-latency metrics)
+    try {
+      let reviewCount = 0;
+      for (const pr of prs) {
+        const reviews = await this.gitHubGitService.fetchPRReviews(token, owner, repoName, pr.number);
+        if (reviews.length > 0) {
+          await this.telemetryService.insertGitHubPRReviews(organizationId, repo, teamId, pr, reviews);
+          reviewCount += reviews.length;
+        }
+      }
+      this.logger.log(`Synced ${reviewCount} PR reviews across ${prs.length} PRs for ${repo}`);
+    } catch (err) {
+      this.logger.warn(`Failed to sync PR reviews for ${repo}: ${err}`);
+    }
+
     // Sync GitHub Deployments (for proper DORA deployment tracking)
     try {
       const deployments = await this.gitHubGitService.fetchDeployments(token, owner, repoName, {

--- a/apps/backend/src/telemetry/telemetry.controller.ts
+++ b/apps/backend/src/telemetry/telemetry.controller.ts
@@ -318,6 +318,29 @@ export class TelemetryController {
     return { ...metrics, githubConnected, githubReposMapped, incidentProviderConnected };
   }
 
+  @Get('review-latency')
+  async getReviewLatencyMetrics(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('teamId') teamId?: string,
+  ) {
+    const metrics = await this.telemetryService.getReviewLatencyMetrics(user.organizationId, startDate, endDate, teamId);
+
+    let githubConnected = false;
+    let githubReposMapped = false;
+    try {
+      const integration = await this.integrationsService.findOne(user.organizationId, 'github');
+      githubConnected = true;
+      const mappings = await this.integrationsService.getMappings(integration.id);
+      githubReposMapped = mappings.length > 0;
+    } catch {
+      // Not found — no GitHub integration
+    }
+
+    return { ...metrics, githubConnected, githubReposMapped };
+  }
+
   @Post('github-sync')
   @HttpCode(HttpStatus.OK)
   async triggerGitHubSync(

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -134,6 +134,30 @@ export class TelemetryService implements OnModuleDestroy {
       this.logger.warn(`Failed to create github_pull_requests table: ${err}`);
     });
 
+    // Auto-create github_pr_reviews table for review-latency metrics
+    this.client.query({
+      query: `
+        CREATE TABLE IF NOT EXISTS github_pr_reviews (
+          organization_id String,
+          repo String,
+          team_id String,
+          pr_number UInt32,
+          review_id UInt64,
+          reviewer String,
+          state String,
+          submitted_at DateTime64(3),
+          pr_author String,
+          pr_created_at DateTime64(3),
+          pr_has_ai_coauthor UInt8 DEFAULT 0,
+          synced_at DateTime DEFAULT now()
+        ) ENGINE = ReplacingMergeTree(synced_at)
+        ORDER BY (organization_id, repo, pr_number, review_id)
+        TTL synced_at + INTERVAL 365 DAY
+      `,
+    }).then((rs) => rs.text()).catch((err) => {
+      this.logger.warn(`Failed to create github_pr_reviews table: ${err}`);
+    });
+
     // Auto-create github_deployments table for DORA deployment tracking
     this.client.query({
       query: `
@@ -1810,6 +1834,48 @@ export class TelemetryService implements OnModuleDestroy {
     }
   }
 
+  async insertGitHubPRReviews(
+    organizationId: string,
+    repo: string,
+    teamId: string,
+    pr: {
+      number: number;
+      author: { login: string };
+      createdAt: string;
+      body: string;
+      title: string;
+    },
+    reviews: Array<{ id: number; reviewer: string; state: string; submittedAt: string }>,
+  ): Promise<void> {
+    if (reviews.length === 0) return;
+
+    const hasAiCoauthor = (pr.body?.includes('Co-Authored-By: Claude') || pr.title?.toLowerCase().includes('[ai]')) ? 1 : 0;
+    const values = reviews.map((r) => ({
+      organization_id: organizationId,
+      repo,
+      team_id: teamId,
+      pr_number: pr.number,
+      review_id: r.id,
+      reviewer: r.reviewer,
+      state: r.state,
+      submitted_at: TelemetryService.dt(r.submittedAt),
+      pr_author: pr.author.login,
+      pr_created_at: TelemetryService.dt(pr.createdAt),
+      pr_has_ai_coauthor: hasAiCoauthor,
+    }));
+
+    try {
+      await this.client.insert({
+        table: 'github_pr_reviews',
+        values,
+        format: 'JSONEachRow',
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to insert PR reviews for ${repo}#${pr.number}: ${err}`);
+      Sentry.captureException(err, { tags: { operation: 'telemetry-insert-github-pr-reviews' }, extra: { repo, prNumber: pr.number } });
+    }
+  }
+
   async insertGitHubDeployments(
     organizationId: string,
     repo: string,
@@ -1929,6 +1995,20 @@ export class TelemetryService implements OnModuleDestroy {
     return 'low';
   }
 
+  private static rateTimeToFirstReview(hours: number): 'elite' | 'high' | 'medium' | 'low' {
+    if (hours < 4) return 'elite';
+    if (hours < 24) return 'high';
+    if (hours < 72) return 'medium';
+    return 'low';
+  }
+
+  private static rateTimeToMerge(hours: number): 'elite' | 'high' | 'medium' | 'low' {
+    if (hours < 24) return 'elite';
+    if (hours < 24 * 3) return 'high';
+    if (hours < 24 * 7) return 'medium';
+    return 'low';
+  }
+
   async getDORAMetrics(
     organizationId: string,
     startDate?: string,
@@ -1939,6 +2019,10 @@ export class TelemetryService implements OnModuleDestroy {
     leadTimeForChanges: { medianHours: number; p95Hours: number; trend: Array<{ week: string; medianHours: number }>; rating: string } | null;
     changeFailureRate: { rate: number; failedDeploys: number; totalDeploys: number; trend: Array<{ week: string; rate: number }>; rating: string } | null;
     meanTimeToRestore: { medianHours: number; p95Hours: number; trend: Array<{ week: string; medianHours: number }>; rating: string } | null;
+    reviewLatency: {
+      timeToFirstReview: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+      timeToMerge: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+    } | null;
     dataSource: 'deployments' | 'pull_requests';
   }> {
     const nullResult = {
@@ -1946,6 +2030,7 @@ export class TelemetryService implements OnModuleDestroy {
       leadTimeForChanges: null,
       changeFailureRate: null,
       meanTimeToRestore: null,
+      reviewLatency: null,
       dataSource: 'pull_requests' as const,
     };
 
@@ -2209,6 +2294,17 @@ export class TelemetryService implements OnModuleDestroy {
         this.logger.warn(`Failed to compute MTTR: ${err}`);
       }
 
+      // ── Review latency summary (for dashboard card) ──
+      let reviewLatencySummary: {
+        timeToFirstReview: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+        timeToMerge: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+      } | null = null;
+      try {
+        reviewLatencySummary = await this.computeReviewLatencySummary(organizationId, startDate, endDate, teamId);
+      } catch (err) {
+        this.logger.warn(`Failed to compute review latency summary: ${err}`);
+      }
+
       return {
         deploymentFrequency: {
           avgPerWeek: Math.round(avgPerWeek * 10) / 10,
@@ -2223,6 +2319,7 @@ export class TelemetryService implements OnModuleDestroy {
         },
         changeFailureRate,
         meanTimeToRestore,
+        reviewLatency: reviewLatencySummary,
         dataSource: hasDeployments ? 'deployments' : 'pull_requests',
       };
     } catch (err) {
@@ -2233,8 +2330,415 @@ export class TelemetryService implements OnModuleDestroy {
         leadTimeForChanges: null,
         changeFailureRate: null,
         meanTimeToRestore: null,
+        reviewLatency: null,
         dataSource: 'pull_requests',
       };
+    }
+  }
+
+  private async computeReviewLatencySummary(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+    teamId?: string,
+  ): Promise<{
+    timeToFirstReview: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+    timeToMerge: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null;
+  } | null> {
+    const params: Record<string, string> = { organizationId };
+    if (startDate) params.startDate = TelemetryService.dt(startDate);
+    if (endDate) params.endDate = TelemetryService.dt(endDate);
+    if (teamId) params.teamId = teamId;
+    const teamFilter = teamId ? ` AND team_id = {teamId: String}` : '';
+
+    let dateFilterReview = '';
+    let dateFilterPR = '';
+    if (startDate) {
+      dateFilterReview += ` AND pr_created_at >= {startDate: DateTime64(3)}`;
+      dateFilterPR += ` AND merged_at >= {startDate: DateTime64(3)}`;
+    }
+    if (endDate) {
+      dateFilterReview += ` AND pr_created_at <= {endDate: DateTime64(3)}`;
+      dateFilterPR += ` AND merged_at <= {endDate: DateTime64(3)}`;
+    }
+
+    // ── Time to first review ──
+    const ttfrResult = await this.client.query({
+      query: `SELECT
+                quantile(0.5)(hours) AS medianHours,
+                count(*) AS sampleCount
+              FROM (
+                SELECT CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                FROM github_pr_reviews FINAL
+                WHERE organization_id = {organizationId: String}
+                  AND reviewer != pr_author
+                  ${dateFilterReview} ${teamFilter}
+                GROUP BY repo, pr_number, pr_created_at
+              )`,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const [ttfrAgg] = await ttfrResult.json<{ medianHours: number; sampleCount: number }>();
+    const ttfrSample = ttfrAgg ? Number(ttfrAgg.sampleCount) : 0;
+
+    let timeToFirstReview: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null = null;
+    if (ttfrSample > 0 && Number(ttfrAgg.medianHours) > 0) {
+      const ttfrTrendResult = await this.client.query({
+        query: `SELECT week, quantile(0.5)(hours) AS medianHours
+                FROM (
+                  SELECT toStartOfWeek(pr_created_at) AS week,
+                         CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                  FROM github_pr_reviews FINAL
+                  WHERE organization_id = {organizationId: String}
+                    AND reviewer != pr_author
+                    ${dateFilterReview} ${teamFilter}
+                  GROUP BY week, repo, pr_number, pr_created_at
+                )
+                GROUP BY week ORDER BY week`,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+      const ttfrTrendRows = await ttfrTrendResult.json<{ week: string; medianHours: number }>();
+      const median = Number(ttfrAgg.medianHours);
+      timeToFirstReview = {
+        medianHours: Math.round(median * 10) / 10,
+        trend: ttfrTrendRows.map((r) => ({ week: r.week, medianHours: Math.round(Number(r.medianHours) * 10) / 10 })),
+        rating: TelemetryService.rateTimeToFirstReview(median),
+      };
+    }
+
+    // ── Time to merge ──
+    const ttmResult = await this.client.query({
+      query: `SELECT
+                quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours,
+                count(*) AS sampleCount
+              FROM github_pull_requests FINAL
+              WHERE organization_id = {organizationId: String}
+                ${dateFilterPR} ${teamFilter}`,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const [ttmAgg] = await ttmResult.json<{ medianHours: number; sampleCount: number }>();
+    const ttmSample = ttmAgg ? Number(ttmAgg.sampleCount) : 0;
+
+    let timeToMerge: { medianHours: number; trend: Array<{ week: string; medianHours: number }>; rating: 'elite' | 'high' | 'medium' | 'low' } | null = null;
+    if (ttmSample > 0 && Number(ttmAgg.medianHours) > 0) {
+      const ttmTrendResult = await this.client.query({
+        query: `SELECT toStartOfWeek(merged_at) AS week,
+                  quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours
+                FROM github_pull_requests FINAL
+                WHERE organization_id = {organizationId: String}
+                  ${dateFilterPR} ${teamFilter}
+                GROUP BY week ORDER BY week`,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+      const ttmTrendRows = await ttmTrendResult.json<{ week: string; medianHours: number }>();
+      const median = Number(ttmAgg.medianHours);
+      timeToMerge = {
+        medianHours: Math.round(median * 10) / 10,
+        trend: ttmTrendRows.map((r) => ({ week: r.week, medianHours: Math.round(Number(r.medianHours) * 10) / 10 })),
+        rating: TelemetryService.rateTimeToMerge(median),
+      };
+    }
+
+    if (!timeToFirstReview && !timeToMerge) return null;
+    return { timeToFirstReview, timeToMerge };
+  }
+
+  async getReviewLatencyMetrics(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+    teamId?: string,
+  ): Promise<{
+    timeToFirstReview: {
+      medianHours: number;
+      p95Hours: number;
+      sampleCount: number;
+      trend: Array<{ week: string; medianHours: number; sampleCount: number }>;
+      splitByAI: {
+        ai: { medianHours: number; sampleCount: number } | null;
+        human: { medianHours: number; sampleCount: number } | null;
+        trend: Array<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>;
+      };
+      rating: 'elite' | 'high' | 'medium' | 'low';
+    } | null;
+    timeToMerge: {
+      medianHours: number;
+      p95Hours: number;
+      sampleCount: number;
+      trend: Array<{ week: string; medianHours: number; sampleCount: number }>;
+      splitByAI: {
+        ai: { medianHours: number; sampleCount: number } | null;
+        human: { medianHours: number; sampleCount: number } | null;
+        trend: Array<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>;
+      };
+      rating: 'elite' | 'high' | 'medium' | 'low';
+    } | null;
+    reviewerLoad: Array<{ reviewer: string; prsReviewed: number; medianTurnaroundHours: number }>;
+  }> {
+    const nullResult = {
+      timeToFirstReview: null,
+      timeToMerge: null,
+      reviewerLoad: [] as Array<{ reviewer: string; prsReviewed: number; medianTurnaroundHours: number }>,
+    };
+    try {
+      const params: Record<string, string> = { organizationId };
+      if (startDate) params.startDate = TelemetryService.dt(startDate);
+      if (endDate) params.endDate = TelemetryService.dt(endDate);
+      if (teamId) params.teamId = teamId;
+      const teamFilter = teamId ? ` AND team_id = {teamId: String}` : '';
+
+      let dateFilterReview = '';
+      let dateFilterPR = '';
+      if (startDate) {
+        dateFilterReview += ` AND pr_created_at >= {startDate: DateTime64(3)}`;
+        dateFilterPR += ` AND merged_at >= {startDate: DateTime64(3)}`;
+      }
+      if (endDate) {
+        dateFilterReview += ` AND pr_created_at <= {endDate: DateTime64(3)}`;
+        dateFilterPR += ` AND merged_at <= {endDate: DateTime64(3)}`;
+      }
+
+      // ── Time to first review ──
+      const ttfrAggResult = await this.client.query({
+        query: `SELECT
+                  quantile(0.5)(hours) AS medianHours,
+                  quantile(0.95)(hours) AS p95Hours,
+                  count(*) AS sampleCount
+                FROM (
+                  SELECT CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                  FROM github_pr_reviews FINAL
+                  WHERE organization_id = {organizationId: String}
+                    AND reviewer != pr_author
+                    ${dateFilterReview} ${teamFilter}
+                  GROUP BY repo, pr_number, pr_created_at
+                )`,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+      const [ttfrAgg] = await ttfrAggResult.json<{ medianHours: number; p95Hours: number; sampleCount: number }>();
+
+      let timeToFirstReview: {
+        medianHours: number;
+        p95Hours: number;
+        sampleCount: number;
+        trend: Array<{ week: string; medianHours: number; sampleCount: number }>;
+        splitByAI: {
+          ai: { medianHours: number; sampleCount: number } | null;
+          human: { medianHours: number; sampleCount: number } | null;
+          trend: Array<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>;
+        };
+        rating: 'elite' | 'high' | 'medium' | 'low';
+      } | null = null;
+
+      if (ttfrAgg && Number(ttfrAgg.sampleCount) > 0) {
+        const ttfrTrendResult = await this.client.query({
+          query: `SELECT week, quantile(0.5)(hours) AS medianHours, count(*) AS sampleCount
+                  FROM (
+                    SELECT toStartOfWeek(pr_created_at) AS week,
+                           CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                    FROM github_pr_reviews FINAL
+                    WHERE organization_id = {organizationId: String}
+                      AND reviewer != pr_author
+                      ${dateFilterReview} ${teamFilter}
+                    GROUP BY week, repo, pr_number, pr_created_at
+                  )
+                  GROUP BY week ORDER BY week`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const ttfrTrendRows = await ttfrTrendResult.json<{ week: string; medianHours: number; sampleCount: number }>();
+
+        const ttfrSplitResult = await this.client.query({
+          query: `SELECT pr_has_ai_coauthor AS isAi, quantile(0.5)(hours) AS medianHours, count(*) AS sampleCount
+                  FROM (
+                    SELECT pr_has_ai_coauthor,
+                           CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                    FROM github_pr_reviews FINAL
+                    WHERE organization_id = {organizationId: String}
+                      AND reviewer != pr_author
+                      ${dateFilterReview} ${teamFilter}
+                    GROUP BY repo, pr_number, pr_created_at, pr_has_ai_coauthor
+                  )
+                  GROUP BY isAi`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const splitRows = await ttfrSplitResult.json<{ isAi: number; medianHours: number; sampleCount: number }>();
+        const aiRow = splitRows.find((r) => Number(r.isAi) === 1);
+        const humanRow = splitRows.find((r) => Number(r.isAi) === 0);
+
+        const ttfrSplitTrendResult = await this.client.query({
+          query: `SELECT week, pr_has_ai_coauthor AS isAi, quantile(0.5)(hours) AS medianHours
+                  FROM (
+                    SELECT toStartOfWeek(pr_created_at) AS week,
+                           pr_has_ai_coauthor,
+                           CAST(dateDiff('second', pr_created_at, min(submitted_at)) AS Float64) / 3600.0 AS hours
+                    FROM github_pr_reviews FINAL
+                    WHERE organization_id = {organizationId: String}
+                      AND reviewer != pr_author
+                      ${dateFilterReview} ${teamFilter}
+                    GROUP BY week, repo, pr_number, pr_created_at, pr_has_ai_coauthor
+                  )
+                  GROUP BY week, isAi ORDER BY week`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const splitTrendRows = await ttfrSplitTrendResult.json<{ week: string; isAi: number; medianHours: number }>();
+        const trendMap = new Map<string, { aiMedianHours: number | null; humanMedianHours: number | null }>();
+        for (const r of splitTrendRows) {
+          const entry = trendMap.get(r.week) ?? { aiMedianHours: null, humanMedianHours: null };
+          if (Number(r.isAi) === 1) entry.aiMedianHours = Math.round(Number(r.medianHours) * 10) / 10;
+          else entry.humanMedianHours = Math.round(Number(r.medianHours) * 10) / 10;
+          trendMap.set(r.week, entry);
+        }
+
+        const median = Number(ttfrAgg.medianHours);
+        timeToFirstReview = {
+          medianHours: Math.round(median * 10) / 10,
+          p95Hours: Math.round(Number(ttfrAgg.p95Hours) * 10) / 10,
+          sampleCount: Number(ttfrAgg.sampleCount),
+          trend: ttfrTrendRows.map((r) => ({
+            week: r.week,
+            medianHours: Math.round(Number(r.medianHours) * 10) / 10,
+            sampleCount: Number(r.sampleCount),
+          })),
+          splitByAI: {
+            ai: aiRow ? { medianHours: Math.round(Number(aiRow.medianHours) * 10) / 10, sampleCount: Number(aiRow.sampleCount) } : null,
+            human: humanRow ? { medianHours: Math.round(Number(humanRow.medianHours) * 10) / 10, sampleCount: Number(humanRow.sampleCount) } : null,
+            trend: Array.from(trendMap.entries())
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([week, v]) => ({ week, aiMedianHours: v.aiMedianHours, humanMedianHours: v.humanMedianHours })),
+          },
+          rating: TelemetryService.rateTimeToFirstReview(median),
+        };
+      }
+
+      // ── Time to merge ──
+      const ttmAggResult = await this.client.query({
+        query: `SELECT
+                  quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours,
+                  quantile(0.95)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS p95Hours,
+                  count(*) AS sampleCount
+                FROM github_pull_requests FINAL
+                WHERE organization_id = {organizationId: String}
+                  ${dateFilterPR} ${teamFilter}`,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+      const [ttmAgg] = await ttmAggResult.json<{ medianHours: number; p95Hours: number; sampleCount: number }>();
+
+      let timeToMerge: {
+        medianHours: number;
+        p95Hours: number;
+        sampleCount: number;
+        trend: Array<{ week: string; medianHours: number; sampleCount: number }>;
+        splitByAI: {
+          ai: { medianHours: number; sampleCount: number } | null;
+          human: { medianHours: number; sampleCount: number } | null;
+          trend: Array<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>;
+        };
+        rating: 'elite' | 'high' | 'medium' | 'low';
+      } | null = null;
+
+      if (ttmAgg && Number(ttmAgg.sampleCount) > 0) {
+        const ttmTrendResult = await this.client.query({
+          query: `SELECT toStartOfWeek(merged_at) AS week,
+                    quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours,
+                    count(*) AS sampleCount
+                  FROM github_pull_requests FINAL
+                  WHERE organization_id = {organizationId: String}
+                    ${dateFilterPR} ${teamFilter}
+                  GROUP BY week ORDER BY week`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const ttmTrendRows = await ttmTrendResult.json<{ week: string; medianHours: number; sampleCount: number }>();
+
+        const ttmSplitResult = await this.client.query({
+          query: `SELECT has_ai_coauthor AS isAi,
+                    quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours,
+                    count(*) AS sampleCount
+                  FROM github_pull_requests FINAL
+                  WHERE organization_id = {organizationId: String}
+                    ${dateFilterPR} ${teamFilter}
+                  GROUP BY isAi`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const ttmSplitRows = await ttmSplitResult.json<{ isAi: number; medianHours: number; sampleCount: number }>();
+        const ttmAiRow = ttmSplitRows.find((r) => Number(r.isAi) === 1);
+        const ttmHumanRow = ttmSplitRows.find((r) => Number(r.isAi) === 0);
+
+        const ttmSplitTrendResult = await this.client.query({
+          query: `SELECT toStartOfWeek(merged_at) AS week, has_ai_coauthor AS isAi,
+                    quantile(0.5)(CAST(dateDiff('second', created_at, merged_at) AS Float64) / 3600.0) AS medianHours
+                  FROM github_pull_requests FINAL
+                  WHERE organization_id = {organizationId: String}
+                    ${dateFilterPR} ${teamFilter}
+                  GROUP BY week, isAi ORDER BY week`,
+          query_params: params,
+          format: 'JSONEachRow',
+        });
+        const ttmSplitTrendRows = await ttmSplitTrendResult.json<{ week: string; isAi: number; medianHours: number }>();
+        const ttmTrendMap = new Map<string, { aiMedianHours: number | null; humanMedianHours: number | null }>();
+        for (const r of ttmSplitTrendRows) {
+          const entry = ttmTrendMap.get(r.week) ?? { aiMedianHours: null, humanMedianHours: null };
+          if (Number(r.isAi) === 1) entry.aiMedianHours = Math.round(Number(r.medianHours) * 10) / 10;
+          else entry.humanMedianHours = Math.round(Number(r.medianHours) * 10) / 10;
+          ttmTrendMap.set(r.week, entry);
+        }
+
+        const median = Number(ttmAgg.medianHours);
+        timeToMerge = {
+          medianHours: Math.round(median * 10) / 10,
+          p95Hours: Math.round(Number(ttmAgg.p95Hours) * 10) / 10,
+          sampleCount: Number(ttmAgg.sampleCount),
+          trend: ttmTrendRows.map((r) => ({
+            week: r.week,
+            medianHours: Math.round(Number(r.medianHours) * 10) / 10,
+            sampleCount: Number(r.sampleCount),
+          })),
+          splitByAI: {
+            ai: ttmAiRow ? { medianHours: Math.round(Number(ttmAiRow.medianHours) * 10) / 10, sampleCount: Number(ttmAiRow.sampleCount) } : null,
+            human: ttmHumanRow ? { medianHours: Math.round(Number(ttmHumanRow.medianHours) * 10) / 10, sampleCount: Number(ttmHumanRow.sampleCount) } : null,
+            trend: Array.from(ttmTrendMap.entries())
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([week, v]) => ({ week, aiMedianHours: v.aiMedianHours, humanMedianHours: v.humanMedianHours })),
+          },
+          rating: TelemetryService.rateTimeToMerge(median),
+        };
+      }
+
+      // ── Reviewer load ──
+      const loadResult = await this.client.query({
+        query: `SELECT reviewer,
+                  count(DISTINCT repo, pr_number) AS prsReviewed,
+                  quantile(0.5)(CAST(dateDiff('second', pr_created_at, submitted_at) AS Float64) / 3600.0) AS medianTurnaroundHours
+                FROM github_pr_reviews FINAL
+                WHERE organization_id = {organizationId: String}
+                  AND reviewer != pr_author
+                  ${dateFilterReview} ${teamFilter}
+                GROUP BY reviewer
+                ORDER BY prsReviewed DESC
+                LIMIT 10`,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+      const loadRows = await loadResult.json<{ reviewer: string; prsReviewed: number; medianTurnaroundHours: number }>();
+      const reviewerLoad = loadRows.map((r) => ({
+        reviewer: r.reviewer,
+        prsReviewed: Number(r.prsReviewed),
+        medianTurnaroundHours: Math.round(Number(r.medianTurnaroundHours) * 10) / 10,
+      }));
+
+      return { timeToFirstReview, timeToMerge, reviewerLoad };
+    } catch (err) {
+      this.logger.warn(`Failed to get review latency metrics: ${err}`);
+      Sentry.captureException(err, { tags: { operation: 'telemetry-review-latency' } });
+      return nullResult;
     }
   }
 }

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -4,12 +4,13 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Zap, Clock, DollarSign, Info, Settings, TrendingUp, TrendingDown, Minus } from 'lucide-react';
-import { getInsightsMetrics, getTokenUsage, getDeveloperCostBreakdown } from '@/lib/api';
-import type { InsightsMetrics, TokenUsageEntry, DeveloperCostEntry } from '@/lib/api';
+import { getInsightsMetrics, getTokenUsage, getDeveloperCostBreakdown, getReviewLatencyMetrics } from '@/lib/api';
+import type { InsightsMetrics, TokenUsageEntry, DeveloperCostEntry, ReviewLatencyMetrics } from '@/lib/api';
 import { TelemetryFilters, useFilterParams } from '@/components/filters/telemetry-filters';
 import { ThroughputChart, CostEfficiencyChart } from '@/components/charts/insights-chart';
 import { TokenUsageChart } from '@/components/charts/token-usage-chart';
 import { DeveloperCostChart } from '@/components/charts/developer-cost-chart';
+import { ReviewLatencyCard } from '@/components/charts/review-latency-card';
 import { InsightsSkeleton } from '@/components/ui/skeleton-helpers';
 
 function formatCurrency(value: number | null, currency = 'USD'): string {
@@ -26,6 +27,7 @@ export default function InsightsPage() {
   const [data, setData] = useState<InsightsMetrics | null>(null);
   const [tokenData, setTokenData] = useState<TokenUsageEntry[]>([]);
   const [devCostData, setDevCostData] = useState<DeveloperCostEntry[]>([]);
+  const [reviewLatency, setReviewLatency] = useState<ReviewLatencyMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const { startDate, endDate, teamId } = useFilterParams();
 
@@ -35,15 +37,17 @@ export default function InsightsPage() {
       setLoading(true);
       try {
         const f = { startDate, endDate, teamId };
-        const [insights, tokens, devCost] = await Promise.allSettled([
+        const [insights, tokens, devCost, review] = await Promise.allSettled([
           getInsightsMetrics(f),
           getTokenUsage(f),
           getDeveloperCostBreakdown(f),
+          getReviewLatencyMetrics(f),
         ]);
         if (cancelled) return;
         if (insights.status === 'fulfilled') setData(insights.value);
         if (tokens.status === 'fulfilled') setTokenData(tokens.value);
         if (devCost.status === 'fulfilled') setDevCostData(devCost.value);
+        if (review.status === 'fulfilled') setReviewLatency(review.value);
       } catch {
         // Non-critical
       } finally {
@@ -229,6 +233,12 @@ export default function InsightsPage() {
               <TokenUsageChart data={tokenData} />
               <DeveloperCostChart data={devCostData} currency={data.assumptions.currency} />
             </div>
+          </div>
+
+          {/* Review Latency */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight">Review Velocity</h2>
+            <ReviewLatencyCard data={reviewLatency} startDate={startDate} endDate={endDate} />
           </div>
 
         </>

--- a/apps/frontend/src/components/charts/dora-metrics-card.tsx
+++ b/apps/frontend/src/components/charts/dora-metrics-card.tsx
@@ -5,7 +5,7 @@ import {
   AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
 } from 'recharts';
 import { TOOLTIP_CONTENT_STYLE, TOOLTIP_LABEL_STYLE, TOOLTIP_ITEM_STYLE } from '@/lib/chart-theme';
-import { Clock, GitPullRequest, AlertTriangle, Wrench, Rocket, ArrowRight } from 'lucide-react';
+import { Clock, GitPullRequest, AlertTriangle, Wrench, Rocket, ArrowRight, MessageSquare, GitMerge } from 'lucide-react';
 import type { DORAMetrics } from '@/lib/api';
 
 const RATING_COLORS: Record<string, string> = {
@@ -122,6 +122,11 @@ export function DORAMetricsCard({ data }: DORAMetricsCardProps) {
   const leadAccent = lead ? RATING_COLORS[lead.rating] : undefined;
   const cfrAccent = cfr ? RATING_COLORS[cfr.rating] : undefined;
   const mttrAccent = mttr ? RATING_COLORS[mttr.rating] : undefined;
+  const reviewLatency = data.reviewLatency;
+  const ttfr = reviewLatency?.timeToFirstReview ?? null;
+  const ttm = reviewLatency?.timeToMerge ?? null;
+  const ttfrAccent = ttfr ? RATING_COLORS[ttfr.rating] : undefined;
+  const ttmAccent = ttm ? RATING_COLORS[ttm.rating] : undefined;
 
   const sourceLabel = data.dataSource === 'deployments' ? 'GitHub Deployments' : 'PR merges';
   const sparklineLabel = data.dataSource === 'deployments' ? 'Deploys / week' : 'PRs merged / week';
@@ -254,6 +259,31 @@ export function DORAMetricsCard({ data }: DORAMetricsCardProps) {
             </div>
           )}
         </section>
+
+        {/* Review tier */}
+        {reviewLatency ? (
+          <section>
+            <SectionLabel>Review</SectionLabel>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <HeroTile
+                icon={<MessageSquare className="size-3.5" />}
+                label="Time to First Review"
+                value={ttfr ? formatDuration(ttfr.medianHours) : '—'}
+                unit={ttfr ? 'median' : undefined}
+                rating={ttfr?.rating}
+                accent={ttfrAccent}
+              />
+              <HeroTile
+                icon={<GitMerge className="size-3.5" />}
+                label="Time to Merge"
+                value={ttm ? formatDuration(ttm.medianHours) : '—'}
+                unit={ttm ? 'median' : undefined}
+                rating={ttm?.rating}
+                accent={ttmAccent}
+              />
+            </div>
+          </section>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/apps/frontend/src/components/charts/review-latency-card.tsx
+++ b/apps/frontend/src/components/charts/review-latency-card.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid } from 'recharts';
+import { AXIS_TICK, TOOLTIP_CONTENT_STYLE, TOOLTIP_LABEL_STYLE, TOOLTIP_ITEM_STYLE, LEGEND_STYLE } from '@/lib/chart-theme';
+import type { ReviewLatencyMetrics, ReviewLatencyStat } from '@/lib/api';
+
+const AI_COLOR = '#60a5fa';
+const HUMAN_COLOR = '#a1a1aa';
+
+interface ReviewLatencyCardProps {
+  data: ReviewLatencyMetrics | null;
+}
+
+function formatDuration(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours < 24) return `${Math.round(hours * 10) / 10}h`;
+  return `${Math.round(hours / 24 * 10) / 10}d`;
+}
+
+function fillWeeks(
+  trend: ReadonlyArray<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>,
+  startDate?: string,
+  endDate?: string,
+): Array<{ label: string; ai: number | null; human: number | null }> {
+  const byWeek = new Map(trend.map((t) => [t.week.slice(0, 10), t]));
+
+  let cursor: Date;
+  let end: Date;
+  if (startDate && endDate) {
+    cursor = new Date(startDate.slice(0, 10));
+    end = new Date(endDate.slice(0, 10));
+    // Snap to start of week (Sunday, matching ClickHouse toStartOfWeek default)
+    cursor.setDate(cursor.getDate() - cursor.getDay());
+  } else if (trend.length > 0) {
+    cursor = new Date(trend[0]!.week.slice(0, 10));
+    end = new Date(trend[trend.length - 1]!.week.slice(0, 10));
+  } else {
+    return [];
+  }
+
+  const result: Array<{ label: string; ai: number | null; human: number | null }> = [];
+  while (cursor <= end) {
+    const key = cursor.toISOString().slice(0, 10);
+    const row = byWeek.get(key);
+    result.push({
+      label: cursor.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      ai: row?.aiMedianHours ?? null,
+      human: row?.humanMedianHours ?? null,
+    });
+    cursor.setDate(cursor.getDate() + 7);
+  }
+  return result;
+}
+
+function SplitChart({
+  title,
+  stat,
+  startDate,
+  endDate,
+}: {
+  title: string;
+  stat: ReviewLatencyStat;
+  startDate?: string;
+  endDate?: string;
+}) {
+  const data = fillWeeks(stat.splitByAI.trend, startDate, endDate);
+  const tickInterval = Math.max(0, Math.ceil(data.length / 8) - 1);
+
+  return (
+    <div>
+      <div className="mb-2 flex items-baseline justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          {title}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          median {formatDuration(stat.medianHours)} · p95 {formatDuration(stat.p95Hours)} · {stat.sampleCount} PRs
+        </span>
+      </div>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+          <CartesianGrid stroke="#ffffff10" vertical={false} />
+          <XAxis dataKey="label" tick={AXIS_TICK} axisLine={false} tickLine={false} interval={tickInterval} />
+          <YAxis
+            tick={AXIS_TICK}
+            axisLine={false}
+            tickLine={false}
+            width={44}
+            tickFormatter={(v: number) => formatDuration(v)}
+          />
+          <Tooltip
+            contentStyle={TOOLTIP_CONTENT_STYLE}
+            labelStyle={TOOLTIP_LABEL_STYLE}
+            itemStyle={TOOLTIP_ITEM_STYLE}
+            formatter={(value: number, name: string) => [formatDuration(value), name]}
+          />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+          <Line type="monotone" dataKey="ai" name="AI PRs" stroke={AI_COLOR} strokeWidth={2} dot={{ r: 2 }} connectNulls />
+          <Line type="monotone" dataKey="human" name="Human PRs" stroke={HUMAN_COLOR} strokeWidth={2} dot={{ r: 2 }} connectNulls />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function AIvsHumanSummary({ stat, label }: { stat: ReviewLatencyStat; label: string }) {
+  const ai = stat.splitByAI.ai;
+  const human = stat.splitByAI.human;
+  if (!ai || !human || ai.sampleCount < 5 || human.sampleCount < 5) return null;
+
+  const diff = human.medianHours - ai.medianHours;
+  const pct = human.medianHours > 0 ? Math.abs(diff / human.medianHours) * 100 : 0;
+  if (pct < 10) return null; // suppress noise
+  const faster = diff > 0 ? 'AI' : 'Human';
+  const direction = diff > 0 ? 'faster' : 'slower';
+
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span className="font-medium text-foreground">{label}:</span>{' '}
+      {faster} PRs {direction} ({formatDuration(faster === 'AI' ? ai.medianHours : human.medianHours)} vs{' '}
+      {formatDuration(faster === 'AI' ? human.medianHours : ai.medianHours)} — {Math.round(pct)}% {direction}).
+    </p>
+  );
+}
+
+export function ReviewLatencyCard({
+  data,
+  startDate,
+  endDate,
+}: ReviewLatencyCardProps & { startDate?: string; endDate?: string }) {
+  if (!data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Review Latency</CardTitle>
+          <CardDescription>How fast PRs get reviewed and merged</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data.githubConnected) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Review Latency</CardTitle>
+          <CardDescription>How fast PRs get reviewed and merged</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">Connect GitHub to see review metrics</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data.githubReposMapped) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Review Latency</CardTitle>
+          <CardDescription>How fast PRs get reviewed and merged</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">
+            Map a GitHub repository to a team in Settings → Integrations to enable review metrics
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { timeToFirstReview, timeToMerge, reviewerLoad } = data;
+
+  if (!timeToFirstReview && !timeToMerge && reviewerLoad.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Review Latency</CardTitle>
+          <CardDescription>How fast PRs get reviewed and merged</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">
+            Syncing review data — appears after the next GitHub sync completes
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Review Latency</CardTitle>
+        <CardDescription>Time-to-first-review and time-to-merge, split by AI vs human PRs</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {timeToFirstReview ? (
+          <SplitChart title="Time to First Review" stat={timeToFirstReview} startDate={startDate} endDate={endDate} />
+        ) : null}
+        {timeToMerge ? (
+          <SplitChart title="Time to Merge" stat={timeToMerge} startDate={startDate} endDate={endDate} />
+        ) : null}
+
+        {(timeToFirstReview || timeToMerge) ? (
+          <div className="space-y-1 rounded-xl border border-border/60 bg-muted/20 px-4 py-3">
+            {timeToFirstReview ? <AIvsHumanSummary stat={timeToFirstReview} label="Time to First Review" /> : null}
+            {timeToMerge ? <AIvsHumanSummary stat={timeToMerge} label="Time to Merge" /> : null}
+          </div>
+        ) : null}
+
+        {reviewerLoad.length > 0 ? (
+          <div>
+            <div className="mb-2 flex items-baseline justify-between">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Reviewer Load
+              </span>
+              <span className="text-xs text-muted-foreground">Top {reviewerLoad.length}, by PRs reviewed</span>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border/60">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/30 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium">Reviewer</th>
+                    <th className="px-4 py-2 text-right font-medium">PRs Reviewed</th>
+                    <th className="px-4 py-2 text-right font-medium">Median Turnaround</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {reviewerLoad.map((r) => (
+                    <tr key={r.reviewer} className="border-t border-border/40">
+                      <td className="px-4 py-2">{r.reviewer}</td>
+                      <td className="px-4 py-2 text-right tabular-nums">{r.prsReviewed}</td>
+                      <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
+                        {formatDuration(r.medianTurnaroundHours)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -777,11 +777,25 @@ export interface DORAMeanTimeToRestore {
   rating: 'elite' | 'high' | 'medium' | 'low';
 }
 
+export interface ReviewLatencySummary {
+  timeToFirstReview: {
+    medianHours: number;
+    trend: Array<{ week: string; medianHours: number }>;
+    rating: 'elite' | 'high' | 'medium' | 'low';
+  } | null;
+  timeToMerge: {
+    medianHours: number;
+    trend: Array<{ week: string; medianHours: number }>;
+    rating: 'elite' | 'high' | 'medium' | 'low';
+  } | null;
+}
+
 export interface DORAMetrics {
   deploymentFrequency: DORADeploymentFrequency | null;
   leadTimeForChanges: DORALeadTime | null;
   changeFailureRate: DORAChangeFailureRate | null;
   meanTimeToRestore: DORAMeanTimeToRestore | null;
+  reviewLatency: ReviewLatencySummary | null;
   dataSource: 'deployments' | 'pull_requests';
   githubConnected: boolean;
   githubReposMapped: boolean;
@@ -790,6 +804,39 @@ export interface DORAMetrics {
 
 export async function getDORAMetrics(filter?: TelemetryFilter): Promise<DORAMetrics> {
   return fetchApi<DORAMetrics>(`/api/telemetry/dora-metrics${buildParams(filter)}`);
+}
+
+// ── Review Latency ──
+
+export interface ReviewLatencyStat {
+  medianHours: number;
+  p95Hours: number;
+  sampleCount: number;
+  trend: Array<{ week: string; medianHours: number; sampleCount: number }>;
+  splitByAI: {
+    ai: { medianHours: number; sampleCount: number } | null;
+    human: { medianHours: number; sampleCount: number } | null;
+    trend: Array<{ week: string; aiMedianHours: number | null; humanMedianHours: number | null }>;
+  };
+  rating: 'elite' | 'high' | 'medium' | 'low';
+}
+
+export interface ReviewerLoadEntry {
+  reviewer: string;
+  prsReviewed: number;
+  medianTurnaroundHours: number;
+}
+
+export interface ReviewLatencyMetrics {
+  timeToFirstReview: ReviewLatencyStat | null;
+  timeToMerge: ReviewLatencyStat | null;
+  reviewerLoad: ReviewerLoadEntry[];
+  githubConnected: boolean;
+  githubReposMapped: boolean;
+}
+
+export async function getReviewLatencyMetrics(filter?: TelemetryFilter): Promise<ReviewLatencyMetrics> {
+  return fetchApi<ReviewLatencyMetrics>(`/api/telemetry/review-latency${buildParams(filter)}`);
 }
 
 // ── Version & Updates ──

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -189,8 +189,49 @@ export interface DORAMetrics {
   readonly leadTimeForChanges: DORALeadTime | null;
   readonly changeFailureRate: DORAChangeFailureRate | null;
   readonly meanTimeToRestore: DORAMeanTimeToRestore | null;
+  readonly reviewLatency: ReviewLatencySummary | null;
   readonly dataSource: 'deployments' | 'pull_requests';
   readonly githubConnected: boolean;
   readonly githubReposMapped: boolean;
   readonly incidentProviderConnected: boolean;
+}
+
+export interface ReviewLatencySummary {
+  readonly timeToFirstReview: {
+    readonly medianHours: number;
+    readonly trend: ReadonlyArray<{ readonly week: string; readonly medianHours: number }>;
+    readonly rating: 'elite' | 'high' | 'medium' | 'low';
+  } | null;
+  readonly timeToMerge: {
+    readonly medianHours: number;
+    readonly trend: ReadonlyArray<{ readonly week: string; readonly medianHours: number }>;
+    readonly rating: 'elite' | 'high' | 'medium' | 'low';
+  } | null;
+}
+
+export interface ReviewLatencyStat {
+  readonly medianHours: number;
+  readonly p95Hours: number;
+  readonly sampleCount: number;
+  readonly trend: ReadonlyArray<{ readonly week: string; readonly medianHours: number; readonly sampleCount: number }>;
+  readonly splitByAI: {
+    readonly ai: { readonly medianHours: number; readonly sampleCount: number } | null;
+    readonly human: { readonly medianHours: number; readonly sampleCount: number } | null;
+    readonly trend: ReadonlyArray<{ readonly week: string; readonly aiMedianHours: number | null; readonly humanMedianHours: number | null }>;
+  };
+  readonly rating: 'elite' | 'high' | 'medium' | 'low';
+}
+
+export interface ReviewerLoadEntry {
+  readonly reviewer: string;
+  readonly prsReviewed: number;
+  readonly medianTurnaroundHours: number;
+}
+
+export interface ReviewLatencyMetrics {
+  readonly timeToFirstReview: ReviewLatencyStat | null;
+  readonly timeToMerge: ReviewLatencyStat | null;
+  readonly reviewerLoad: ReadonlyArray<ReviewerLoadEntry>;
+  readonly githubConnected: boolean;
+  readonly githubReposMapped: boolean;
 }


### PR DESCRIPTION
## Summary

- New **Review** tier on the main dashboard's DORA card — Time to First Review and Time to Merge tiles with rating badges.
- New full-breakdown card on `/insights` with AI-PR vs human-PR split line charts, a headline AI-vs-human stat, and a top-10 reviewer-load leaderboard.
- Ingests PR reviews from GitHub into a new `github_pr_reviews` ClickHouse table via the existing 4h github-sync job (no new OAuth scopes, `pulls:read` already granted).

This is the actionable follow-up pulled out of the SGS-49 Graphite research — the one gap where Graphite Insights clearly beat Tandemu. The AI/human split is the angle Graphite structurally can't match because they don't track `Co-Authored-By: Claude`.

### Architecture notes

- `github_pr_reviews` denormalizes `pr_created_at`, `pr_author`, and `pr_has_ai_coauthor` onto each review row so the hot queries (time-to-first-review grouped by week × AI-flag) avoid FINAL joins.
- Rating thresholds (elite <4h / high <24h / medium <72h / low ≥72h for TTFR; <24h / <3d / <7d / ≥7d for TTM) are starting guesses — calibrate after a week of real data.
- AI-vs-human headline stat is suppressed when N_AI < 5, N_human < 5, or the delta is under 10% to avoid noise-driven claims.
- Self-reviews (reviewer == PR author) are filtered out of TTFR.
- Empty states follow the existing DORA card pattern: no GitHub → connect; no repo mapping → map; connected → syncing.

### Scope out of this PR

- Historical backfill (let the 5-day overlap window fill naturally over ~3 months).
- Draft-PR lifecycle (time-to-ready-for-review) — would require webhooks.
- Review-quality metrics (approval rate, changes-requested rate, comment density).

## Test plan

- [ ] Backend boot: logs show `github_pr_reviews` table created without error.
- [ ] After one sync: `SELECT count(*) FROM github_pr_reviews` > 0 for a repo with recent merged PRs.
- [ ] `GET /api/telemetry/review-latency?startDate=&endDate=` returns non-null `timeToFirstReview` with a reasonable median.
- [ ] `/insights` renders the Review Velocity section with two split line charts + reviewer table; AI/Human lines visibly different.
- [ ] Main dashboard's DORA card shows a new Review section between Delivery and Reliability with two populated HeroTiles.
- [ ] Fresh org with no data: empty states render cleanly without JS errors (`reviewLatency: null` path).

## Follow-ups (not in this PR)

- Tune rating thresholds against 1 week of production data.
- Confirm `has_ai_coauthor` detection (currently `Co-Authored-By: Claude` in PR body or `[ai]` in title) captures actual Tandemu AI PRs before relying on the split as the headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)