### PR TITLE
fix(skills): prepend env source to every Bash call using TANDEMU_* vars

### DIFF
--- a/apps/skills/create/SKILL.md
+++ b/apps/skills/create/SKILL.md
@@ -9,6 +9,12 @@ allowed-tools:
 
 Create a new task in the team's ticket system. Use when you discover work that needs tracking while coding.
 
+**IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
+
+```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+```
+
 ## Steps
 
 ### 1. Setup
@@ -62,6 +68,7 @@ Set `SELECTED_TEAM_ID` from the choice. If single team, use `$TANDEMU_TEAM_ID` d
 **Determine the provider**: If there's an active task (from step 1), use its `provider` field. Otherwise omit — the backend prefers dedicated trackers (Linear, Jira, etc.) over GitHub by default.
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 RESULT=$(curl -sf -X POST "$TANDEMU_API/api/tasks" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/finish/SKILL.md
+++ b/apps/skills/finish/SKILL.md
@@ -15,6 +15,12 @@ Help the developer wrap up their current task cleanly, measure the work done, an
 
 **Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, OTEL setup, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Prepare telemetry". Keep context-dependent operations (git diff, git stash) and user-facing operations (task selection, PR checks, summaries) as separate calls.
 
+**IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
+
+```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+```
+
 ## Steps
 
 ### 1. Check for uncommitted work
@@ -137,6 +143,7 @@ Build the request body from the collected data — do NOT calculate AI lines you
 **IMPORTANT: This call MUST succeed for /finish to complete. If it fails, tell the developer and STOP.**
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 RESULT=$(curl -sf -X POST "$TANDEMU_API/api/telemetry/tasks/<taskId>/finish" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
@@ -170,12 +177,14 @@ If the curl fails or returns an error, tell the developer and **STOP**.
 If the developer marked the task as "Done", update the status on the provider. First fetch the available statuses, then pick the one that best represents "done" or "completed":
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "done", "completed", or "closed" from the returned list, then:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/morning/SKILL.md
+++ b/apps/skills/morning/SKILL.md
@@ -16,6 +16,12 @@ Help the developer start their work session by picking a task.
 
 **Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Setup". Keep user-facing operations (task selection, PR checks, summaries) as separate, clearly described calls.
 
+**IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, `$TANDEMU_TEAM_ID`, etc. MUST source the env loader first:
+
+```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+```
+
 ## Steps
 
 ### 0. Greet personally (memory)
@@ -156,6 +162,7 @@ Set `SELECTED_TEAM_ID` from the choice. If "All teams" is selected, set `SELECTE
 Fetch tasks assigned to the current developer in a single call. The API handles multi-team dedup and unassigned fallback server-side:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&mine=true&fallbackUnassigned=true&sort=priority&order=desc"
 ```
 
@@ -186,6 +193,7 @@ If there are more than 4 tasks, show the top 4 and mention how many more exist.
 After the developer picks a task, check if `hasSubtasks` is `true` on the selected task. If so, fetch the subtasks:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/subtasks?provider=<task.provider>"
 ```
 
@@ -284,6 +292,7 @@ EOF
 - Update the task on the ticket system — set status to "in progress" AND assign it to the current developer. First fetch the available statuses, then pick the one that best represents "in progress":
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 # Fetch available statuses for this task
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/statuses?provider=<task.provider>"
 ```
@@ -293,6 +302,7 @@ This returns an array of `{ id, name, type }` objects — the actual statuses av
 Then send a single PATCH to update both status and assignee:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<task.id>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
@@ -311,6 +321,7 @@ If you can't determine which status to use, still send the assignee update witho
 After setting up the task, silently check for knowledge gaps:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 GAPS=$(curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/memory/gaps" 2>/dev/null)
 ```
 

--- a/apps/skills/pause/SKILL.md
+++ b/apps/skills/pause/SKILL.md
@@ -11,6 +11,12 @@ Pause the current task so the developer can switch to something else.
 
 **Execution style:** Minimize tool call noise. Combine pure-read infrastructure commands (config loads, active task reads, OTEL setup, timestamp calculations) into as few Bash calls as possible with brief descriptions like "Setup". Keep user-facing operations (git stats, summaries) as separate calls.
 
+**IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
+
+```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+```
+
 ## Steps
 
 ### 1. Setup — load config, active task, and OTEL endpoint
@@ -78,6 +84,8 @@ Sum additions, deletions, and commits across all repos.
 Convert timestamps and send a `task_session` span with `status=paused` (use the OTEL endpoint from setup):
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+OTEL_ENDPOINT=$(python3 -c "import json; s=json.load(open('$HOME/.claude/settings.json')); print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))" 2>/dev/null)
 START_NS=$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('<startedAt>'.replace('Z','+00:00')).timestamp()*1e9))")
 END_NS=$(python3 -c "from datetime import datetime; print(int(datetime.utcnow().timestamp()*1e9))")
 TRACE_ID=$(python3 -c "import secrets; print(secrets.token_hex(16))")
@@ -119,12 +127,14 @@ curl -sf -X POST "$OTEL_ENDPOINT/v1/traces" \
 Set the task back to a paused/backlog state on the provider. First fetch available statuses, then pick the one that best represents "paused", "on hold", "todo", or "backlog":
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "todo", "backlog", "on hold", or "paused" from the returned list, then:
 
 ```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/standup/SKILL.md
+++ b/apps/skills/standup/SKILL.md
@@ -12,6 +12,12 @@ Generate a team standup report. Options: $ARGUMENTS
 
 **Execution style:** Minimize tool call noise. Load config and fetch standup data in a single Bash call ("Fetch standup data"). Keep the formatted report output as a separate step.
 
+**IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
+
+```bash
+. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+```
+
 ## Steps
 
 ### 1. Fetch standup data


### PR DESCRIPTION
## Summary
Each Claude Code Bash invocation is a fresh shell. Skills assumed env vars set in the setup block persisted to later Bash calls — they don't. Curl snippets failed with `URL rejected: No host part in the URL` because `\$TANDEMU_API` was empty.

## Symptom (reproduced)
Running `/tandemu:morning`:
```
Bash(curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?...")
  ⎿  Error: Exit code 3
     FAILED: curl curl: (3) URL rejected: No host part in the URL
```

## Fix
- Added `IMPORTANT — env vars don't persist across Bash calls` note near the top of each skill (morning, finish, pause, create, standup).
- Prepended `. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null` to every curl snippet that lives in its own Bash block (8 snippets across 4 skills). Snippets inside the setup block are unchanged — same shell as the source.
- pause's OTEL trace POST also re-derives `OTEL_ENDPOINT` from `settings.json` since that var doesn't persist either.

## Test plan
- [ ] Run `/tandemu:morning` end-to-end — task list loads without curl errors.
- [ ] Run `/tandemu:finish` — telemetry POST succeeds.
- [ ] Run `/tandemu:pause` — partial OTEL trace fires.
- [ ] Run `/tandemu:create` — task creates via POST.
- [ ] Run `/tandemu:standup` — standup data fetches (no behavior change here, was already working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)