### PR TITLE
fix(release): drop unsupported bumper out-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,6 @@
     "plugins": {
       "@release-it/bumper": {
         "out": [
-          {
-            "path": "packages/types/src/version.ts",
-            "type": "text/plain",
-            "consumeWholeFile": true,
-            "data": "export const VERSION = '${version}';\n"
-          },
           "apps/backend/package.json",
           "apps/frontend/package.json"
         ]

--- a/scripts/bump-plugin-versions.mjs
+++ b/scripts/bump-plugin-versions.mjs
@@ -31,4 +31,7 @@ const opencodePlugin = JSON.parse(readFileSync(opencodePluginPath, 'utf8'));
 opencodePlugin.version = version;
 writeFileSync(opencodePluginPath, JSON.stringify(opencodePlugin, null, 2) + '\n');
 
-console.log(`Bumped plugin manifests to ${version}`);
+const versionTsPath = resolve(repoRoot, 'packages/types/src/version.ts');
+writeFileSync(versionTsPath, `export const VERSION = '${version}';\n`);
+
+console.log(`Bumped plugin manifests + VERSION.ts to ${version}`);


### PR DESCRIPTION
## Summary
- \`pnpm release\` failed with \`ERROR Patterns must be a string (non empty) or an array of strings\` after generating the changelog. Cause: \`@release-it/bumper@7\` reinterpreted the \`path\` key in \`out\` entries as a JMESPath, not a file path, so the object entry for \`packages/types/src/version.ts\` was invalid. Triggered the v0.4.0 release to fall back to manual bumps.
- Drop the object entry from \`@release-it/bumper.out\` (now just \`apps/backend/package.json\`, \`apps/frontend/package.json\`).
- Move the \`VERSION.ts\` write into \`scripts/bump-plugin-versions.mjs\` so the \`after:bump\` hook keeps it in sync with plugin manifests.

## Test plan
- [ ] \`pnpm release\` (or \`pnpm release-it <ver> --ci --dry-run\`) completes without the \"Patterns must be a string\" error.
- [ ] After release, \`packages/types/src/version.ts\`, root + backend + frontend + opencode-plugin \`package.json\`, claude-plugin manifest, and \`marketplace.json\` all show the new version.
- [ ] Release workflow's \`Verify opencode-plugin version matches release\` step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)