### PR TITLE
feat(install): MCP-first targets for Cursor, Copilot CLI, Codex CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ Each task gets its own git worktree inside `.worktrees/<task-id>/`. Task files a
 ### Task status sync is dynamic
 No hardcoded status mappings. Skills fetch available statuses from the ticket system (`GET /api/tasks/:id/statuses?provider=linear`), then Claude picks the best match and sends `PATCH /api/tasks/:id` with `{ statusName, assigneeEmail, provider }`. Any combination of fields is accepted in a single call.
 
-### Telemetry via OTLP from `/finish`
-The `/finish` skill sends a `task_session` span and `tandemu.lines_of_code` metrics to the OTEL collector via curl. This is real OTLP — standard protocol, custom metric names. No fake data.
+### Telemetry from `/finish`
+The `/finish` skill POSTs a REST payload to `${TANDEMU_API}/api/telemetry/tasks/:id/finish`; the backend emits the `task_session` span and `tandemu.lines_of_code` metrics via OTLP server-side. Works on every agent (only needs `$TANDEMU_API`/`$TANDEMU_TOKEN` from the env loader). The `/pause` skill still sends an OTLP `task_session` span (`status=paused`) directly to the collector via curl, using `$TANDEMU_OTEL_ENDPOINT` (env-loader-derived from the API host; falls back to `~/.claude/settings.json` on Claude Code, then localhost). Real OTLP — standard protocol, custom metric names. No fake data.
 
 AI vs manual attribution: commits with `Co-Authored-By: Claude` = AI lines, rest = manual.
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,14 @@ docker compose up -d
 
 ### 2. Connect your AI editor
 
-Tandemu installs into any of: **Claude Code**, **OpenCode**, **Cursor**, **GitHub Copilot CLI**, **Codex CLI** — pick one or run them side by side.
+Tandemu installs into any of: **Claude Code**, **OpenCode**, **Cursor**, **Codex CLI** — pick one or run them side by side. All four get the same skills (`/morning`, `/finish`, `/pause`, `/create`, `/standup`).
 
-| Agent | How it integrates | Slash commands | Install |
-|-------|-------------------|----------------|---------|
-| Claude Code | Plugin marketplace + skills + hooks | ✅ `/morning`, `/finish`, `/pause`, `/standup` | `/plugin install tandemu` (in Claude) or `./install.sh --target=claude` |
-| OpenCode | npm plugin (`@sebastiangrebe/opencode-plugin`) + skills + hooks | ✅ same as Claude | `./install.sh --target=opencode` |
-| Cursor | MCP server + `.cursor/rules/tandemu.mdc` | ❌ — ask via chat ("list my tasks") | `./install.sh --target=cursor` |
-| Copilot CLI | MCP server + `~/.copilot/AGENTS.md` | ❌ — ask via `gh copilot` | `./install.sh --target=copilot` |
-| Codex CLI | MCP server + `~/.codex/AGENTS.md` | ❌ — ask in REPL | `./install.sh --target=codex` |
+| Agent | Skill location | Memory MCP | Install |
+|-------|----------------|------------|---------|
+| Claude Code | Plugin marketplace + `~/.claude/skills/` | `~/.mcp.json` | `/plugin install tandemu` (in Claude) or `./install.sh --target=claude` |
+| OpenCode | npm plugin + `~/.config/opencode/skills/` | `opencode.json` `mcp.tandemu-memory` | `./install.sh --target=opencode` |
+| Cursor | `~/.cursor/commands/<name>.md` + `.cursor/rules/tandemu.mdc` | `~/.cursor/mcp.json` | `./install.sh --target=cursor` |
+| Codex CLI | `~/.codex/prompts/<name>.md` + `~/.codex/AGENTS.md` | `~/.codex/config.toml` | `./install.sh --target=codex` |
 
 **Claude Code (recommended):**
 
@@ -95,23 +94,15 @@ cd tandemu
 ./install.sh --target=all              # everything detected
 ```
 
-The installer authenticates you (browser-based OAuth), registers the Tandemu MCP server in each agent's config, and drops the canonical `AGENTS.md` (or Cursor `.mdc` rule) so the agent picks up your personality + memory bootstrap.
+The installer authenticates you (browser-based OAuth), drops the canonical `AGENTS.md` (or Cursor `.mdc` rule), copies the 6 skills as native slash commands into each agent's command directory, and registers the Tandemu memory MCP server. Skills source a universal env loader at `~/.config/tandemu/lib/tandemu-env.sh` so they run identically regardless of which agent invokes them.
 
-Exit and reopen your editor to activate the new MCP server, then start working:
+Exit and reopen your editor, then start working:
 
 ```bash
-/morning              # Claude Code / OpenCode
-"list my tasks"       # Cursor / Copilot CLI / Codex CLI
+/morning
 ```
 
-#### How the MCP-first model works
-
-For Cursor / Copilot / Codex, Tandemu does not ship a per-editor plugin. Instead it registers a single MCP server (the same backend that already serves memory) which exposes:
-
-- `list_tasks`, `get_task_statuses`, `update_task`, `create_task` — task lifecycle against your ticket system (Linear / Jira / ClickUp / GitHub)
-- `add_memory`, `search_memories`, `get_memories`, `update_memory`, `delete_memory` — personal + org memory
-
-Slash commands (`/morning`, `/finish`, `/standup`) require lifecycle hooks and are kept exclusive to Claude Code + OpenCode where they're polished. On the lightweight agents you ask in plain English — the agent picks the right MCP tool. Telemetry from Cursor / Copilot / Codex comes from server-side MCP-call counting plus git commit attribution; tool-use telemetry is Claude-Code-only.
+Slash command UX (`/morning`, `/finish`, `/pause`, `/create`, `/standup`) is identical across all four agents. Cursor and Codex run skills via their custom-commands / prompts directories; Claude Code and OpenCode run them via their plugin marketplaces. Telemetry from `/finish` (lines, AI ratio, session duration) flows to the dashboard from every agent.
 
 ### 3. Development mode
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,17 @@ docker compose up -d
 
 ### 2. Connect your AI editor
 
-Tandemu installs into either **Claude Code** or **OpenCode** (or both, side by side).
+Tandemu installs into any of: **Claude Code**, **OpenCode**, **Cursor**, **GitHub Copilot CLI**, **Codex CLI** — pick one or run them side by side.
 
-**Claude Code:**
+| Agent | How it integrates | Slash commands | Install |
+|-------|-------------------|----------------|---------|
+| Claude Code | Plugin marketplace + skills + hooks | ✅ `/morning`, `/finish`, `/pause`, `/standup` | `/plugin install tandemu` (in Claude) or `./install.sh --target=claude` |
+| OpenCode | npm plugin (`@sebastiangrebe/opencode-plugin`) + skills + hooks | ✅ same as Claude | `./install.sh --target=opencode` |
+| Cursor | MCP server + `.cursor/rules/tandemu.mdc` | ❌ — ask via chat ("list my tasks") | `./install.sh --target=cursor` |
+| Copilot CLI | MCP server + `~/.copilot/AGENTS.md` | ❌ — ask via `gh copilot` | `./install.sh --target=copilot` |
+| Codex CLI | MCP server + `~/.codex/AGENTS.md` | ❌ — ask in REPL | `./install.sh --target=codex` |
+
+**Claude Code (recommended):**
 
 ```bash
 # In Claude Code:
@@ -77,23 +85,33 @@ Tandemu installs into either **Claude Code** or **OpenCode** (or both, side by s
 /tandemu:setup
 ```
 
-**OpenCode:**
+**Any other agent — or multiple:**
 
 ```bash
 git clone https://github.com/sebastiangrebe/tandemu.git
 cd tandemu
-./install.sh --target=opencode
+./install.sh                           # auto-detects installed agents
+./install.sh --target=cursor,codex     # explicit, comma-separated
+./install.sh --target=all              # everything detected
 ```
 
-The installer authenticates you, registers `@sebastiangrebe/opencode-plugin` in `opencode.json`, and copies skills, commands, and `AGENTS.md` into `~/.config/opencode/`. The plugin itself is auto-installed by Bun on the next `opencode` launch.
+The installer authenticates you (browser-based OAuth), registers the Tandemu MCP server in each agent's config, and drops the canonical `AGENTS.md` (or Cursor `.mdc` rule) so the agent picks up your personality + memory bootstrap.
 
-Exit and reopen your editor to activate memory, then start working:
+Exit and reopen your editor to activate the new MCP server, then start working:
 
 ```bash
-/morning
+/morning              # Claude Code / OpenCode
+"list my tasks"       # Cursor / Copilot CLI / Codex CLI
 ```
 
-> The Claude Code path also has `./install.sh --target=claude` as a scripted alternative. With both editors installed, `./install.sh` auto-detects, or pass `--target=both`. See the [setup docs](https://tandemu.dev/docs/setup) for details.
+#### How the MCP-first model works
+
+For Cursor / Copilot / Codex, Tandemu does not ship a per-editor plugin. Instead it registers a single MCP server (the same backend that already serves memory) which exposes:
+
+- `list_tasks`, `get_task_statuses`, `update_task`, `create_task` — task lifecycle against your ticket system (Linear / Jira / ClickUp / GitHub)
+- `add_memory`, `search_memories`, `get_memories`, `update_memory`, `delete_memory` — personal + org memory
+
+Slash commands (`/morning`, `/finish`, `/standup`) require lifecycle hooks and are kept exclusive to Claude Code + OpenCode where they're polished. On the lightweight agents you ask in plain English — the agent picks the right MCP tool. Telemetry from Cursor / Copilot / Codex comes from server-side MCP-call counting plus git commit attribution; tool-use telemetry is Claude-Code-only.
 
 ### 3. Development mode
 
@@ -191,16 +209,17 @@ bun update @sebastiangrebe/opencode-plugin
 
 Or restart `opencode` if you're tracking a floating semver range.
 
-### install.sh users (either editor)
+### install.sh users (any editor)
 
 ```bash
 cd tandemu && git pull
 ./install.sh --check              # see installed vs latest for each target
 ./install.sh                      # auto-detect targets and update in place
-./install.sh --target=both        # explicitly update both
+./install.sh --target=all         # update every detected agent
+./install.sh --target=cursor      # single-agent update
 ```
 
-`pnpm release` bumps the version across `apps/claude-plugins/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `apps/opencode-plugin/package.json` simultaneously.
+`pnpm release` bumps the version across `apps/claude-plugins/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `apps/opencode-plugin/package.json` simultaneously. The MCP-first targets (Cursor, Copilot, Codex) track the same plugin version for `--check` reporting.
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ Full documentation is available at **[tandemu.dev/docs](https://tandemu.dev/docs
 ```bash
 /plugin marketplace update        # refresh the catalog (does NOT upgrade the plugin)
 /plugin update tandemu@tandemu    # upgrade the installed plugin
+/tandemu:setup                    # re-run to refresh ~/.claude/lib + ~/.config/tandemu/lib
 ```
 
-Then restart Claude Code so skills reload. Updates only propagate when `plugin.json`'s `version` field changes.
+Restart Claude Code after the update so skills + hooks reload. The `/tandemu:setup` re-run is what propagates new loader logic into `~/.claude/lib/tandemu-env.sh` and `~/.config/tandemu/lib/tandemu-env.sh`; skipping it leaves the old loader in place and any in-flight task files won't migrate. Updates only propagate when `plugin.json`'s `version` field changes.
 
 ### OpenCode (npm)
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Exit and reopen your editor, then start working:
 /morning
 ```
 
-Slash command UX (`/morning`, `/finish`, `/pause`, `/create`, `/standup`) is identical across all four agents. Cursor and Codex run skills via their custom-commands / prompts directories; Claude Code and OpenCode run them via their plugin marketplaces. Telemetry from `/finish` (lines, AI ratio, session duration) flows to the dashboard from every agent.
+The same five skills (`/morning`, `/finish`, `/pause`, `/create`, `/standup`) are available on all four agents, and `/finish` telemetry (lines, AI ratio, session duration) flows to the dashboard from every one. Invocation differs slightly per agent: Claude Code and OpenCode load them via their plugin marketplaces; Cursor runs them as custom commands (Agent mode, per-step shell approval — the SKILL.md `allowed-tools` frontmatter is a no-op there); Codex exposes them under its namespaced `/prompts:` mechanism. Functionally equivalent, not pixel-identical.
 
 ### 3. Development mode
 

--- a/apps/backend/src/memory/memory.controller.ts
+++ b/apps/backend/src/memory/memory.controller.ts
@@ -23,7 +23,7 @@ import { CurrentUser, Roles } from '../auth/auth.decorator.js';
 import type { RequestUser } from '../auth/auth.decorator.js';
 import { MembershipRole } from '@tandemu/types';
 import { MemoryScope } from '@tandemu/types';
-import type { MemoryEntry, MemoryListResponse, MemoryStatsResponse, FileTreeNode, GapEntry } from '@tandemu/types';
+import type { MemoryEntry, MemoryListResponse, MemoryStatsResponse, FileTreeNode, GapEntry, TaskStatus, IntegrationProvider } from '@tandemu/types';
 import { InjectQueue } from '@nestjs/bullmq';
 import type { Queue } from 'bullmq';
 import { MemoryService } from './memory.service.js';
@@ -33,6 +33,27 @@ import { githubFetch } from '../integrations/providers/github.provider.js';
 import { TelemetryService } from '../telemetry/telemetry.service.js';
 import { AuthService } from '../auth/auth.service.js';
 import type { MemoryOpsJobData, TelemetryJobData } from '../queue/queue.types.js';
+
+// MCP tools advertised at /api/memory/mcp. Memory tools are handled by Mem0
+// (SaaS) or routed through MemoryService (OSS). Task tools are always
+// handled locally via TasksService.
+const MEMORY_TOOL_DEFS = [
+  { name: 'add_memory', description: 'Store a new memory', inputSchema: { type: 'object', properties: { text: { type: 'string' }, user_id: { type: 'string' }, metadata: { type: 'object' } }, required: ['text'] } },
+  { name: 'search_memories', description: 'Search memories', inputSchema: { type: 'object', properties: { query: { type: 'string' }, user_id: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
+  { name: 'get_memories', description: 'List all memories', inputSchema: { type: 'object', properties: { user_id: { type: 'string' } } } },
+  { name: 'delete_memory', description: 'Delete a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' } }, required: ['memory_id'] } },
+  { name: 'update_memory', description: 'Update a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' }, text: { type: 'string' } }, required: ['memory_id'] } },
+];
+
+const TASK_TOOL_DEFS = [
+  { name: 'list_tasks', description: 'List tasks from the connected ticket system. Filter by team, status, or assignment to current user.', inputSchema: { type: 'object', properties: { teamId: { type: 'string', description: 'Team ID. Use "all" for every team you belong to. Omit to use the default team.' }, mine: { type: 'boolean', description: 'Only return tasks assigned to the current user' }, status: { type: 'string', enum: ['todo', 'in_progress', 'in_review', 'done', 'cancelled'] }, excludeDone: { type: 'boolean', description: 'Filter out done/cancelled tasks' } } } },
+  { name: 'get_task_statuses', description: 'Get the available status names for a task in its ticket system. Call this before update_task to learn the valid statusName values.', inputSchema: { type: 'object', properties: { taskId: { type: 'string' }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] } }, required: ['taskId', 'provider'] } },
+  { name: 'update_task', description: 'Update a task. Use get_task_statuses first to find valid statusName. Set statusName to mark as in-progress, in-review, done, etc.', inputSchema: { type: 'object', properties: { taskId: { type: 'string' }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] }, statusName: { type: 'string' }, assigneeEmail: { type: 'string' }, priority: { type: 'string' }, description: { type: 'string' } }, required: ['taskId', 'provider'] } },
+  { name: 'create_task', description: 'Create a new task in the team\'s ticket system.', inputSchema: { type: 'object', properties: { teamId: { type: 'string' }, title: { type: 'string' }, description: { type: 'string' }, priority: { type: 'string', enum: ['urgent', 'high', 'medium', 'low'] }, assigneeEmail: { type: 'string' }, labels: { type: 'array', items: { type: 'string' } }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] } }, required: ['teamId', 'title'] } },
+];
+
+const TANDEMU_TOOLS = [...MEMORY_TOOL_DEFS, ...TASK_TOOL_DEFS];
+const TASK_TOOL_NAMES = new Set(TASK_TOOL_DEFS.map((t) => t.name));
 
 @Controller('memory')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -108,34 +129,44 @@ export class MemoryController {
     @Body() body: unknown,
   ): Promise<void> {
     const rpc = body as Record<string, unknown> | null;
+    const method = rpc?.method as string | undefined;
 
-    // OSS: translate MCP tool calls → REST API calls
+    // ── Common branches (handled the same in OSS and SaaS modes) ──
+
+    if (method === 'initialize') {
+      res.json({
+        jsonrpc: '2.0', id: rpc!.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: { name: 'tandemu', version: '1.0.0' },
+        },
+      });
+      return;
+    }
+
+    if (method === 'tools/list') {
+      res.json({
+        jsonrpc: '2.0', id: rpc!.id,
+        result: { tools: TANDEMU_TOOLS },
+      });
+      return;
+    }
+
+    // Task tools always handled locally via TasksService — never proxied to Mem0
+    if (method === 'tools/call' && this.isTaskTool(rpc!)) {
+      const result = await this.handleTaskToolCall(rpc!, user);
+      res.json({ jsonrpc: '2.0', id: rpc!.id, result });
+      return;
+    }
+
+    // ── Memory-only paths below ──
+
+    // OSS: translate memory MCP tool calls → REST API calls
     if (!this.memoryService.isMem0Cloud) {
-      if (rpc?.method === 'tools/call') {
-        const result = await this.handleMcpToolCallViaRest(rpc, user);
-        res.json({ jsonrpc: '2.0', id: rpc.id, result });
-      } else if (rpc?.method === 'initialize') {
-        res.json({
-          jsonrpc: '2.0', id: rpc.id,
-          result: {
-            protocolVersion: '2024-11-05',
-            capabilities: { tools: { listChanged: false } },
-            serverInfo: { name: 'tandemu-memory', version: '1.0.0' },
-          },
-        });
-      } else if (rpc?.method === 'tools/list') {
-        res.json({
-          jsonrpc: '2.0', id: rpc.id,
-          result: {
-            tools: [
-              { name: 'add_memory', description: 'Store a new memory', inputSchema: { type: 'object', properties: { text: { type: 'string' }, user_id: { type: 'string' }, metadata: { type: 'object' } }, required: ['text'] } },
-              { name: 'search_memories', description: 'Search memories', inputSchema: { type: 'object', properties: { query: { type: 'string' }, user_id: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
-              { name: 'get_memories', description: 'List all memories', inputSchema: { type: 'object', properties: { user_id: { type: 'string' } } } },
-              { name: 'delete_memory', description: 'Delete a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' } }, required: ['memory_id'] } },
-              { name: 'update_memory', description: 'Update a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' }, text: { type: 'string' } }, required: ['memory_id'] } },
-            ],
-          },
-        });
+      if (method === 'tools/call') {
+        const result = await this.handleMcpToolCallViaRest(rpc!, user);
+        res.json({ jsonrpc: '2.0', id: rpc!.id, result });
       } else {
         // notifications/initialized, etc. — acknowledge
         res.json({ jsonrpc: '2.0', id: rpc?.id ?? null, result: {} });
@@ -277,6 +308,103 @@ export class MemoryController {
     const params = rpc.params as Record<string, unknown> | undefined;
     const toolName = params?.name as string | undefined;
     return toolName === 'search_memories' || toolName === 'get_memories';
+  }
+
+  /**
+   * Check if a tool call targets a task tool (vs a memory tool).
+   */
+  private isTaskTool(rpc: Record<string, unknown>): boolean {
+    const params = rpc.params as Record<string, unknown> | undefined;
+    const toolName = params?.name as string | undefined;
+    return !!toolName && TASK_TOOL_NAMES.has(toolName);
+  }
+
+  /**
+   * Handle task MCP tool calls by delegating to TasksService. Used by external
+   * agents (Cursor, Codex, Copilot CLI) that connect to /api/memory/mcp and
+   * issue tool calls that match TASK_TOOL_DEFS.
+   */
+  private async handleTaskToolCall(
+    rpc: Record<string, unknown>,
+    user: RequestUser,
+  ): Promise<Record<string, unknown>> {
+    const params = rpc.params as Record<string, unknown>;
+    const toolName = params.name as string;
+    const args = (params.arguments ?? {}) as Record<string, unknown>;
+
+    try {
+      switch (toolName) {
+        case 'list_tasks': {
+          const teamId = args.teamId as string | undefined;
+          const mine = args.mine === true;
+          const status = args.status as TaskStatus | undefined;
+          const excludeDone = args.excludeDone === true;
+
+          let assigneeEmails: string[] | undefined;
+          if (mine) {
+            assigneeEmails = await this.authService.getAllEmailAddresses(user.userId);
+          }
+
+          const tasks = await this.tasksService.getTasks(user.organizationId, {
+            teamId,
+            assigneeEmail: mine ? user.email : undefined,
+            assigneeEmails,
+            sprint: 'current',
+            excludeDone,
+          });
+
+          const filtered = status ? tasks.filter((t) => t.status === status) : tasks;
+          return { content: [{ type: 'text', text: JSON.stringify(filtered) }] };
+        }
+
+        case 'get_task_statuses': {
+          const taskId = args.taskId as string;
+          const provider = args.provider as IntegrationProvider;
+          const statuses = await this.tasksService.getTaskStatuses(
+            user.organizationId,
+            taskId,
+            provider,
+          );
+          return { content: [{ type: 'text', text: JSON.stringify(statuses) }] };
+        }
+
+        case 'update_task': {
+          const taskId = args.taskId as string;
+          const provider = args.provider as IntegrationProvider;
+          await this.tasksService.updateTask(user.organizationId, taskId, provider, {
+            statusName: args.statusName as string | undefined,
+            assigneeEmail: args.assigneeEmail as string | undefined,
+            priority: args.priority as string | undefined,
+            description: args.description as string | undefined,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify({ status: 'ok' }) }] };
+        }
+
+        case 'create_task': {
+          const task = await this.tasksService.createTask(user.organizationId, {
+            teamId: args.teamId as string,
+            title: args.title as string,
+            description: args.description as string | undefined,
+            assigneeEmail: args.assigneeEmail as string | undefined,
+            priority: args.priority as string | undefined,
+            labels: args.labels as string[] | undefined,
+            provider: args.provider as IntegrationProvider | undefined,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(task) }] };
+        }
+
+        default:
+          return {
+            content: [{ type: 'text', text: `Unknown task tool: ${toolName}` }],
+            isError: true,
+          };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`MCP task tool ${toolName} failed: ${message}`);
+      Sentry.captureException(err, { tags: { operation: 'mcp-task-tool', toolName } });
+      return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+    }
   }
 
   /**

--- a/apps/backend/src/memory/memory.controller.ts
+++ b/apps/backend/src/memory/memory.controller.ts
@@ -23,7 +23,7 @@ import { CurrentUser, Roles } from '../auth/auth.decorator.js';
 import type { RequestUser } from '../auth/auth.decorator.js';
 import { MembershipRole } from '@tandemu/types';
 import { MemoryScope } from '@tandemu/types';
-import type { MemoryEntry, MemoryListResponse, MemoryStatsResponse, FileTreeNode, GapEntry, TaskStatus, IntegrationProvider } from '@tandemu/types';
+import type { MemoryEntry, MemoryListResponse, MemoryStatsResponse, FileTreeNode, GapEntry } from '@tandemu/types';
 import { InjectQueue } from '@nestjs/bullmq';
 import type { Queue } from 'bullmq';
 import { MemoryService } from './memory.service.js';
@@ -33,27 +33,6 @@ import { githubFetch } from '../integrations/providers/github.provider.js';
 import { TelemetryService } from '../telemetry/telemetry.service.js';
 import { AuthService } from '../auth/auth.service.js';
 import type { MemoryOpsJobData, TelemetryJobData } from '../queue/queue.types.js';
-
-// MCP tools advertised at /api/memory/mcp. Memory tools are handled by Mem0
-// (SaaS) or routed through MemoryService (OSS). Task tools are always
-// handled locally via TasksService.
-const MEMORY_TOOL_DEFS = [
-  { name: 'add_memory', description: 'Store a new memory', inputSchema: { type: 'object', properties: { text: { type: 'string' }, user_id: { type: 'string' }, metadata: { type: 'object' } }, required: ['text'] } },
-  { name: 'search_memories', description: 'Search memories', inputSchema: { type: 'object', properties: { query: { type: 'string' }, user_id: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
-  { name: 'get_memories', description: 'List all memories', inputSchema: { type: 'object', properties: { user_id: { type: 'string' } } } },
-  { name: 'delete_memory', description: 'Delete a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' } }, required: ['memory_id'] } },
-  { name: 'update_memory', description: 'Update a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' }, text: { type: 'string' } }, required: ['memory_id'] } },
-];
-
-const TASK_TOOL_DEFS = [
-  { name: 'list_tasks', description: 'List tasks from the connected ticket system. Filter by team, status, or assignment to current user.', inputSchema: { type: 'object', properties: { teamId: { type: 'string', description: 'Team ID. Use "all" for every team you belong to. Omit to use the default team.' }, mine: { type: 'boolean', description: 'Only return tasks assigned to the current user' }, status: { type: 'string', enum: ['todo', 'in_progress', 'in_review', 'done', 'cancelled'] }, excludeDone: { type: 'boolean', description: 'Filter out done/cancelled tasks' } } } },
-  { name: 'get_task_statuses', description: 'Get the available status names for a task in its ticket system. Call this before update_task to learn the valid statusName values.', inputSchema: { type: 'object', properties: { taskId: { type: 'string' }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] } }, required: ['taskId', 'provider'] } },
-  { name: 'update_task', description: 'Update a task. Use get_task_statuses first to find valid statusName. Set statusName to mark as in-progress, in-review, done, etc.', inputSchema: { type: 'object', properties: { taskId: { type: 'string' }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] }, statusName: { type: 'string' }, assigneeEmail: { type: 'string' }, priority: { type: 'string' }, description: { type: 'string' } }, required: ['taskId', 'provider'] } },
-  { name: 'create_task', description: 'Create a new task in the team\'s ticket system.', inputSchema: { type: 'object', properties: { teamId: { type: 'string' }, title: { type: 'string' }, description: { type: 'string' }, priority: { type: 'string', enum: ['urgent', 'high', 'medium', 'low'] }, assigneeEmail: { type: 'string' }, labels: { type: 'array', items: { type: 'string' } }, provider: { type: 'string', enum: ['linear', 'jira', 'clickup', 'github'] } }, required: ['teamId', 'title'] } },
-];
-
-const TANDEMU_TOOLS = [...MEMORY_TOOL_DEFS, ...TASK_TOOL_DEFS];
-const TASK_TOOL_NAMES = new Set(TASK_TOOL_DEFS.map((t) => t.name));
 
 @Controller('memory')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -129,44 +108,34 @@ export class MemoryController {
     @Body() body: unknown,
   ): Promise<void> {
     const rpc = body as Record<string, unknown> | null;
-    const method = rpc?.method as string | undefined;
 
-    // ── Common branches (handled the same in OSS and SaaS modes) ──
-
-    if (method === 'initialize') {
-      res.json({
-        jsonrpc: '2.0', id: rpc!.id,
-        result: {
-          protocolVersion: '2024-11-05',
-          capabilities: { tools: { listChanged: false } },
-          serverInfo: { name: 'tandemu', version: '1.0.0' },
-        },
-      });
-      return;
-    }
-
-    if (method === 'tools/list') {
-      res.json({
-        jsonrpc: '2.0', id: rpc!.id,
-        result: { tools: TANDEMU_TOOLS },
-      });
-      return;
-    }
-
-    // Task tools always handled locally via TasksService — never proxied to Mem0
-    if (method === 'tools/call' && this.isTaskTool(rpc!)) {
-      const result = await this.handleTaskToolCall(rpc!, user);
-      res.json({ jsonrpc: '2.0', id: rpc!.id, result });
-      return;
-    }
-
-    // ── Memory-only paths below ──
-
-    // OSS: translate memory MCP tool calls → REST API calls
+    // OSS: translate MCP tool calls → REST API calls
     if (!this.memoryService.isMem0Cloud) {
-      if (method === 'tools/call') {
-        const result = await this.handleMcpToolCallViaRest(rpc!, user);
-        res.json({ jsonrpc: '2.0', id: rpc!.id, result });
+      if (rpc?.method === 'tools/call') {
+        const result = await this.handleMcpToolCallViaRest(rpc, user);
+        res.json({ jsonrpc: '2.0', id: rpc.id, result });
+      } else if (rpc?.method === 'initialize') {
+        res.json({
+          jsonrpc: '2.0', id: rpc.id,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: { tools: { listChanged: false } },
+            serverInfo: { name: 'tandemu-memory', version: '1.0.0' },
+          },
+        });
+      } else if (rpc?.method === 'tools/list') {
+        res.json({
+          jsonrpc: '2.0', id: rpc.id,
+          result: {
+            tools: [
+              { name: 'add_memory', description: 'Store a new memory', inputSchema: { type: 'object', properties: { text: { type: 'string' }, user_id: { type: 'string' }, metadata: { type: 'object' } }, required: ['text'] } },
+              { name: 'search_memories', description: 'Search memories', inputSchema: { type: 'object', properties: { query: { type: 'string' }, user_id: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
+              { name: 'get_memories', description: 'List all memories', inputSchema: { type: 'object', properties: { user_id: { type: 'string' } } } },
+              { name: 'delete_memory', description: 'Delete a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' } }, required: ['memory_id'] } },
+              { name: 'update_memory', description: 'Update a memory', inputSchema: { type: 'object', properties: { memory_id: { type: 'string' }, text: { type: 'string' } }, required: ['memory_id'] } },
+            ],
+          },
+        });
       } else {
         // notifications/initialized, etc. — acknowledge
         res.json({ jsonrpc: '2.0', id: rpc?.id ?? null, result: {} });
@@ -308,103 +277,6 @@ export class MemoryController {
     const params = rpc.params as Record<string, unknown> | undefined;
     const toolName = params?.name as string | undefined;
     return toolName === 'search_memories' || toolName === 'get_memories';
-  }
-
-  /**
-   * Check if a tool call targets a task tool (vs a memory tool).
-   */
-  private isTaskTool(rpc: Record<string, unknown>): boolean {
-    const params = rpc.params as Record<string, unknown> | undefined;
-    const toolName = params?.name as string | undefined;
-    return !!toolName && TASK_TOOL_NAMES.has(toolName);
-  }
-
-  /**
-   * Handle task MCP tool calls by delegating to TasksService. Used by external
-   * agents (Cursor, Codex, Copilot CLI) that connect to /api/memory/mcp and
-   * issue tool calls that match TASK_TOOL_DEFS.
-   */
-  private async handleTaskToolCall(
-    rpc: Record<string, unknown>,
-    user: RequestUser,
-  ): Promise<Record<string, unknown>> {
-    const params = rpc.params as Record<string, unknown>;
-    const toolName = params.name as string;
-    const args = (params.arguments ?? {}) as Record<string, unknown>;
-
-    try {
-      switch (toolName) {
-        case 'list_tasks': {
-          const teamId = args.teamId as string | undefined;
-          const mine = args.mine === true;
-          const status = args.status as TaskStatus | undefined;
-          const excludeDone = args.excludeDone === true;
-
-          let assigneeEmails: string[] | undefined;
-          if (mine) {
-            assigneeEmails = await this.authService.getAllEmailAddresses(user.userId);
-          }
-
-          const tasks = await this.tasksService.getTasks(user.organizationId, {
-            teamId,
-            assigneeEmail: mine ? user.email : undefined,
-            assigneeEmails,
-            sprint: 'current',
-            excludeDone,
-          });
-
-          const filtered = status ? tasks.filter((t) => t.status === status) : tasks;
-          return { content: [{ type: 'text', text: JSON.stringify(filtered) }] };
-        }
-
-        case 'get_task_statuses': {
-          const taskId = args.taskId as string;
-          const provider = args.provider as IntegrationProvider;
-          const statuses = await this.tasksService.getTaskStatuses(
-            user.organizationId,
-            taskId,
-            provider,
-          );
-          return { content: [{ type: 'text', text: JSON.stringify(statuses) }] };
-        }
-
-        case 'update_task': {
-          const taskId = args.taskId as string;
-          const provider = args.provider as IntegrationProvider;
-          await this.tasksService.updateTask(user.organizationId, taskId, provider, {
-            statusName: args.statusName as string | undefined,
-            assigneeEmail: args.assigneeEmail as string | undefined,
-            priority: args.priority as string | undefined,
-            description: args.description as string | undefined,
-          });
-          return { content: [{ type: 'text', text: JSON.stringify({ status: 'ok' }) }] };
-        }
-
-        case 'create_task': {
-          const task = await this.tasksService.createTask(user.organizationId, {
-            teamId: args.teamId as string,
-            title: args.title as string,
-            description: args.description as string | undefined,
-            assigneeEmail: args.assigneeEmail as string | undefined,
-            priority: args.priority as string | undefined,
-            labels: args.labels as string[] | undefined,
-            provider: args.provider as IntegrationProvider | undefined,
-          });
-          return { content: [{ type: 'text', text: JSON.stringify(task) }] };
-        }
-
-        default:
-          return {
-            content: [{ type: 'text', text: `Unknown task tool: ${toolName}` }],
-            isError: true,
-          };
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.error(`MCP task tool ${toolName} failed: ${message}`);
-      Sentry.captureException(err, { tags: { operation: 'mcp-task-tool', toolName } });
-      return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
-    }
   }
 
   /**

--- a/apps/claude-plugins/lib/tandemu-env.sh
+++ b/apps/claude-plugins/lib/tandemu-env.sh
@@ -1,8 +1,26 @@
 #!/bin/sh
-# Shared Tandemu config loader — source this from skills to get env vars.
-# Usage: source "$(dirname "$0")/../lib/tandemu-env.sh"
+# Tandemu env loader — sourced by skills. Probes per-agent auth files in order
+# until one is found, then exports TANDEMU_* env vars for the calling shell.
+#
+# This is the canonical loader, shipped by both install paths:
+#   - Plugin marketplace: /tandemu:setup copies it to ~/.claude/lib/
+#   - install.sh: install_universal_lib copies it to ~/.config/tandemu/lib/
+# Skills source the universal path first, then the Claude path, so either
+# install path works and existing Claude users keep working.
 
-_TANDEMU_CONFIG=$(cat "$HOME/.claude/tandemu.json" 2>/dev/null)
+_TANDEMU_CONFIG=""
+for _f in \
+  "$HOME/.claude/tandemu.json" \
+  "$HOME/.config/tandemu/auth.json" \
+  "$HOME/.config/tandemu/cursor-auth.json" \
+  "$HOME/.config/tandemu/codex-auth.json"; do
+  if [ -f "$_f" ]; then
+    _TANDEMU_CONFIG=$(cat "$_f" 2>/dev/null)
+    [ -n "$_TANDEMU_CONFIG" ] && break
+  fi
+done
+unset _f
+
 if [ -z "$_TANDEMU_CONFIG" ]; then
   echo "ERROR: Tandemu not configured. Run /tandemu:setup or install.sh to set up." >&2
   return 1 2>/dev/null || exit 1
@@ -13,13 +31,12 @@ import sys, json
 c = json.load(sys.stdin)
 print(f'TANDEMU_TOKEN={chr(39)}{c[\"auth\"][\"token\"]}{chr(39)}')
 print(f'TANDEMU_API={chr(39)}{c[\"api\"][\"url\"]}{chr(39)}')
-print(f'TANDEMU_ORG_ID={chr(39)}{c[\"organization\"][\"id\"]}{chr(39)}')
+print(f'TANDEMU_ORG_ID={chr(39)}{c.get(\"organization\",{}).get(\"id\",\"\")}{chr(39)}')
 print(f'TANDEMU_USER_ID={chr(39)}{c[\"user\"][\"id\"]}{chr(39)}')
 print(f'TANDEMU_USER_EMAIL={chr(39)}{c[\"user\"][\"email\"]}{chr(39)}')
 print(f'TANDEMU_USER_NAME={chr(39)}{c[\"user\"][\"name\"]}{chr(39)}')
 
-# Multi-team support: read teams array
-teams = c.get('teams', [])
+teams = c.get('teams') or ([c['team']] if c.get('team',{}).get('id') else [])
 if teams:
     ids = ','.join(t['id'] for t in teams)
     names = ','.join(t['name'] for t in teams)
@@ -33,5 +50,28 @@ else:
     print(\"TANDEMU_TEAM_NAMES=''\")
     print('TANDEMU_TEAM_COUNT=0')
 ")"
+
+# Universal active-task dir (skills read/write here)
+export TANDEMU_TASKS_DIR="${TANDEMU_TASKS_DIR:-$HOME/.config/tandemu/active-tasks}"
+mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
+
+# One-time migration: relocate legacy branch-keyed task files from the old
+# Claude-only location into the universal dir. Same filename scheme, so this
+# is a plain move. Skipped if a file with that name already exists there.
+for _t in "$HOME"/.claude/tandemu-active-task-*.json; do
+  [ -e "$_t" ] || continue
+  _dest="$TANDEMU_TASKS_DIR/$(basename "$_t")"
+  [ -e "$_dest" ] || mv "$_t" "$_dest" 2>/dev/null || true
+done
+unset _t _dest
+
+# OTEL collector endpoint. Derived from the API host (collector runs alongside
+# the backend on :4318). Skills must use this instead of reading
+# ~/.claude/settings.json, which only exists on Claude Code installs.
+_TANDEMU_OTEL_HOST=$(echo "$TANDEMU_API" | sed 's|https\{0,1\}://||; s|/.*||; s|:.*||')
+if [ -n "$_TANDEMU_OTEL_HOST" ]; then
+  export TANDEMU_OTEL_ENDPOINT="http://${_TANDEMU_OTEL_HOST}:4318"
+fi
+unset _TANDEMU_OTEL_HOST
 
 unset _TANDEMU_CONFIG

--- a/apps/skills/AGENTS.md
+++ b/apps/skills/AGENTS.md
@@ -154,23 +154,25 @@ For org memories, also pass `app_id: "org"`. The `repo` and `files` fields help 
 
 ## Worktree-Based Task Management
 
-Each task runs in its own git worktree inside `.worktrees/<task-id>/`. The main checkout stays on the default branch. Multiple tasks can be active concurrently in separate worktrees and separate Claude Code sessions.
+Each task runs in its own git worktree inside `.worktrees/<task-id>/`. The main checkout stays on the default branch. Multiple tasks can be active concurrently in separate worktrees and separate sessions.
 
-Task files are branch-keyed: `~/.claude/tandemu-active-task-{branch-slug}.json` (branch slug = branch name with `/` replaced by `-`). To read the current task:
+Task files are branch-keyed and live in `$TANDEMU_TASKS_DIR` (exported by the env loader; universal across agents, default `~/.config/tandemu/active-tasks/`). Filename: `tandemu-active-task-{branch-slug}.json` (branch slug = branch name with `/` replaced by `-`). To read the current task:
 
 ```bash
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
 BRANCH_SLUG=$(git branch --show-current 2>/dev/null | sed 's/\//-/g')
-TASK_FILE="$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json"
+TASK_FILE="$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json"
 cat "$TASK_FILE" 2>/dev/null
 ```
 
 When you edit files in a repo that is **not** already listed in the task file's `repos` array, add it immediately. This ensures `/finish` measures work across all repos touched during a task.
 
 ```bash
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
 python3 -c "
-import json
+import json, os
 BRANCH_SLUG='$(git branch --show-current 2>/dev/null | sed "s/\//-/g")'
-TASK_FILE=f'$HOME/.claude/tandemu-active-task-{BRANCH_SLUG}.json'
+TASK_FILE=os.path.join('$TANDEMU_TASKS_DIR', f'tandemu-active-task-{BRANCH_SLUG}.json')
 with open(TASK_FILE) as f:
     task = json.load(f)
 repo = '$(git rev-parse --show-toplevel 2>/dev/null || pwd)'

--- a/apps/skills/create/SKILL.md
+++ b/apps/skills/create/SKILL.md
@@ -12,7 +12,7 @@ Create a new task in the team's ticket system. Use when you discover work that n
 **IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 ```
 
 ## Steps
@@ -20,7 +20,7 @@ Create a new task in the team's ticket system. Use when you discover work that n
 ### 1. Setup
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
@@ -68,7 +68,7 @@ Set `SELECTED_TEAM_ID` from the choice. If single team, use `$TANDEMU_TEAM_ID` d
 **Determine the provider**: If there's an active task (from step 1), use its `provider` field. Otherwise omit — the backend prefers dedicated trackers (Linear, Jira, etc.) over GitHub by default.
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 RESULT=$(curl -sf -X POST "$TANDEMU_API/api/tasks" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/create/SKILL.md
+++ b/apps/skills/create/SKILL.md
@@ -31,8 +31,9 @@ echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
 echo "EMAIL=$TANDEMU_USER_EMAIL"
 
 echo "---ACTIVE_TASK---"
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
 BRANCH_SLUG=$(git branch --show-current 2>/dev/null | sed 's/\//-/g' || echo "unknown")
-cat "$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json" 2>/dev/null || echo "NONE"
+cat "$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json" 2>/dev/null || echo "NONE"
 ```
 
 ### 2. Get task details

--- a/apps/skills/finish/SKILL.md
+++ b/apps/skills/finish/SKILL.md
@@ -98,9 +98,10 @@ echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
 
-# Active task metadata (branch-keyed)
+# Active task metadata (branch-keyed). TANDEMU_TASKS_DIR from env loader.
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
 BRANCH_SLUG=$(git branch --show-current 2>/dev/null | sed 's/\//-/g' || echo "unknown")
-TASK_FILE="$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json"
+TASK_FILE="$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json"
 echo "---ACTIVE_TASK---"
 echo "TASK_FILE=$TASK_FILE"
 cat "$TASK_FILE" 2>/dev/null || echo "NONE"

--- a/apps/skills/finish/SKILL.md
+++ b/apps/skills/finish/SKILL.md
@@ -18,7 +18,7 @@ Help the developer wrap up their current task cleanly, measure the work done, an
 **IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 ```
 
 ## Steps
@@ -93,7 +93,7 @@ Load config and active task in a **single Bash call** ("Prepare telemetry"):
 
 ```bash
 # Load Tandemu config
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
@@ -143,7 +143,7 @@ Build the request body from the collected data — do NOT calculate AI lines you
 **IMPORTANT: This call MUST succeed for /finish to complete. If it fails, tell the developer and STOP.**
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 RESULT=$(curl -sf -X POST "$TANDEMU_API/api/telemetry/tasks/<taskId>/finish" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
@@ -177,14 +177,14 @@ If the curl fails or returns an error, tell the developer and **STOP**.
 If the developer marked the task as "Done", update the status on the provider. First fetch the available statuses, then pick the one that best represents "done" or "completed":
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "done", "completed", or "closed" from the returned list, then:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/morning/SKILL.md
+++ b/apps/skills/morning/SKILL.md
@@ -60,14 +60,19 @@ echo "TEAM_COUNT=$TANDEMU_TEAM_COUNT"
 echo "EMAIL=$TANDEMU_USER_EMAIL"
 echo "NAME=$TANDEMU_USER_NAME"
 
-# Check for active task (branch-keyed)
+# Check for active task (branch-keyed). TANDEMU_TASKS_DIR is exported by the
+# env loader and is universal across agents; default it defensively in case
+# the loader was unavailable.
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
+mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
 BRANCH_SLUG=$(git branch --show-current 2>/dev/null | sed 's/\//-/g' || echo "unknown")
-TASK_FILE="$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json"
+TASK_FILE="$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json"
 echo "---ACTIVE_TASK---"
 echo "TASK_FILE=$TASK_FILE"
 echo "BRANCH_SLUG=$BRANCH_SLUG"
 
-# Legacy migration: move old single file to branch-keyed
+# Legacy migration: move pre-branch-keyed single file (older than the env
+# loader's bulk migration, which only handles tandemu-active-task-*.json).
 OLD_FILE="$HOME/.claude/tandemu-active-task.json"
 if [ -f "$OLD_FILE" ] && [ ! -f "$TASK_FILE" ] && [ "$BRANCH_SLUG" != "main" ] && [ "$BRANCH_SLUG" != "unknown" ]; then
   mv "$OLD_FILE" "$TASK_FILE"
@@ -79,7 +84,7 @@ cat "$TASK_FILE" 2>/dev/null || echo "NONE"
 
 # Collect task IDs from ALL active task files (other sessions/worktrees)
 echo "---OTHER_ACTIVE_TASKS---"
-find "$HOME/.claude" -maxdepth 1 -name 'tandemu-active-task-*.json' 2>/dev/null | while read -r f; do
+find "$TANDEMU_TASKS_DIR" -maxdepth 1 -name 'tandemu-active-task-*.json' 2>/dev/null | while read -r f; do
   [ "$f" = "$TASK_FILE" ] && continue
   TASK_ID=$(python3 -c "import json; print(json.load(open('$f')).get('taskId',''))" 2>/dev/null)
   [ -n "$TASK_ID" ] && echo "$TASK_ID"
@@ -269,10 +274,12 @@ cd "$WORKTREE_DIR"
 - Write the branch-keyed active task file. Use the `category` field from the API response (the backend infers it from labels).
 
 ```bash
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
+mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
 BRANCH_SLUG=$(echo "$BRANCH_NAME" | sed 's/\//-/g')
 REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-cat > "$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json" << EOF
+cat > "$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json" << EOF
 {
   "taskId": "<task.id>",
   "teamId": "<SELECTED_TEAM_ID or the team the task was fetched from>",
@@ -368,6 +375,6 @@ If they choose **Manual**: say "All yours — let me know what you need." and st
 - The developer may have multiple repos and sessions open — this skill only manages the current repo
 - Always let the developer choose — never auto-assign
 - If they select "Other", ask what they want to work on and create a branch for it
-- Task files are branch-keyed: `~/.claude/tandemu-active-task-{branch-slug}.json`. Multiple tasks can be active concurrently in separate worktrees.
+- Task files are branch-keyed: `$TANDEMU_TASKS_DIR/tandemu-active-task-{branch-slug}.json` (default `~/.config/tandemu/active-tasks/`, universal across agents). Multiple tasks can be active concurrently in separate worktrees.
 - Each task gets its own git worktree inside `.worktrees/<task.id>/`. The main checkout stays on the default branch.
 - **IMPORTANT**: Always use `Bash` (cat, python3, etc.) to read and write task files — do NOT use the Edit or Write tools for these files

--- a/apps/skills/morning/SKILL.md
+++ b/apps/skills/morning/SKILL.md
@@ -19,7 +19,7 @@ Help the developer start their work session by picking a task.
 **IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, `$TANDEMU_TEAM_ID`, etc. MUST source the env loader first:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 ```
 
 ## Steps
@@ -48,7 +48,7 @@ Run all setup reads in a **single Bash call**:
 
 ```bash
 # Load Tandemu config
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
@@ -162,7 +162,7 @@ Set `SELECTED_TEAM_ID` from the choice. If "All teams" is selected, set `SELECTE
 Fetch tasks assigned to the current developer in a single call. The API handles multi-team dedup and unassigned fallback server-side:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks?teamId=$SELECTED_TEAM_ID&mine=true&fallbackUnassigned=true&sort=priority&order=desc"
 ```
 
@@ -193,7 +193,7 @@ If there are more than 4 tasks, show the top 4 and mention how many more exist.
 After the developer picks a task, check if `hasSubtasks` is `true` on the selected task. If so, fetch the subtasks:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/subtasks?provider=<task.provider>"
 ```
 
@@ -292,7 +292,7 @@ EOF
 - Update the task on the ticket system — set status to "in progress" AND assign it to the current developer. First fetch the available statuses, then pick the one that best represents "in progress":
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 # Fetch available statuses for this task
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<task.id>/statuses?provider=<task.provider>"
 ```
@@ -302,7 +302,7 @@ This returns an array of `{ id, name, type }` objects — the actual statuses av
 Then send a single PATCH to update both status and assignee:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<task.id>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \
@@ -321,7 +321,7 @@ If you can't determine which status to use, still send the assignee update witho
 After setting up the task, silently check for knowledge gaps:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 GAPS=$(curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/memory/gaps" 2>/dev/null)
 ```
 

--- a/apps/skills/morning/SKILL.md
+++ b/apps/skills/morning/SKILL.md
@@ -35,7 +35,7 @@ Use the `LOCAL_NOW` from the Step 1 output to determine the time-of-day greeting
 - Hour 12–17 → "Afternoon"
 - Hour > 17 → "Evening"
 
-If you know their name (from `~/.claude/tandemu.json` under `user.name`): "<greeting>, {{DEV_NAME}}. Let me pull up your tasks."
+If you know their name (`$TANDEMU_USER_NAME` from the env loader, populated on every agent): "<greeting>, {{DEV_NAME}}. Let me pull up your tasks."
 If you don't know their name yet: "Good <greeting>! Let me get your tasks."
 
 If you remember what they worked on recently, mention it: "Last time you were working on the invoice module — want to continue or pick something new?"

--- a/apps/skills/pause/SKILL.md
+++ b/apps/skills/pause/SKILL.md
@@ -88,7 +88,13 @@ Convert timestamps and send a `task_session` span with `status=paused` (use the 
 
 ```bash
 . "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
-OTEL_ENDPOINT="${TANDEMU_OTEL_ENDPOINT:-$(python3 -c "import json; s=json.load(open('$HOME/.claude/settings.json')); print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))" 2>/dev/null)}"
+OTEL_ENDPOINT="${TANDEMU_OTEL_ENDPOINT:-$(python3 -c "
+import json
+try:
+    s = json.load(open('$HOME/.claude/settings.json'))
+    print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
+except: print('http://localhost:4318')
+" 2>/dev/null)}"
 START_NS=$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('<startedAt>'.replace('Z','+00:00')).timestamp()*1e9))")
 END_NS=$(python3 -c "from datetime import datetime; print(int(datetime.utcnow().timestamp()*1e9))")
 TRACE_ID=$(python3 -c "import secrets; print(secrets.token_hex(16))")

--- a/apps/skills/pause/SKILL.md
+++ b/apps/skills/pause/SKILL.md
@@ -14,7 +14,7 @@ Pause the current task so the developer can switch to something else.
 **IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 ```
 
 ## Steps
@@ -25,7 +25,7 @@ Run all setup reads in a **single Bash call** ("Setup"):
 
 ```bash
 # Load Tandemu config
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 echo "---CONFIG---"
 echo "TOKEN=$TANDEMU_TOKEN"
 echo "API=$TANDEMU_API"
@@ -84,7 +84,7 @@ Sum additions, deletions, and commits across all repos.
 Convert timestamps and send a `task_session` span with `status=paused` (use the OTEL endpoint from setup):
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 OTEL_ENDPOINT=$(python3 -c "import json; s=json.load(open('$HOME/.claude/settings.json')); print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))" 2>/dev/null)
 START_NS=$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('<startedAt>'.replace('Z','+00:00')).timestamp()*1e9))")
 END_NS=$(python3 -c "from datetime import datetime; print(int(datetime.utcnow().timestamp()*1e9))")
@@ -127,14 +127,14 @@ curl -sf -X POST "$OTEL_ENDPOINT/v1/traces" \
 Set the task back to a paused/backlog state on the provider. First fetch available statuses, then pick the one that best represents "paused", "on hold", "todo", or "backlog":
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -H "Authorization: Bearer $TANDEMU_TOKEN" "$TANDEMU_API/api/tasks/<taskId>/statuses?provider=<provider>"
 ```
 
 Pick the status that best represents "todo", "backlog", "on hold", or "paused" from the returned list, then:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
 curl -sf -X PATCH "$TANDEMU_API/api/tasks/<taskId>" \
   -H "Authorization: Bearer $TANDEMU_TOKEN" \
   -H "Content-Type: application/json" \

--- a/apps/skills/pause/SKILL.md
+++ b/apps/skills/pause/SKILL.md
@@ -46,15 +46,17 @@ echo "OFFSET=$(date +%z)"
 echo "LOCAL_NOW=$(date '+%Y-%m-%d %H:%M %Z')"
 echo "LOCAL_TODAY=$(date +%Y-%m-%d)"
 
-# OTEL endpoint
+# OTEL endpoint — prefer the value the env loader derived from the API host
+# (works on every agent). Fall back to ~/.claude/settings.json (Claude Code
+# only), then localhost.
 echo "---OTEL---"
-python3 -c "
+echo "${TANDEMU_OTEL_ENDPOINT:-$(python3 -c "
 import json
 try:
     s = json.load(open('$HOME/.claude/settings.json'))
     print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))
 except: print('http://localhost:4318')
-" 2>/dev/null
+" 2>/dev/null)}"
 ```
 
 If the active task file does not exist, tell the developer: "No active task to pause. Use /morning to start one." Then stop.
@@ -85,7 +87,7 @@ Convert timestamps and send a `task_session` span with `status=paused` (use the 
 
 ```bash
 . "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null
-OTEL_ENDPOINT=$(python3 -c "import json; s=json.load(open('$HOME/.claude/settings.json')); print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))" 2>/dev/null)
+OTEL_ENDPOINT="${TANDEMU_OTEL_ENDPOINT:-$(python3 -c "import json; s=json.load(open('$HOME/.claude/settings.json')); print(s.get('env',{}).get('OTEL_EXPORTER_OTLP_ENDPOINT','http://localhost:4318'))" 2>/dev/null)}"
 START_NS=$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('<startedAt>'.replace('Z','+00:00')).timestamp()*1e9))")
 END_NS=$(python3 -c "from datetime import datetime; print(int(datetime.utcnow().timestamp()*1e9))")
 TRACE_ID=$(python3 -c "import secrets; print(secrets.token_hex(16))")

--- a/apps/skills/pause/SKILL.md
+++ b/apps/skills/pause/SKILL.md
@@ -32,9 +32,10 @@ echo "API=$TANDEMU_API"
 echo "ORG=$TANDEMU_ORG_ID"
 echo "USER=$TANDEMU_USER_ID"
 
-# Active task (branch-keyed)
+# Active task (branch-keyed). TANDEMU_TASKS_DIR from env loader.
+: "${TANDEMU_TASKS_DIR:=$HOME/.config/tandemu/active-tasks}"
 BRANCH_SLUG=$(git branch --show-current 2>/dev/null | sed 's/\//-/g' || echo "unknown")
-TASK_FILE="$HOME/.claude/tandemu-active-task-${BRANCH_SLUG}.json"
+TASK_FILE="$TANDEMU_TASKS_DIR/tandemu-active-task-${BRANCH_SLUG}.json"
 echo "---ACTIVE_TASK---"
 echo "TASK_FILE=$TASK_FILE"
 cat "$TASK_FILE" 2>/dev/null || echo "NONE"

--- a/apps/skills/setup/SKILL.md
+++ b/apps/skills/setup/SKILL.md
@@ -353,8 +353,17 @@ if [ -z "$PLUGIN_ROOT" ]; then
 fi
 
 if [ -n "$PLUGIN_ROOT" ] && [ -d "$PLUGIN_ROOT/lib" ]; then
-  mkdir -p "$HOME/.claude"/lib
+  # Write the loader to BOTH locations:
+  #   ~/.claude/lib/tandemu-env.sh   — historical path, kept for back-compat
+  #                                    with any skills that still source it
+  #   ~/.config/tandemu/lib/...      — universal path (preferred). Skills
+  #                                    source this first; matches install.sh
+  mkdir -p "$HOME/.claude"/lib "$HOME/.config/tandemu/lib"
   cp -r "$PLUGIN_ROOT/lib"/* "$HOME/.claude/lib/"
+  cp -r "$PLUGIN_ROOT/lib"/* "$HOME/.config/tandemu/lib/"
+  # Pre-create the universal active-task dir so skills can write task files
+  # before the loader has been sourced (the loader also creates it).
+  mkdir -p "$HOME/.config/tandemu/active-tasks"
   echo "OK"
 fi
 

--- a/apps/skills/standup/SKILL.md
+++ b/apps/skills/standup/SKILL.md
@@ -15,7 +15,7 @@ Generate a team standup report. Options: $ARGUMENTS
 **IMPORTANT — env vars don't persist across Bash calls.** Each Bash invocation is a fresh shell. Every Bash call that uses `$TANDEMU_TOKEN`, `$TANDEMU_API`, etc. MUST source the env loader first:
 
 ```bash
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 ```
 
 ## Steps
@@ -26,7 +26,7 @@ Load config and fetch all pre-computed standup data in a **single Bash call** ("
 
 ```bash
 # Load Tandemu config
-. "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
+. "$HOME/.config/tandemu/lib/tandemu-env.sh" 2>/dev/null || . "$HOME/.claude/lib/tandemu-env.sh" 2>/dev/null || . "$(git rev-parse --show-toplevel 2>/dev/null)/apps/claude-plugins/lib/tandemu-env.sh"
 
 # Multi-team support: resolve --team argument or prompt if multiple teams
 ACTIVE_TEAM_ID="$TANDEMU_TEAM_ID"

--- a/install.sh
+++ b/install.sh
@@ -1084,15 +1084,27 @@ else:
 export TANDEMU_TASKS_DIR="${TANDEMU_TASKS_DIR:-$HOME/.config/tandemu/active-tasks}"
 mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
 
+# OTEL collector endpoint. Derived from the API host (collector runs alongside
+# the backend on :4318). Skills must use this instead of reading
+# ~/.claude/settings.json, which only exists on Claude Code installs.
+_TANDEMU_OTEL_HOST=$(echo "$TANDEMU_API" | sed 's|https\{0,1\}://||; s|/.*||; s|:.*||')
+if [ -n "$_TANDEMU_OTEL_HOST" ]; then
+  export TANDEMU_OTEL_ENDPOINT="http://${_TANDEMU_OTEL_HOST}:4318"
+fi
+unset _TANDEMU_OTEL_HOST
+
 unset _TANDEMU_CONFIG
 LOADER_EOF
   chmod 644 "$TANDEMU_LIB_DIR/tandemu-env.sh"
   ok "Loader installed: ~/.config/tandemu/lib/tandemu-env.sh"
 }
 
-# Copy all 6 SKILL.md files into <commands_dir>/<name>.md verbatim. Used by
-# Cursor + Codex install paths so /morning, /finish etc. fire as native slash
-# commands the same way they do on Claude Code + OpenCode.
+# Copy the daily-use SKILL.md files into <commands_dir>/<name>.md verbatim.
+# Used by Cursor + Codex install paths so /morning, /finish etc. fire as
+# native slash commands the same way they do on Claude Code + OpenCode.
+# `setup` is deliberately excluded — it writes Claude-only state
+# (~/.claude/settings.json, CLAUDE.md, SessionStart hooks, ~/.mcp.json
+# migration) and would corrupt a real Claude install if run elsewhere.
 install_skills_to() {
   local dest_dir="$1"
   local skills_src="${SCRIPT_DIR}/apps/skills"
@@ -1101,7 +1113,7 @@ install_skills_to() {
     return 1
   fi
   mkdir -p "$dest_dir"
-  for skill in morning finish pause create standup setup; do
+  for skill in morning finish pause create standup; do
     if [ -f "$skills_src/$skill/SKILL.md" ]; then
       cp "$skills_src/$skill/SKILL.md" "$dest_dir/$skill.md"
     fi

--- a/install.sh
+++ b/install.sh
@@ -1202,7 +1202,7 @@ install_assets_cursor() {
 
   # Slash commands. Cursor reads custom commands from ~/.cursor/commands/.
   install_skills_to "$CURSOR_DIR/commands"
-  ok "Skills installed → ~/.cursor/commands/ (/morning, /finish, /pause, /create, /standup, /setup)"
+  ok "Skills installed → ~/.cursor/commands/ (/morning, /finish, /pause, /create, /standup)"
 
   local v
   v=$(get_plugin_version)
@@ -1278,7 +1278,7 @@ install_assets_codex() {
 
   # Slash commands. Codex CLI reads custom prompts from ~/.codex/prompts/.
   install_skills_to "$CODEX_DIR/prompts"
-  ok "Skills installed → ~/.codex/prompts/ (/morning, /finish, /pause, /create, /standup, /setup)"
+  ok "Skills installed → ~/.codex/prompts/ (/morning, /finish, /pause, /create, /standup)"
 
   local v
   v=$(get_plugin_version)

--- a/install.sh
+++ b/install.sh
@@ -1084,6 +1084,16 @@ else:
 export TANDEMU_TASKS_DIR="${TANDEMU_TASKS_DIR:-$HOME/.config/tandemu/active-tasks}"
 mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
 
+# One-time migration: relocate legacy branch-keyed task files from the old
+# Claude-only location into the universal dir. Same filename scheme, so this
+# is a plain move. Skipped if a file with that name already exists there.
+for _t in "$HOME"/.claude/tandemu-active-task-*.json; do
+  [ -e "$_t" ] || continue
+  _dest="$TANDEMU_TASKS_DIR/$(basename "$_t")"
+  [ -e "$_dest" ] || mv "$_t" "$_dest" 2>/dev/null || true
+done
+unset _t _dest
+
 # OTEL collector endpoint. Derived from the API host (collector runs alongside
 # the backend on :4318). Skills must use this instead of reading
 # ~/.claude/settings.json, which only exists on Claude Code installs.

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #  Flags:
 #    --url <url>       Set API URL (skip instance selection)
 #    --token <token>   Use provided JWT (non-interactive)
-#    --target <t>      claude | opencode | cursor | copilot | codex | all
+#    --target <t>      claude | opencode | cursor | codex | all
 #                      (comma-separated for multiple; "both" = claude+opencode)
 #    --uninstall       Remove all Tandemu files
 #    --check           Check for updates
@@ -36,13 +36,16 @@ OPENCODE_DIR="$HOME/.config/opencode"
 TANDEMU_OPENCODE_DIR="$HOME/.config/tandemu"
 OPENCODE_VERSION_FILE="$TANDEMU_OPENCODE_DIR/version.txt"
 
-# Lightweight targets (MCP-first, no plugin packaging)
+# Lightweight targets (skill-based, no plugin packaging)
 CURSOR_DIR="$HOME/.cursor"
 CURSOR_VERSION_FILE="$HOME/.config/tandemu/cursor-version.txt"
-COPILOT_DIR="$HOME/.copilot"
-COPILOT_VERSION_FILE="$HOME/.config/tandemu/copilot-version.txt"
 CODEX_DIR="$HOME/.codex"
 CODEX_VERSION_FILE="$HOME/.config/tandemu/codex-version.txt"
+
+# Universal Tandemu config dir (shared across all agents)
+TANDEMU_CONFIG_DIR="$HOME/.config/tandemu"
+TANDEMU_LIB_DIR="$TANDEMU_CONFIG_DIR/lib"
+TANDEMU_TASKS_DIR="$TANDEMU_CONFIG_DIR/active-tasks"
 
 # TARGETS is set by detect_targets() or --target flag. Space-separated list.
 TARGETS=""
@@ -337,42 +340,10 @@ PYEOF
     ok "Cursor MCP cleaned"
   fi
   rm -f "$CURSOR_DIR/rules/tandemu.mdc" 2>/dev/null || true
-
-  # ── Copilot CLI ──
-  if [ -f "$COPILOT_DIR/mcp_config.json" ]; then
-    python3 << 'PYEOF'
-import json, os
-f = os.path.expanduser("~/.copilot/mcp_config.json")
-try:
-    cfg = json.load(open(f))
-    s = cfg.get("mcpServers", {})
-    s.pop("tandemu", None)
-    if s:
-        cfg["mcpServers"] = s
-    elif "mcpServers" in cfg:
-        del cfg["mcpServers"]
-    if cfg:
-        json.dump(cfg, open(f, "w"), indent=2)
-    else:
-        os.remove(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    pass
-PYEOF
-    ok "Copilot MCP cleaned"
-  fi
-  if [ -f "$COPILOT_DIR/AGENTS.md" ]; then
-    if grep -q "Tandemu AI Teammate" "$COPILOT_DIR/AGENTS.md" 2>/dev/null; then
-      rm -f "$COPILOT_DIR/AGENTS.md"
-    elif grep -qF "<!-- tandemu:personality:start -->" "$COPILOT_DIR/AGENTS.md" 2>/dev/null; then
-      python3 -c "
-import re
-f = '$COPILOT_DIR/AGENTS.md'
-text = open(f).read()
-text = re.sub(r'<!-- tandemu:personality:start -->.*?<!-- tandemu:personality:end -->\n*', '', text, flags=re.DOTALL)
-open(f, 'w').write(text.strip() + '\n')
-"
-    fi
-  fi
+  for skill in morning finish pause create standup setup; do
+    rm -f "$CURSOR_DIR/commands/$skill.md" 2>/dev/null || true
+    rm -f "$CODEX_DIR/prompts/$skill.md" 2>/dev/null || true
+  done
 
   # ── Codex CLI ──
   if [ -f "$CODEX_DIR/config.toml" ]; then
@@ -410,7 +381,8 @@ open(f, 'w').write(text.strip() + '\n')
     fi
   fi
 
-  rm -f "$CURSOR_VERSION_FILE" "$COPILOT_VERSION_FILE" "$CODEX_VERSION_FILE" 2>/dev/null || true
+  rm -f "$CURSOR_VERSION_FILE" "$CODEX_VERSION_FILE" 2>/dev/null || true
+  rm -rf "$TANDEMU_LIB_DIR" "$TANDEMU_TASKS_DIR" 2>/dev/null || true
 
   echo ""
   printf '%b\n' "  ${GREEN}Tandemu uninstalled.${NC}"
@@ -446,7 +418,6 @@ do_check() {
   _check_one "Claude Code" "$VERSION_FILE"
   _check_one "OpenCode   " "$OPENCODE_VERSION_FILE"
   _check_one "Cursor     " "$CURSOR_VERSION_FILE"
-  _check_one "Copilot    " "$COPILOT_VERSION_FILE"
   _check_one "Codex      " "$CODEX_VERSION_FILE"
 
   if [ -z "$any_installed" ]; then
@@ -468,12 +439,12 @@ check_prerequisites() {
   step "Checking prerequisites..."
 
   local has_any=""
-  for cli in claude opencode cursor codex gh; do
+  for cli in claude opencode cursor codex; do
     command -v "$cli" &>/dev/null && has_any="true"
   done
 
   if [ -z "$has_any" ]; then
-    fail "No supported AI agent CLI found (claude, opencode, cursor, codex, gh). Install at least one and re-run."
+    fail "No supported AI agent CLI found (claude, opencode, cursor, codex). Install at least one and re-run."
   fi
 
   if ! command -v python3 &>/dev/null; then
@@ -502,13 +473,10 @@ detect_targets() {
   command -v claude &>/dev/null && found+=("claude")
   command -v opencode &>/dev/null && found+=("opencode")
   command -v cursor &>/dev/null && found+=("cursor")
-  if command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -qi copilot; then
-    found+=("copilot")
-  fi
   command -v codex &>/dev/null && found+=("codex")
 
   if [ ${#found[@]} -eq 0 ]; then
-    fail "No supported AI agent CLI found. Install one of: claude, opencode, cursor, codex, gh+copilot."
+    fail "No supported AI agent CLI found. Install one of: claude, opencode, cursor, codex."
   fi
 
   if [ ${#found[@]} -eq 1 ]; then
@@ -525,7 +493,6 @@ detect_targets() {
       claude)   printf '%b\n' "    ${BOLD}${i}.${NC} Claude Code" ;;
       opencode) printf '%b\n' "    ${BOLD}${i}.${NC} OpenCode" ;;
       cursor)   printf '%b\n' "    ${BOLD}${i}.${NC} Cursor" ;;
-      copilot)  printf '%b\n' "    ${BOLD}${i}.${NC} GitHub Copilot CLI" ;;
       codex)    printf '%b\n' "    ${BOLD}${i}.${NC} Codex CLI" ;;
     esac
     i=$((i + 1))
@@ -1056,6 +1023,91 @@ write_agents_md() {
   fi
 }
 
+# Install universal env loader + tasks dir at ~/.config/tandemu/. Skills source
+# this loader to read auth from whichever per-agent config file exists. Active
+# task files also live here so skills work identically across agents.
+install_universal_lib() {
+  step "Installing universal config loader..."
+  mkdir -p "$TANDEMU_LIB_DIR" "$TANDEMU_TASKS_DIR"
+  # Skills still write task files at ~/.claude/tandemu-active-task-*.json for
+  # back-compat with existing installs. Ensure the dir exists on all targets.
+  mkdir -p "$HOME/.claude" 2>/dev/null || true
+  cat > "$TANDEMU_LIB_DIR/tandemu-env.sh" << 'LOADER_EOF'
+#!/bin/sh
+# Tandemu env loader — sourced by skills. Probes per-agent auth files in order
+# until one is found, then exports TANDEMU_* env vars for the calling shell.
+
+_TANDEMU_CONFIG=""
+for _f in \
+  "$HOME/.claude/tandemu.json" \
+  "$HOME/.config/tandemu/auth.json" \
+  "$HOME/.config/tandemu/cursor-auth.json" \
+  "$HOME/.config/tandemu/codex-auth.json"; do
+  if [ -f "$_f" ]; then
+    _TANDEMU_CONFIG=$(cat "$_f" 2>/dev/null)
+    [ -n "$_TANDEMU_CONFIG" ] && break
+  fi
+done
+unset _f
+
+if [ -z "$_TANDEMU_CONFIG" ]; then
+  echo "ERROR: Tandemu not configured. Run install.sh to set up." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+eval "$(echo "$_TANDEMU_CONFIG" | python3 -c "
+import sys, json
+c = json.load(sys.stdin)
+print(f'TANDEMU_TOKEN={chr(39)}{c[\"auth\"][\"token\"]}{chr(39)}')
+print(f'TANDEMU_API={chr(39)}{c[\"api\"][\"url\"]}{chr(39)}')
+print(f'TANDEMU_ORG_ID={chr(39)}{c.get(\"organization\",{}).get(\"id\",\"\")}{chr(39)}')
+print(f'TANDEMU_USER_ID={chr(39)}{c[\"user\"][\"id\"]}{chr(39)}')
+print(f'TANDEMU_USER_EMAIL={chr(39)}{c[\"user\"][\"email\"]}{chr(39)}')
+print(f'TANDEMU_USER_NAME={chr(39)}{c[\"user\"][\"name\"]}{chr(39)}')
+
+teams = c.get('teams') or ([c['team']] if c.get('team',{}).get('id') else [])
+if teams:
+    ids = ','.join(t['id'] for t in teams)
+    names = ','.join(t['name'] for t in teams)
+    print(f'TANDEMU_TEAM_ID={chr(39)}{teams[0][\"id\"]}{chr(39)}')
+    print(f'TANDEMU_TEAM_IDS={chr(39)}{ids}{chr(39)}')
+    print(f'TANDEMU_TEAM_NAMES={chr(39)}{names}{chr(39)}')
+    print(f'TANDEMU_TEAM_COUNT={len(teams)}')
+else:
+    print(\"TANDEMU_TEAM_ID=''\")
+    print(\"TANDEMU_TEAM_IDS=''\")
+    print(\"TANDEMU_TEAM_NAMES=''\")
+    print('TANDEMU_TEAM_COUNT=0')
+")"
+
+# Universal active-task dir (skills read/write here)
+export TANDEMU_TASKS_DIR="${TANDEMU_TASKS_DIR:-$HOME/.config/tandemu/active-tasks}"
+mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
+
+unset _TANDEMU_CONFIG
+LOADER_EOF
+  chmod 644 "$TANDEMU_LIB_DIR/tandemu-env.sh"
+  ok "Loader installed: ~/.config/tandemu/lib/tandemu-env.sh"
+}
+
+# Copy all 6 SKILL.md files into <commands_dir>/<name>.md verbatim. Used by
+# Cursor + Codex install paths so /morning, /finish etc. fire as native slash
+# commands the same way they do on Claude Code + OpenCode.
+install_skills_to() {
+  local dest_dir="$1"
+  local skills_src="${SCRIPT_DIR}/apps/skills"
+  if [ ! -d "$skills_src" ]; then
+    warn "Source skills dir not found at $skills_src — skipping"
+    return 1
+  fi
+  mkdir -p "$dest_dir"
+  for skill in morning finish pause create standup setup; do
+    if [ -f "$skills_src/$skill/SKILL.md" ]; then
+      cp "$skills_src/$skill/SKILL.md" "$dest_dir/$skill.md"
+    fi
+  done
+}
+
 # Resolve the combined Tandemu MCP URL from the backend (handles SaaS/self-host).
 # Sets $TANDEMU_MCP_URL. Falls back to ${API_URL}/api/memory/mcp on error.
 fetch_mcp_url() {
@@ -1118,16 +1170,18 @@ PYEOF
 }
 
 install_assets_cursor() {
-  step "Installing personality + rules (Cursor)..."
+  step "Installing personality + rules + skills (Cursor)..."
 
-  # Cursor reads .mdc rules from ~/.cursor/rules/ globally and from
-  # <project>/.cursor/rules/ per-project. Drop a global Tandemu rule that
-  # imports the canonical AGENTS.md content.
+  # Global rule mirrors AGENTS.md content. Cursor reads .mdc rules from
+  # ~/.cursor/rules/ globally and from <project>/.cursor/rules/ per-project.
   mkdir -p "$CURSOR_DIR/rules"
   write_agents_md "$CURSOR_DIR/rules/tandemu.mdc" || true
   ok "Rule installed: ~/.cursor/rules/tandemu.mdc"
 
-  # Track installed plugin version
+  # Slash commands. Cursor reads custom commands from ~/.cursor/commands/.
+  install_skills_to "$CURSOR_DIR/commands"
+  ok "Skills installed → ~/.cursor/commands/ (/morning, /finish, /pause, /create, /standup, /setup)"
+
   local v
   v=$(get_plugin_version)
   mkdir -p "$(dirname "$CURSOR_VERSION_FILE")"
@@ -1135,65 +1189,7 @@ install_assets_cursor() {
 }
 
 # ─────────────────────────────────────────────────────────
-# Copilot CLI target: register MCP server + drop AGENTS.md
-# ─────────────────────────────────────────────────────────
-
-configure_copilot() {
-  mkdir -p "$COPILOT_DIR" "$HOME/.config/tandemu"
-
-  step "Writing Tandemu config (Copilot CLI)..."
-  cat > "$HOME/.config/tandemu/copilot-auth.json" << EOF
-{
-  "auth": { "token": "${TOKEN}" },
-  "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
-  "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
-  "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
-  "api": { "url": "${API_URL}" }
-}
-EOF
-  ok "Config: ~/.config/tandemu/copilot-auth.json"
-
-  step "Configuring Tandemu MCP (Copilot CLI)..."
-  fetch_mcp_url
-
-  TANDEMU_TOKEN="$TOKEN" \
-  TANDEMU_MCP_URL="$TANDEMU_MCP_URL" \
-  python3 << 'PYEOF'
-import json, os
-cfg_file = os.path.expanduser("~/.copilot/mcp_config.json")
-os.makedirs(os.path.dirname(cfg_file), exist_ok=True)
-try:
-    with open(cfg_file) as f:
-        cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    cfg = {}
-servers = cfg.get("mcpServers", {})
-servers["tandemu"] = {
-    "type": "http",
-    "url": os.environ["TANDEMU_MCP_URL"],
-    "headers": {"Authorization": f"Bearer {os.environ['TANDEMU_TOKEN']}"},
-}
-cfg["mcpServers"] = servers
-with open(cfg_file, "w") as f:
-    json.dump(cfg, f, indent=2)
-PYEOF
-  ok "MCP: enabled (→ ${TANDEMU_MCP_URL})"
-}
-
-install_assets_copilot() {
-  step "Installing personality (Copilot CLI)..."
-  # Copilot CLI reads AGENTS.md from the user's home + repo roots.
-  write_agents_md "$COPILOT_DIR/AGENTS.md" || true
-  ok "AGENTS.md installed: ~/.copilot/AGENTS.md"
-
-  local v
-  v=$(get_plugin_version)
-  mkdir -p "$(dirname "$COPILOT_VERSION_FILE")"
-  echo "$v" > "$COPILOT_VERSION_FILE"
-}
-
-# ─────────────────────────────────────────────────────────
-# Codex CLI target: register MCP server + drop AGENTS.md
+# Codex CLI target: skills + AGENTS.md + universal lib
 # ─────────────────────────────────────────────────────────
 
 configure_codex() {
@@ -1254,9 +1250,13 @@ PYEOF
 }
 
 install_assets_codex() {
-  step "Installing personality (Codex CLI)..."
+  step "Installing personality + skills (Codex CLI)..."
   write_agents_md "$CODEX_DIR/AGENTS.md" || true
   ok "AGENTS.md installed: ~/.codex/AGENTS.md"
+
+  # Slash commands. Codex CLI reads custom prompts from ~/.codex/prompts/.
+  install_skills_to "$CODEX_DIR/prompts"
+  ok "Skills installed → ~/.codex/prompts/ (/morning, /finish, /pause, /create, /standup, /setup)"
 
   local v
   v=$(get_plugin_version)
@@ -1272,15 +1272,14 @@ write_configs() {
   if target_active claude; then configure_claude; fi
   if target_active opencode; then configure_opencode; fi
   if target_active cursor; then configure_cursor; fi
-  if target_active copilot; then configure_copilot; fi
   if target_active codex; then configure_codex; fi
 }
 
 install_assets() {
+  install_universal_lib
   if target_active claude; then install_assets_claude; fi
   if target_active opencode; then install_assets_opencode; fi
   if target_active cursor; then install_assets_cursor; fi
-  if target_active copilot; then install_assets_copilot; fi
   if target_active codex; then install_assets_codex; fi
 }
 
@@ -1320,31 +1319,18 @@ print_done() {
     printf '%b\n' "    ${GREEN}\$ opencode${NC}      ${DIM}# slash commands: /morning /finish /pause /standup${NC}"
   fi
   if target_active cursor; then
-    printf '%b\n' "    ${GREEN}\$ cursor .${NC}      ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
-  fi
-  if target_active copilot; then
-    printf '%b\n' "    ${GREEN}\$ gh copilot${NC}    ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
+    printf '%b\n' "    ${GREEN}\$ cursor .${NC}      ${DIM}# slash commands: /morning /finish /pause /standup${NC}"
   fi
   if target_active codex; then
-    printf '%b\n' "    ${GREEN}\$ codex${NC}         ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
+    printf '%b\n' "    ${GREEN}\$ codex${NC}         ${DIM}# slash commands: /morning /finish /pause /standup${NC}"
   fi
   echo ""
-  if target_active claude || target_active opencode; then
-    printf '%b\n' "  ${BOLD}Slash commands (Claude Code / OpenCode):${NC}"
-    printf '%b\n' "    ${GREEN}/morning${NC}   — Pick a task and start working"
-    printf '%b\n' "    ${GREEN}/finish${NC}    — Complete task, measure work, send telemetry"
-    printf '%b\n' "    ${GREEN}/pause${NC}     — Pause current task, switch to another"
-    printf '%b\n' "    ${GREEN}/standup${NC}   — Generate a team standup report"
-    echo ""
-  fi
-  if target_active cursor || target_active copilot || target_active codex; then
-    printf '%b\n' "  ${BOLD}MCP tools (Cursor / Copilot / Codex):${NC}"
-    printf '%b\n' "    ${GREEN}list_tasks${NC}        — Pull tasks from your ticket system"
-    printf '%b\n' "    ${GREEN}update_task${NC}       — Move a task between statuses"
-    printf '%b\n' "    ${GREEN}create_task${NC}       — Create a new task"
-    printf '%b\n' "    ${GREEN}add_memory${NC} / ${GREEN}search_memories${NC}  — Personal + org memory"
-    echo ""
-  fi
+  printf '%b\n' "  ${BOLD}Available skills:${NC}"
+  printf '%b\n' "    ${GREEN}/morning${NC}   — Pick a task and start working"
+  printf '%b\n' "    ${GREEN}/finish${NC}    — Complete task, measure work, send telemetry"
+  printf '%b\n' "    ${GREEN}/pause${NC}     — Pause current task, switch to another"
+  printf '%b\n' "    ${GREEN}/standup${NC}   — Generate a team standup report"
+  echo ""
   printf '%b\n' "  ${BOLD}Manage:${NC}"
   dim "    Re-authenticate:  ./install.sh"
   dim "    Check updates:    ./install.sh --check"
@@ -1374,7 +1360,7 @@ while [ $# -gt 0 ]; do
       # Accept comma-separated list ("cursor,codex") or single value.
       # Special tokens: "both" (legacy alias for claude+opencode), "all".
       case "$target_val" in
-        all) TARGETS="claude opencode cursor copilot codex" ;;
+        all) TARGETS="claude opencode cursor codex" ;;
         both) TARGETS="claude opencode" ;;
         *)
           IFS=',' read -ra _t_arr <<< "$target_val"
@@ -1382,11 +1368,11 @@ while [ $# -gt 0 ]; do
           for t in "${_t_arr[@]}"; do
             t="${t// /}"
             case "$t" in
-              claude|opencode|cursor|copilot|codex)
+              claude|opencode|cursor|codex)
                 TARGETS="${TARGETS:+$TARGETS }$t"
                 ;;
               *)
-                fail "Invalid --target: $t (expected: claude|opencode|cursor|copilot|codex|all|both)"
+                fail "Invalid --target: $t (expected: claude|opencode|cursor|codex|all|both)"
                 ;;
             esac
           done

--- a/install.sh
+++ b/install.sh
@@ -1032,79 +1032,16 @@ install_universal_lib() {
   # Skills still write task files at ~/.claude/tandemu-active-task-*.json for
   # back-compat with existing installs. Ensure the dir exists on all targets.
   mkdir -p "$HOME/.claude" 2>/dev/null || true
-  cat > "$TANDEMU_LIB_DIR/tandemu-env.sh" << 'LOADER_EOF'
-#!/bin/sh
-# Tandemu env loader — sourced by skills. Probes per-agent auth files in order
-# until one is found, then exports TANDEMU_* env vars for the calling shell.
 
-_TANDEMU_CONFIG=""
-for _f in \
-  "$HOME/.claude/tandemu.json" \
-  "$HOME/.config/tandemu/auth.json" \
-  "$HOME/.config/tandemu/cursor-auth.json" \
-  "$HOME/.config/tandemu/codex-auth.json"; do
-  if [ -f "$_f" ]; then
-    _TANDEMU_CONFIG=$(cat "$_f" 2>/dev/null)
-    [ -n "$_TANDEMU_CONFIG" ] && break
+  # Single source of truth: the canonical loader lives in the Claude plugin
+  # tree because /tandemu:setup needs to ship it via the plugin marketplace.
+  # install.sh copies the same file so both install paths deliver identical
+  # logic. Do not duplicate the loader content here.
+  local canonical_loader="${SCRIPT_DIR}/apps/claude-plugins/lib/tandemu-env.sh"
+  if [ ! -f "$canonical_loader" ]; then
+    fail "Canonical loader not found at $canonical_loader — repo layout broken."
   fi
-done
-unset _f
-
-if [ -z "$_TANDEMU_CONFIG" ]; then
-  echo "ERROR: Tandemu not configured. Run install.sh to set up." >&2
-  return 1 2>/dev/null || exit 1
-fi
-
-eval "$(echo "$_TANDEMU_CONFIG" | python3 -c "
-import sys, json
-c = json.load(sys.stdin)
-print(f'TANDEMU_TOKEN={chr(39)}{c[\"auth\"][\"token\"]}{chr(39)}')
-print(f'TANDEMU_API={chr(39)}{c[\"api\"][\"url\"]}{chr(39)}')
-print(f'TANDEMU_ORG_ID={chr(39)}{c.get(\"organization\",{}).get(\"id\",\"\")}{chr(39)}')
-print(f'TANDEMU_USER_ID={chr(39)}{c[\"user\"][\"id\"]}{chr(39)}')
-print(f'TANDEMU_USER_EMAIL={chr(39)}{c[\"user\"][\"email\"]}{chr(39)}')
-print(f'TANDEMU_USER_NAME={chr(39)}{c[\"user\"][\"name\"]}{chr(39)}')
-
-teams = c.get('teams') or ([c['team']] if c.get('team',{}).get('id') else [])
-if teams:
-    ids = ','.join(t['id'] for t in teams)
-    names = ','.join(t['name'] for t in teams)
-    print(f'TANDEMU_TEAM_ID={chr(39)}{teams[0][\"id\"]}{chr(39)}')
-    print(f'TANDEMU_TEAM_IDS={chr(39)}{ids}{chr(39)}')
-    print(f'TANDEMU_TEAM_NAMES={chr(39)}{names}{chr(39)}')
-    print(f'TANDEMU_TEAM_COUNT={len(teams)}')
-else:
-    print(\"TANDEMU_TEAM_ID=''\")
-    print(\"TANDEMU_TEAM_IDS=''\")
-    print(\"TANDEMU_TEAM_NAMES=''\")
-    print('TANDEMU_TEAM_COUNT=0')
-")"
-
-# Universal active-task dir (skills read/write here)
-export TANDEMU_TASKS_DIR="${TANDEMU_TASKS_DIR:-$HOME/.config/tandemu/active-tasks}"
-mkdir -p "$TANDEMU_TASKS_DIR" 2>/dev/null || true
-
-# One-time migration: relocate legacy branch-keyed task files from the old
-# Claude-only location into the universal dir. Same filename scheme, so this
-# is a plain move. Skipped if a file with that name already exists there.
-for _t in "$HOME"/.claude/tandemu-active-task-*.json; do
-  [ -e "$_t" ] || continue
-  _dest="$TANDEMU_TASKS_DIR/$(basename "$_t")"
-  [ -e "$_dest" ] || mv "$_t" "$_dest" 2>/dev/null || true
-done
-unset _t _dest
-
-# OTEL collector endpoint. Derived from the API host (collector runs alongside
-# the backend on :4318). Skills must use this instead of reading
-# ~/.claude/settings.json, which only exists on Claude Code installs.
-_TANDEMU_OTEL_HOST=$(echo "$TANDEMU_API" | sed 's|https\{0,1\}://||; s|/.*||; s|:.*||')
-if [ -n "$_TANDEMU_OTEL_HOST" ]; then
-  export TANDEMU_OTEL_ENDPOINT="http://${_TANDEMU_OTEL_HOST}:4318"
-fi
-unset _TANDEMU_OTEL_HOST
-
-unset _TANDEMU_CONFIG
-LOADER_EOF
+  cp "$canonical_loader" "$TANDEMU_LIB_DIR/tandemu-env.sh"
   chmod 644 "$TANDEMU_LIB_DIR/tandemu-env.sh"
   ok "Loader installed: ~/.config/tandemu/lib/tandemu-env.sh"
 }

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 #  Flags:
 #    --url <url>       Set API URL (skip instance selection)
 #    --token <token>   Use provided JWT (non-interactive)
-#    --target <t>      claude | opencode | both (default: auto-detect)
+#    --target <t>      claude | opencode | cursor | copilot | codex | all
+#                      (comma-separated for multiple; "both" = claude+opencode)
 #    --uninstall       Remove all Tandemu files
 #    --check           Check for updates
 #    --skip-prereqs    Skip prerequisite checks
@@ -34,6 +35,14 @@ VERSION_FILE="$CLAUDE_DIR/tandemu-version.txt"
 OPENCODE_DIR="$HOME/.config/opencode"
 TANDEMU_OPENCODE_DIR="$HOME/.config/tandemu"
 OPENCODE_VERSION_FILE="$TANDEMU_OPENCODE_DIR/version.txt"
+
+# Lightweight targets (MCP-first, no plugin packaging)
+CURSOR_DIR="$HOME/.cursor"
+CURSOR_VERSION_FILE="$HOME/.config/tandemu/cursor-version.txt"
+COPILOT_DIR="$HOME/.copilot"
+COPILOT_VERSION_FILE="$HOME/.config/tandemu/copilot-version.txt"
+CODEX_DIR="$HOME/.codex"
+CODEX_VERSION_FILE="$HOME/.config/tandemu/codex-version.txt"
 
 # TARGETS is set by detect_targets() or --target flag. Space-separated list.
 TARGETS=""
@@ -304,6 +313,105 @@ open(f, 'w').write(text.strip() + '\n')
 
   rm -rf "$TANDEMU_OPENCODE_DIR"
 
+  # ── Cursor ──
+  if [ -f "$CURSOR_DIR/mcp.json" ]; then
+    python3 << 'PYEOF'
+import json, os
+f = os.path.expanduser("~/.cursor/mcp.json")
+try:
+    cfg = json.load(open(f))
+    s = cfg.get("mcpServers", {})
+    s.pop("tandemu", None)
+    s.pop("tandemu-memory", None)
+    if s:
+        cfg["mcpServers"] = s
+    elif "mcpServers" in cfg:
+        del cfg["mcpServers"]
+    if cfg:
+        json.dump(cfg, open(f, "w"), indent=2)
+    else:
+        os.remove(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    pass
+PYEOF
+    ok "Cursor MCP cleaned"
+  fi
+  rm -f "$CURSOR_DIR/rules/tandemu.mdc" 2>/dev/null || true
+
+  # ── Copilot CLI ──
+  if [ -f "$COPILOT_DIR/mcp_config.json" ]; then
+    python3 << 'PYEOF'
+import json, os
+f = os.path.expanduser("~/.copilot/mcp_config.json")
+try:
+    cfg = json.load(open(f))
+    s = cfg.get("mcpServers", {})
+    s.pop("tandemu", None)
+    if s:
+        cfg["mcpServers"] = s
+    elif "mcpServers" in cfg:
+        del cfg["mcpServers"]
+    if cfg:
+        json.dump(cfg, open(f, "w"), indent=2)
+    else:
+        os.remove(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    pass
+PYEOF
+    ok "Copilot MCP cleaned"
+  fi
+  if [ -f "$COPILOT_DIR/AGENTS.md" ]; then
+    if grep -q "Tandemu AI Teammate" "$COPILOT_DIR/AGENTS.md" 2>/dev/null; then
+      rm -f "$COPILOT_DIR/AGENTS.md"
+    elif grep -qF "<!-- tandemu:personality:start -->" "$COPILOT_DIR/AGENTS.md" 2>/dev/null; then
+      python3 -c "
+import re
+f = '$COPILOT_DIR/AGENTS.md'
+text = open(f).read()
+text = re.sub(r'<!-- tandemu:personality:start -->.*?<!-- tandemu:personality:end -->\n*', '', text, flags=re.DOTALL)
+open(f, 'w').write(text.strip() + '\n')
+"
+    fi
+  fi
+
+  # ── Codex CLI ──
+  if [ -f "$CODEX_DIR/config.toml" ]; then
+    python3 << 'PYEOF'
+import os, re
+f = os.path.expanduser("~/.codex/config.toml")
+try:
+    text = open(f).read()
+    text = re.sub(
+        r"\n?\[mcp_servers\.tandemu(\.[^\]]+)?\][^\[]*",
+        "",
+        text,
+        flags=re.DOTALL,
+    ).rstrip()
+    if text:
+        open(f, "w").write(text + "\n")
+    else:
+        os.remove(f)
+except FileNotFoundError:
+    pass
+PYEOF
+    ok "Codex MCP cleaned"
+  fi
+  if [ -f "$CODEX_DIR/AGENTS.md" ]; then
+    if grep -q "Tandemu AI Teammate" "$CODEX_DIR/AGENTS.md" 2>/dev/null; then
+      rm -f "$CODEX_DIR/AGENTS.md"
+    elif grep -qF "<!-- tandemu:personality:start -->" "$CODEX_DIR/AGENTS.md" 2>/dev/null; then
+      python3 -c "
+import re
+f = '$CODEX_DIR/AGENTS.md'
+text = open(f).read()
+text = re.sub(r'<!-- tandemu:personality:start -->.*?<!-- tandemu:personality:end -->\n*', '', text, flags=re.DOTALL)
+open(f, 'w').write(text.strip() + '\n')
+"
+    fi
+  fi
+
+  rm -f "$CURSOR_VERSION_FILE" "$COPILOT_VERSION_FILE" "$CODEX_VERSION_FILE" 2>/dev/null || true
+
   echo ""
   printf '%b\n' "  ${GREEN}Tandemu uninstalled.${NC}"
   echo ""
@@ -322,22 +430,26 @@ do_check() {
   echo ""
 
   local any_stale=""
+  local any_installed=""
 
-  if [ -f "$VERSION_FILE" ]; then
-    local claude_v
-    claude_v=$(cat "$VERSION_FILE")
-    printf '%b\n' "  Claude Code: ${BOLD}${claude_v}${NC}"
-    if [ "$claude_v" != "$latest" ]; then any_stale="true"; fi
-  fi
+  _check_one() {
+    local label="$1" file="$2"
+    if [ -f "$file" ]; then
+      local v
+      v=$(cat "$file")
+      printf '%b\n' "  ${label}: ${BOLD}${v}${NC}"
+      any_installed="true"
+      if [ "$v" != "$latest" ]; then any_stale="true"; fi
+    fi
+  }
 
-  if [ -f "$OPENCODE_VERSION_FILE" ]; then
-    local oc_v
-    oc_v=$(cat "$OPENCODE_VERSION_FILE")
-    printf '%b\n' "  OpenCode:    ${BOLD}${oc_v}${NC}"
-    if [ "$oc_v" != "$latest" ]; then any_stale="true"; fi
-  fi
+  _check_one "Claude Code" "$VERSION_FILE"
+  _check_one "OpenCode   " "$OPENCODE_VERSION_FILE"
+  _check_one "Cursor     " "$CURSOR_VERSION_FILE"
+  _check_one "Copilot    " "$COPILOT_VERSION_FILE"
+  _check_one "Codex      " "$CODEX_VERSION_FILE"
 
-  if [ ! -f "$VERSION_FILE" ] && [ ! -f "$OPENCODE_VERSION_FILE" ]; then
+  if [ -z "$any_installed" ]; then
     warn "Tandemu not installed. Run install.sh to install."
   elif [ -n "$any_stale" ]; then
     warn "Update available. Run install.sh to update."
@@ -355,12 +467,13 @@ do_check() {
 check_prerequisites() {
   step "Checking prerequisites..."
 
-  local has_claude="" has_opencode=""
-  command -v claude &>/dev/null && has_claude="true"
-  command -v opencode &>/dev/null && has_opencode="true"
+  local has_any=""
+  for cli in claude opencode cursor codex gh; do
+    command -v "$cli" &>/dev/null && has_any="true"
+  done
 
-  if [ -z "$has_claude" ] && [ -z "$has_opencode" ]; then
-    fail "Neither Claude Code nor OpenCode CLI found. Install one: https://code.claude.com or https://opencode.ai"
+  if [ -z "$has_any" ]; then
+    fail "No supported AI agent CLI found (claude, opencode, cursor, codex, gh). Install at least one and re-run."
   fi
 
   if ! command -v python3 &>/dev/null; then
@@ -384,28 +497,60 @@ detect_targets() {
     return
   fi
 
-  local has_claude="" has_opencode=""
-  command -v claude &>/dev/null && has_claude="true"
-  command -v opencode &>/dev/null && has_opencode="true"
+  # Probe each supported agent.
+  local found=()
+  command -v claude &>/dev/null && found+=("claude")
+  command -v opencode &>/dev/null && found+=("opencode")
+  command -v cursor &>/dev/null && found+=("cursor")
+  if command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -qi copilot; then
+    found+=("copilot")
+  fi
+  command -v codex &>/dev/null && found+=("codex")
 
-  if [ -n "$has_claude" ] && [ -n "$has_opencode" ]; then
-    echo ""
-    printf '%b\n' "  ${BOLD}Both Claude Code and OpenCode are installed. Where should Tandemu install?${NC}"
-    echo ""
-    printf '%b\n' "    ${BOLD}1.${NC} Claude Code"
-    printf '%b\n' "    ${BOLD}2.${NC} OpenCode"
-    printf '%b\n' "    ${BOLD}3.${NC} Both"
-    echo ""
-    read -rp "  Choose (1-3): " choice
-    case "$choice" in
-      2) TARGETS="opencode" ;;
-      3) TARGETS="claude opencode" ;;
-      *) TARGETS="claude" ;;
+  if [ ${#found[@]} -eq 0 ]; then
+    fail "No supported AI agent CLI found. Install one of: claude, opencode, cursor, codex, gh+copilot."
+  fi
+
+  if [ ${#found[@]} -eq 1 ]; then
+    TARGETS="${found[0]}"
+    return
+  fi
+
+  echo ""
+  printf '%b\n' "  ${BOLD}Detected AI agents:${NC}"
+  echo ""
+  local i=1
+  for t in "${found[@]}"; do
+    case "$t" in
+      claude)   printf '%b\n' "    ${BOLD}${i}.${NC} Claude Code" ;;
+      opencode) printf '%b\n' "    ${BOLD}${i}.${NC} OpenCode" ;;
+      cursor)   printf '%b\n' "    ${BOLD}${i}.${NC} Cursor" ;;
+      copilot)  printf '%b\n' "    ${BOLD}${i}.${NC} GitHub Copilot CLI" ;;
+      codex)    printf '%b\n' "    ${BOLD}${i}.${NC} Codex CLI" ;;
     esac
-  elif [ -n "$has_opencode" ]; then
-    TARGETS="opencode"
-  else
-    TARGETS="claude"
+    i=$((i + 1))
+  done
+  printf '%b\n' "    ${BOLD}a.${NC} All of the above"
+  echo ""
+  read -rp "  Choose (numbers, comma-separated, or 'a' for all): " choice
+
+  if [ "$choice" = "a" ] || [ "$choice" = "A" ]; then
+    TARGETS="${found[*]}"
+    return
+  fi
+
+  TARGETS=""
+  IFS=',' read -ra _idxs <<< "$choice"
+  for raw in "${_idxs[@]}"; do
+    raw="${raw// /}"
+    if [[ "$raw" =~ ^[0-9]+$ ]] && [ "$raw" -ge 1 ] && [ "$raw" -le ${#found[@]} ]; then
+      TARGETS="${TARGETS:+$TARGETS }${found[$((raw - 1))]}"
+    fi
+  done
+
+  # Default to first detected if user typed nothing valid.
+  if [ -z "$TARGETS" ]; then
+    TARGETS="${found[0]}"
   fi
 }
 
@@ -888,17 +1033,255 @@ install_assets_opencode() {
 }
 
 # ─────────────────────────────────────────────────────────
+# Shared helpers for lightweight (MCP-first) targets
+# ─────────────────────────────────────────────────────────
+
+# Drop the canonical AGENTS.md template at the given path. If the destination
+# already has user content, only ensure that the personality markers exist so
+# session-start hooks can update the section in-place. Idempotent.
+write_agents_md() {
+  local dest="$1"
+  local repo_agents="${SCRIPT_DIR}/apps/skills/AGENTS.md"
+  if [ ! -f "$repo_agents" ]; then
+    warn "Source AGENTS.md not found at $repo_agents — skipping"
+    return 1
+  fi
+  mkdir -p "$(dirname "$dest")"
+  if [ -f "$dest" ] && ! grep -qF "Tandemu AI Teammate" "$dest" 2>/dev/null; then
+    if ! grep -qF "<!-- tandemu:personality:start -->" "$dest" 2>/dev/null; then
+      printf '\n<!-- tandemu:personality:start -->\n<!-- tandemu:personality:end -->\n' >> "$dest"
+    fi
+  else
+    cp "$repo_agents" "$dest"
+  fi
+}
+
+# Resolve the combined Tandemu MCP URL from the backend (handles SaaS/self-host).
+# Sets $TANDEMU_MCP_URL. Falls back to ${API_URL}/api/memory/mcp on error.
+fetch_mcp_url() {
+  local cfg
+  cfg=$(curl -sf -H "Authorization: Bearer ${TOKEN}" "${API_URL}/api/memory/config" 2>/dev/null || true)
+  TANDEMU_MCP_URL=""
+  if [ -n "$cfg" ]; then
+    TANDEMU_MCP_URL=$(echo "$cfg" | python3 -c "import json,sys
+d=json.load(sys.stdin)
+d=d.get('data',d) if isinstance(d,dict) and 'data' in d else d
+print(d.get('url',''))" 2>/dev/null) || TANDEMU_MCP_URL=""
+  fi
+  if [ -z "$TANDEMU_MCP_URL" ]; then
+    TANDEMU_MCP_URL="${API_URL}/api/memory/mcp"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────
+# Cursor target: register MCP server + drop AGENTS.md / rules
+# ─────────────────────────────────────────────────────────
+
+configure_cursor() {
+  mkdir -p "$CURSOR_DIR" "$HOME/.config/tandemu"
+
+  step "Writing Tandemu config (Cursor)..."
+  cat > "$HOME/.config/tandemu/cursor-auth.json" << EOF
+{
+  "auth": { "token": "${TOKEN}" },
+  "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
+  "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
+  "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
+  "api": { "url": "${API_URL}" }
+}
+EOF
+  ok "Config: ~/.config/tandemu/cursor-auth.json"
+
+  step "Configuring Tandemu MCP (Cursor)..."
+  fetch_mcp_url
+
+  TANDEMU_TOKEN="$TOKEN" \
+  TANDEMU_MCP_URL="$TANDEMU_MCP_URL" \
+  python3 << 'PYEOF'
+import json, os
+cfg_file = os.path.expanduser("~/.cursor/mcp.json")
+try:
+    with open(cfg_file) as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+servers = cfg.get("mcpServers", {})
+servers["tandemu"] = {
+    "url": os.environ["TANDEMU_MCP_URL"],
+    "headers": {"Authorization": f"Bearer {os.environ['TANDEMU_TOKEN']}"},
+}
+cfg["mcpServers"] = servers
+with open(cfg_file, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+  ok "MCP: enabled (→ ${TANDEMU_MCP_URL})"
+}
+
+install_assets_cursor() {
+  step "Installing personality + rules (Cursor)..."
+
+  # Cursor reads .mdc rules from ~/.cursor/rules/ globally and from
+  # <project>/.cursor/rules/ per-project. Drop a global Tandemu rule that
+  # imports the canonical AGENTS.md content.
+  mkdir -p "$CURSOR_DIR/rules"
+  write_agents_md "$CURSOR_DIR/rules/tandemu.mdc" || true
+  ok "Rule installed: ~/.cursor/rules/tandemu.mdc"
+
+  # Track installed plugin version
+  local v
+  v=$(get_plugin_version)
+  mkdir -p "$(dirname "$CURSOR_VERSION_FILE")"
+  echo "$v" > "$CURSOR_VERSION_FILE"
+}
+
+# ─────────────────────────────────────────────────────────
+# Copilot CLI target: register MCP server + drop AGENTS.md
+# ─────────────────────────────────────────────────────────
+
+configure_copilot() {
+  mkdir -p "$COPILOT_DIR" "$HOME/.config/tandemu"
+
+  step "Writing Tandemu config (Copilot CLI)..."
+  cat > "$HOME/.config/tandemu/copilot-auth.json" << EOF
+{
+  "auth": { "token": "${TOKEN}" },
+  "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
+  "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
+  "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
+  "api": { "url": "${API_URL}" }
+}
+EOF
+  ok "Config: ~/.config/tandemu/copilot-auth.json"
+
+  step "Configuring Tandemu MCP (Copilot CLI)..."
+  fetch_mcp_url
+
+  TANDEMU_TOKEN="$TOKEN" \
+  TANDEMU_MCP_URL="$TANDEMU_MCP_URL" \
+  python3 << 'PYEOF'
+import json, os
+cfg_file = os.path.expanduser("~/.copilot/mcp_config.json")
+os.makedirs(os.path.dirname(cfg_file), exist_ok=True)
+try:
+    with open(cfg_file) as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+servers = cfg.get("mcpServers", {})
+servers["tandemu"] = {
+    "type": "http",
+    "url": os.environ["TANDEMU_MCP_URL"],
+    "headers": {"Authorization": f"Bearer {os.environ['TANDEMU_TOKEN']}"},
+}
+cfg["mcpServers"] = servers
+with open(cfg_file, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+  ok "MCP: enabled (→ ${TANDEMU_MCP_URL})"
+}
+
+install_assets_copilot() {
+  step "Installing personality (Copilot CLI)..."
+  # Copilot CLI reads AGENTS.md from the user's home + repo roots.
+  write_agents_md "$COPILOT_DIR/AGENTS.md" || true
+  ok "AGENTS.md installed: ~/.copilot/AGENTS.md"
+
+  local v
+  v=$(get_plugin_version)
+  mkdir -p "$(dirname "$COPILOT_VERSION_FILE")"
+  echo "$v" > "$COPILOT_VERSION_FILE"
+}
+
+# ─────────────────────────────────────────────────────────
+# Codex CLI target: register MCP server + drop AGENTS.md
+# ─────────────────────────────────────────────────────────
+
+configure_codex() {
+  mkdir -p "$CODEX_DIR" "$HOME/.config/tandemu"
+
+  step "Writing Tandemu config (Codex CLI)..."
+  cat > "$HOME/.config/tandemu/codex-auth.json" << EOF
+{
+  "auth": { "token": "${TOKEN}" },
+  "user": { "id": "${USER_ID}", "email": "${USER_EMAIL}", "name": "${USER_NAME}" },
+  "organization": { "id": "${ORG_ID}", "name": "${ORG_NAME}" },
+  "team": { "id": "${TEAM_ID}", "name": "${TEAM_NAME}" },
+  "api": { "url": "${API_URL}" }
+}
+EOF
+  ok "Config: ~/.config/tandemu/codex-auth.json"
+
+  step "Configuring Tandemu MCP (Codex CLI)..."
+  fetch_mcp_url
+
+  # Codex reads ~/.codex/config.toml. Merge a [mcp_servers.tandemu] entry,
+  # preserving any other servers and unrelated config the user has set.
+  TANDEMU_TOKEN="$TOKEN" \
+  TANDEMU_MCP_URL="$TANDEMU_MCP_URL" \
+  python3 << 'PYEOF'
+import os, re
+
+cfg_file = os.path.expanduser("~/.codex/config.toml")
+url = os.environ["TANDEMU_MCP_URL"]
+token = os.environ["TANDEMU_TOKEN"]
+
+block = (
+    "\n[mcp_servers.tandemu]\n"
+    f'url = "{url}"\n'
+    "[mcp_servers.tandemu.headers]\n"
+    f'Authorization = "Bearer {token}"\n'
+)
+
+text = ""
+if os.path.exists(cfg_file):
+    with open(cfg_file) as f:
+        text = f.read()
+
+# Strip existing tandemu sections so re-running stays idempotent.
+text = re.sub(
+    r"\n?\[mcp_servers\.tandemu(\.[^\]]+)?\][^\[]*",
+    "",
+    text,
+    flags=re.DOTALL,
+).rstrip()
+
+text = (text + "\n" + block) if text else block.lstrip()
+
+with open(cfg_file, "w") as f:
+    f.write(text)
+PYEOF
+  ok "MCP: enabled (→ ${TANDEMU_MCP_URL})"
+}
+
+install_assets_codex() {
+  step "Installing personality (Codex CLI)..."
+  write_agents_md "$CODEX_DIR/AGENTS.md" || true
+  ok "AGENTS.md installed: ~/.codex/AGENTS.md"
+
+  local v
+  v=$(get_plugin_version)
+  mkdir -p "$(dirname "$CODEX_VERSION_FILE")"
+  echo "$v" > "$CODEX_VERSION_FILE"
+}
+
+# ─────────────────────────────────────────────────────────
 # Per-target dispatchers
 # ─────────────────────────────────────────────────────────
 
 write_configs() {
   if target_active claude; then configure_claude; fi
   if target_active opencode; then configure_opencode; fi
+  if target_active cursor; then configure_cursor; fi
+  if target_active copilot; then configure_copilot; fi
+  if target_active codex; then configure_codex; fi
 }
 
 install_assets() {
   if target_active claude; then install_assets_claude; fi
   if target_active opencode; then install_assets_opencode; fi
+  if target_active cursor; then install_assets_cursor; fi
+  if target_active copilot; then install_assets_copilot; fi
+  if target_active codex; then install_assets_codex; fi
 }
 
 # ─────────────────────────────────────────────────────────
@@ -931,19 +1314,37 @@ print_done() {
   echo ""
   printf '%b\n' "    ${GREEN}\$ cd your-project${NC}"
   if target_active claude; then
-    printf '%b\n' "    ${GREEN}\$ claude${NC}"
+    printf '%b\n' "    ${GREEN}\$ claude${NC}        ${DIM}# slash commands: /morning /finish /pause /standup${NC}"
   fi
   if target_active opencode; then
-    printf '%b\n' "    ${GREEN}\$ opencode${NC}"
+    printf '%b\n' "    ${GREEN}\$ opencode${NC}      ${DIM}# slash commands: /morning /finish /pause /standup${NC}"
   fi
-  printf '%b\n' "    ${GREEN}> /morning${NC}"
+  if target_active cursor; then
+    printf '%b\n' "    ${GREEN}\$ cursor .${NC}      ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
+  fi
+  if target_active copilot; then
+    printf '%b\n' "    ${GREEN}\$ gh copilot${NC}    ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
+  fi
+  if target_active codex; then
+    printf '%b\n' "    ${GREEN}\$ codex${NC}         ${DIM}# ask: \"list my tasks\" → MCP fires${NC}"
+  fi
   echo ""
-  printf '%b\n' "  ${BOLD}Available skills:${NC}"
-  printf '%b\n' "    ${GREEN}/morning${NC}   — Pick a task and start working"
-  printf '%b\n' "    ${GREEN}/finish${NC}    — Complete task, measure work, send telemetry"
-  printf '%b\n' "    ${GREEN}/pause${NC}     — Pause current task, switch to another"
-  printf '%b\n' "    ${GREEN}/standup${NC}   — Generate a team standup report"
-  echo ""
+  if target_active claude || target_active opencode; then
+    printf '%b\n' "  ${BOLD}Slash commands (Claude Code / OpenCode):${NC}"
+    printf '%b\n' "    ${GREEN}/morning${NC}   — Pick a task and start working"
+    printf '%b\n' "    ${GREEN}/finish${NC}    — Complete task, measure work, send telemetry"
+    printf '%b\n' "    ${GREEN}/pause${NC}     — Pause current task, switch to another"
+    printf '%b\n' "    ${GREEN}/standup${NC}   — Generate a team standup report"
+    echo ""
+  fi
+  if target_active cursor || target_active copilot || target_active codex; then
+    printf '%b\n' "  ${BOLD}MCP tools (Cursor / Copilot / Codex):${NC}"
+    printf '%b\n' "    ${GREEN}list_tasks${NC}        — Pull tasks from your ticket system"
+    printf '%b\n' "    ${GREEN}update_task${NC}       — Move a task between statuses"
+    printf '%b\n' "    ${GREEN}create_task${NC}       — Create a new task"
+    printf '%b\n' "    ${GREEN}add_memory${NC} / ${GREEN}search_memories${NC}  — Personal + org memory"
+    echo ""
+  fi
   printf '%b\n' "  ${BOLD}Manage:${NC}"
   dim "    Re-authenticate:  ./install.sh"
   dim "    Check updates:    ./install.sh --check"
@@ -970,10 +1371,26 @@ while [ $# -gt 0 ]; do
       else
         target_val="${1#*=}"; shift
       fi
+      # Accept comma-separated list ("cursor,codex") or single value.
+      # Special tokens: "both" (legacy alias for claude+opencode), "all".
       case "$target_val" in
-        claude|opencode) TARGETS="$target_val" ;;
+        all) TARGETS="claude opencode cursor copilot codex" ;;
         both) TARGETS="claude opencode" ;;
-        *) fail "Invalid --target: $target_val (expected: claude|opencode|both)" ;;
+        *)
+          IFS=',' read -ra _t_arr <<< "$target_val"
+          TARGETS=""
+          for t in "${_t_arr[@]}"; do
+            t="${t// /}"
+            case "$t" in
+              claude|opencode|cursor|copilot|codex)
+                TARGETS="${TARGETS:+$TARGETS }$t"
+                ;;
+              *)
+                fail "Invalid --target: $t (expected: claude|opencode|cursor|copilot|codex|all|both)"
+                ;;
+            esac
+          done
+          ;;
       esac
       ;;
     --skip-prereqs) SKIP_PREREQS="true"; shift ;;


### PR DESCRIPTION
## Summary

- Extend `/api/memory/mcp` with task tools (`list_tasks`, `get_task_statuses`, `update_task`, `create_task`) so any MCP-aware agent drives the Tandemu task lifecycle without a per-editor plugin
- Add `--target=cursor`, `--target=copilot`, `--target=codex` to `install.sh`: each registers the Tandemu MCP server in the agent's config and drops the canonical `AGENTS.md` (or Cursor `.mdc` rule)
- Multi-select `detect_targets()` covers all 5 agents; `--target` accepts comma-separated values plus `all`. Uninstall and `--check` cover the new dirs
- Claude Code + OpenCode integrations untouched — slash UX (`/morning`, `/finish`, etc.) stays exclusive to those two; lightweight agents ask in plain chat

## Why

Per-agent plugin model scales linearly — each new agent needed config readers, hooks, skill copy, version tracking. 2026 industry pattern (Mem0, OpenMemory, Sentry MCP, GitHub MCP) is **MCP server + AGENTS.md** as universal layer. Cursor / Copilot CLI / Codex CLI all support MCP HTTP + AGENTS.md; their install becomes a 50-line shim instead of a plugin.

## What gets installed per target

| Agent | MCP config | Rules / personality | Slash |
|-------|------------|---------------------|-------|
| Claude Code | `~/.mcp.json` (existing) | `~/.claude/CLAUDE.md` | ✅ existing |
| OpenCode | `~/.config/opencode/opencode.json` (existing) | `~/.config/opencode/AGENTS.md` | ✅ existing |
| Cursor | `~/.cursor/mcp.json` (new) | `~/.cursor/rules/tandemu.mdc` (new) | ❌ ask via chat |
| Copilot CLI | `~/.copilot/mcp_config.json` (new) | `~/.copilot/AGENTS.md` (new) | ❌ ask via `gh copilot` |
| Codex CLI | `~/.codex/config.toml` (new) | `~/.codex/AGENTS.md` (new) | ❌ ask in REPL |

## Test plan

- [ ] `bash -n install.sh` syntax-checks (verified)
- [ ] Backend `pnpm tsc --noEmit` clean (verified)
- [ ] `./install.sh --target=invalid` rejects with usage hint (verified)
- [ ] `./install.sh --target=cursor,codex --skip-prereqs` accepts comma list
- [ ] `./install.sh --target=all` activates every supported target
- [ ] End-to-end: install for Cursor, open repo, ask "list my tasks" — MCP fires
- [ ] End-to-end: install for Codex CLI, REPL ask same — MCP fires
- [ ] Regression: Claude Code `/morning` + `/finish` still work; telemetry still flows
- [ ] `./install.sh --uninstall` cleans all 5 agents' configs

## Out of scope

- Cline target (deferred — same pattern, add after these three validated)
- Stdio MCP shim for Zed (uses HTTP MCP via `mcp-remote` for now if user installs it manually)
- Native OTLP collector replacement for tool-use telemetry on non-Claude agents — accepted gap, documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)