### PR TITLE
fix(opencode-plugin): rename to @sebastiangrebe/opencode-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         working-directory: apps/opencode-plugin
         run: pnpm exec tsc --noEmit
 
-      - name: Publish @tandemu/opencode-plugin to npm
+      - name: Publish @sebastiangrebe/opencode-plugin to npm
         working-directory: apps/opencode-plugin
         run: npm publish --access public --provenance
         env:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cd tandemu
 ./install.sh --target=opencode
 ```
 
-The installer authenticates you, registers `@tandemu/opencode-plugin` in `opencode.json`, and copies skills, commands, and `AGENTS.md` into `~/.config/opencode/`. The plugin itself is auto-installed by Bun on the next `opencode` launch.
+The installer authenticates you, registers `@sebastiangrebe/opencode-plugin` in `opencode.json`, and copies skills, commands, and `AGENTS.md` into `~/.config/opencode/`. The plugin itself is auto-installed by Bun on the next `opencode` launch.
 
 Exit and reopen your editor to activate memory, then start working:
 
@@ -113,7 +113,7 @@ apps/
   frontend/       — Next.js dashboard (shadcn/ui + Recharts)
   skills/         — Shared skills + AGENTS.md (used by both editor plugins)
   claude-plugins/ — Claude Code packaging (marketplace plugin)
-  opencode-plugin/— OpenCode packaging (npm plugin: @tandemu/opencode-plugin)
+  opencode-plugin/— OpenCode packaging (npm plugin: @sebastiangrebe/opencode-plugin)
   e2e/            — Playwright E2E tests
 packages/
   types/          — Shared TypeScript types
@@ -186,7 +186,7 @@ Then restart Claude Code so skills reload. Updates only propagate when `plugin.j
 OpenCode resolves the plugin from npm via Bun. Update by re-resolving:
 
 ```bash
-bun update @tandemu/opencode-plugin
+bun update @sebastiangrebe/opencode-plugin
 ```
 
 Or restart `opencode` if you're tracking a floating semver range.

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -1,4 +1,4 @@
-# @tandemu/opencode-plugin
+# @sebastiangrebe/opencode-plugin
 
 Tandemu AI Teammate plugin for [OpenCode](https://opencode.ai). Adds the same task lifecycle, telemetry, persistent memory, and personality system that Tandemu provides to Claude Code, but native to OpenCode.
 
@@ -11,7 +11,7 @@ Tandemu AI Teammate plugin for [OpenCode](https://opencode.ai). Adds the same ta
 # 2. Add the plugin to opencode.json (install.sh does this automatically):
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@tandemu/opencode-plugin"]
+  "plugin": ["@sebastiangrebe/opencode-plugin"]
 }
 ```
 

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tandemu/opencode-plugin",
+  "name": "@sebastiangrebe/opencode-plugin",
   "version": "0.4.0",
   "description": "Tandemu AI Teammate plugin for OpenCode — task lifecycle, telemetry, memory, personality.",
   "type": "module",

--- a/apps/opencode-plugin/src/lib/otlp.ts
+++ b/apps/opencode-plugin/src/lib/otlp.ts
@@ -74,7 +74,7 @@ function buildOtlpPayload(batch: Counter[], config: TandemuConfig) {
         },
         scopeMetrics: [
           {
-            scope: { name: "@tandemu/opencode-plugin", version: "1.9.8" },
+            scope: { name: "@sebastiangrebe/opencode-plugin", version: "0.4.0" },
             metrics: [...byMetric.entries()].map(([metric, points]) => ({
               name: metric,
               sum: {

--- a/install.sh
+++ b/install.sh
@@ -764,8 +764,8 @@ except (FileNotFoundError, json.JSONDecodeError):
 cfg.setdefault("$schema", "https://opencode.ai/config.json")
 
 plugins = cfg.get("plugin", [])
-if "@tandemu/opencode-plugin" not in plugins:
-    plugins.append("@tandemu/opencode-plugin")
+if "@sebastiangrebe/opencode-plugin" not in plugins:
+    plugins.append("@sebastiangrebe/opencode-plugin")
 cfg["plugin"] = plugins
 
 mem_type = os.environ.get("TANDEMU_MEM_TYPE", "")


### PR DESCRIPTION
## Summary
- Release workflow's npm publish step fails with \`404 Scope not found\` because the \`@tandemu\` npm scope is not provisioned and the publishing account does not own it.
- Rename to \`@sebastiangrebe/opencode-plugin\` (personal scope, already owned) so publishes succeed without an org migration.
- Updates: \`apps/opencode-plugin/package.json\` (name), \`install.sh\` (opencode.json plugin entry), root \`README.md\` and \`apps/opencode-plugin/README.md\` (install + update snippets), \`apps/opencode-plugin/src/lib/otlp.ts\` (scope name + bump stale \`1.9.8\` → \`0.4.0\`), \`.github/workflows/release.yml\` (step label).

## Test plan
- [ ] After merge + tag, Release workflow's \`Publish ... to npm\` step succeeds (no 404 / 403).
- [ ] Fresh \`./install.sh --target=opencode\` writes \`{"plugin": ["@sebastiangrebe/opencode-plugin"]}\` to \`~/.config/opencode/opencode.json\`.
- [ ] OpenCode launches and Bun installs the package from the new name.
- [ ] OTLP metrics arrive at the backend with \`scope.name = "@sebastiangrebe/opencode-plugin"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)