### PR TITLE
feat(billing): generic resource caps for Lifetime Deal tiers

### DIFF
--- a/apps/backend/src/invites/invites.service.ts
+++ b/apps/backend/src/invites/invites.service.ts
@@ -120,6 +120,33 @@ export class InvitesService {
       throw new ForbiddenException('This invite is not for your email address');
     }
 
+    // Canonical seat cap. OSS reads generic numeric caps only (no billing
+    // knowledge): max_seats NULL = unlimited. The FREE recurring plan is a
+    // hard 1 seat even though its max_seats stays NULL. Defense-in-depth:
+    // covers acceptance, not just invite creation.
+    const capResult = await this.db.query<{
+      max_seats: number | null;
+      plan_tier: string;
+    }>(
+      'SELECT max_seats, plan_tier FROM organizations WHERE id = $1',
+      [invite.organization_id],
+    );
+    const planTier = capResult.rows[0]?.plan_tier ?? 'free';
+    let maxSeats: number | null = capResult.rows[0]?.max_seats ?? null;
+    if (planTier === 'free') maxSeats = 1;
+    if (maxSeats !== null) {
+      const seatResult = await this.db.query<{ count: string }>(
+        'SELECT COUNT(*) AS count FROM memberships WHERE organization_id = $1',
+        [invite.organization_id],
+      );
+      const currentSeats = parseInt(seatResult.rows[0]!.count, 10);
+      if (currentSeats >= maxSeats) {
+        throw new ForbiddenException(
+          `Seat limit reached (${maxSeats}). Upgrade to the $25/seat/month plan to add more team members.`,
+        );
+      }
+    }
+
     // Use a transaction to accept the invite, create membership, and assign team
     const result = await this.db.withTransaction(async (client) => {
       // Update invite status

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -41,6 +41,9 @@ export class OrganizationsService {
           plan_tier: string;
           subscription_status: string;
           settings: Record<string, unknown>;
+          max_seats: number | null;
+          max_repos: number | null;
+          retention_days: number | null;
           created_at: Date;
           updated_at: Date;
         }>(
@@ -87,6 +90,9 @@ export class OrganizationsService {
       plan_tier: string;
       subscription_status: string;
       settings: Record<string, unknown>;
+      max_seats: number | null;
+      max_repos: number | null;
+      retention_days: number | null;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -109,6 +115,9 @@ export class OrganizationsService {
       plan_tier: string;
       subscription_status: string;
       settings: Record<string, unknown>;
+      max_seats: number | null;
+      max_repos: number | null;
+      retention_days: number | null;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -152,6 +161,18 @@ export class OrganizationsService {
       fields.push(`stripe_subscription_id = $${paramIndex++}`);
       values.push(dto.stripeSubscriptionId);
     }
+    if (dto.maxSeats !== undefined) {
+      fields.push(`max_seats = $${paramIndex++}`);
+      values.push(dto.maxSeats);
+    }
+    if (dto.maxRepos !== undefined) {
+      fields.push(`max_repos = $${paramIndex++}`);
+      values.push(dto.maxRepos);
+    }
+    if (dto.retentionDays !== undefined) {
+      fields.push(`retention_days = $${paramIndex++}`);
+      values.push(dto.retentionDays);
+    }
     if (dto.settings !== undefined) {
       fields.push(`settings = settings || $${paramIndex++}::jsonb`);
       values.push(JSON.stringify(dto.settings));
@@ -173,6 +194,9 @@ export class OrganizationsService {
       plan_tier: string;
       subscription_status: string;
       settings: Record<string, unknown>;
+      max_seats: number | null;
+      max_repos: number | null;
+      retention_days: number | null;
       created_at: Date;
       updated_at: Date;
     }>(
@@ -312,6 +336,9 @@ export class OrganizationsService {
     plan_tier: string;
     subscription_status: string;
     settings?: Record<string, unknown>;
+    max_seats?: number | null;
+    max_repos?: number | null;
+    retention_days?: number | null;
     created_at: Date;
     updated_at: Date;
   }): Organization {
@@ -326,6 +353,9 @@ export class OrganizationsService {
       settings: row.settings && Object.keys(row.settings).length > 0
         ? row.settings as Organization['settings']
         : undefined,
+      maxSeats: row.max_seats ?? undefined,
+      maxRepos: row.max_repos ?? undefined,
+      retentionDays: row.retention_days ?? undefined,
       createdAt: row.created_at.toISOString(),
       updatedAt: row.updated_at.toISOString(),
     };

--- a/apps/backend/src/queue/github-sync.processor.ts
+++ b/apps/backend/src/queue/github-sync.processor.ts
@@ -1,6 +1,7 @@
 import { Processor } from '@nestjs/bullmq';
 import { Logger, Inject, forwardRef } from '@nestjs/common';
 import type { Job } from 'bullmq';
+import * as Sentry from '@sentry/nestjs';
 import { SentryProcessor } from './sentry-processor.js';
 import { TelemetryService } from '../telemetry/telemetry.service.js';
 import { GitHubGitService } from '../integrations/providers/github-git.service.js';
@@ -36,6 +37,27 @@ export class GitHubSyncProcessor extends SentryProcessor {
     if (!owner || !repoName) {
       this.logger.warn(`Invalid repo format: ${repo}`);
       return;
+    }
+
+    // Generic repo cap. NULL = uncapped (OSS standalone-correct). Only *new*
+    // repos beyond the cap are blocked; already-tracked repos keep syncing.
+    const maxRepos = await this.telemetryService.maxReposFor(organizationId);
+    if (maxRepos !== null) {
+      const tracked = await this.telemetryService.repoAlreadyTracked(organizationId, repo);
+      if (!tracked) {
+        const distinct = await this.telemetryService.countDistinctRepos(organizationId);
+        if (distinct >= maxRepos) {
+          this.logger.warn(
+            `Repo cap reached for org ${organizationId} (${distinct}/${maxRepos}); skipping new repo ${repo}`,
+          );
+          Sentry.captureMessage('github-sync repo cap reached', {
+            level: 'warning',
+            tags: { organizationId },
+            extra: { repo, distinct, maxRepos },
+          });
+          return;
+        }
+      }
     }
 
     this.logger.log(`Syncing PRs for ${repo} (org: ${organizationId})`);

--- a/apps/backend/src/queue/queue.types.ts
+++ b/apps/backend/src/queue/queue.types.ts
@@ -68,11 +68,16 @@ export interface GitSelfHealJob {
   readonly input: FinishTaskInput;
 }
 
+export interface RetentionPruneJob {
+  readonly type: 'retention-prune';
+}
+
 export type TelemetryJobData =
   | MemoryAccessLogJob
   | OtlpTraceJob
   | OtlpMetricsJob
-  | GitSelfHealJob;
+  | GitSelfHealJob
+  | RetentionPruneJob;
 
 // ── github-sync queue ──
 

--- a/apps/backend/src/queue/telemetry.processor.ts
+++ b/apps/backend/src/queue/telemetry.processor.ts
@@ -38,6 +38,9 @@ export class TelemetryProcessor extends SentryProcessor {
           job.data.input,
         );
         break;
+      case 'retention-prune':
+        await this.telemetryService.pruneExpiredTelemetry();
+        break;
     }
   }
 

--- a/apps/backend/src/telemetry/retention-prune.scheduler.ts
+++ b/apps/backend/src/telemetry/retention-prune.scheduler.ts
@@ -1,0 +1,31 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Queue } from 'bullmq';
+import type { TelemetryJobData } from '../queue/queue.types.js';
+
+/**
+ * Schedules the daily telemetry retention prune. The actual deletion runs in
+ * TelemetryService.pruneExpiredTelemetry() via the telemetry queue processor.
+ * Cadence is daily off-peak: ClickHouse `ALTER TABLE ... DELETE` is a heavy
+ * async mutation, so we deliberately avoid frequent runs.
+ */
+@Injectable()
+export class RetentionPruneScheduler implements OnModuleInit {
+  private readonly logger = new Logger(RetentionPruneScheduler.name);
+
+  constructor(
+    @InjectQueue('telemetry') private readonly telemetryQueue: Queue<TelemetryJobData>,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.telemetryQueue.add(
+      'retention-prune-trigger',
+      { type: 'retention-prune' },
+      {
+        repeat: { pattern: '30 3 * * *' },
+        jobId: 'retention-prune-repeatable',
+      },
+    );
+    this.logger.log('Retention prune scheduler registered (daily 03:30)');
+  }
+}

--- a/apps/backend/src/telemetry/telemetry.module.ts
+++ b/apps/backend/src/telemetry/telemetry.module.ts
@@ -11,6 +11,7 @@ import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { TelemetryProcessor } from '../queue/telemetry.processor.js';
 import { GitHubSyncProcessor } from '../queue/github-sync.processor.js';
 import { GitHubSyncScheduler } from './github-sync.scheduler.js';
+import { RetentionPruneScheduler } from './retention-prune.scheduler.js';
 import { IncidentSyncProcessor } from '../queue/incident-sync.processor.js';
 import { IncidentSyncScheduler } from './incident-sync.scheduler.js';
 import { PagerDutyProviderService } from '../integrations/providers/pagerduty.service.js';
@@ -32,6 +33,7 @@ import { OpsgenieProviderService } from '../integrations/providers/opsgenie.serv
     TelemetryProcessor,
     GitHubSyncProcessor,
     GitHubSyncScheduler,
+    RetentionPruneScheduler,
     IncidentSyncProcessor,
     IncidentSyncScheduler,
     PagerDutyProviderService,

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -8,6 +8,7 @@ import { randomBytes } from 'crypto';
 import * as Sentry from '@sentry/nestjs';
 import type { AIvsManualRatio, FrictionEvent, DeveloperStat, TaskVelocityEntry, InsightsMetrics, InsightsDaily, OrgSettings, DeveloperCostEntry } from '@tandemu/types';
 import { MemoryService } from '../memory/memory.service.js';
+import { DatabaseService } from '../database/database.service.js';
 import { GitHubGitService } from '../integrations/providers/github-git.service.js';
 import { IntegrationsService } from '../integrations/integrations.service.js';
 import type { TelemetryJobData } from '../queue/queue.types.js';
@@ -76,6 +77,7 @@ export class TelemetryService implements OnModuleDestroy {
 
   constructor(
     private readonly configService: ConfigService,
+    private readonly db: DatabaseService,
     @Inject(forwardRef(() => MemoryService)) private readonly memoryService: MemoryService,
     @Inject(forwardRef(() => GitHubGitService)) private readonly gitHubGitService: GitHubGitService,
     @Inject(forwardRef(() => IntegrationsService)) private readonly integrationsService: IntegrationsService,
@@ -227,6 +229,141 @@ export class TelemetryService implements OnModuleDestroy {
   private static dtEnd(iso: string): string {
     const trimmed = iso.endsWith('Z') ? iso.slice(0, -1) : iso;
     return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? `${trimmed} 23:59:59.999` : trimmed;
+  }
+
+  /**
+   * Resolve the retention floor for an org from the generic `retention_days`
+   * cap (NULL = unlimited, OSS standalone-correct). Returns an ISO timestamp
+   * `now - retention_days`, or null when uncapped / on any error.
+   */
+  private async retentionFloorIso(organizationId: string): Promise<string | null> {
+    try {
+      const { rows } = await this.db.query<{ retention_days: number | null }>(
+        'SELECT retention_days FROM organizations WHERE id = $1',
+        [organizationId],
+      );
+      const days = rows[0]?.retention_days ?? null;
+      return days == null ? null : new Date(Date.now() - days * 86_400_000).toISOString();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Clamp a query's start date to the org's retention window. With no floor,
+   * behaviour is unchanged. With a floor and no start, the floor becomes the
+   * start. Otherwise the later of the two wins.
+   */
+  private async clampStartToRetention(
+    organizationId: string,
+    startDate?: string,
+  ): Promise<string | undefined> {
+    const floor = await this.retentionFloorIso(organizationId);
+    if (!floor) return startDate;
+    if (!startDate) return floor;
+    return new Date(startDate).getTime() < new Date(floor).getTime() ? floor : startDate;
+  }
+
+  /** Generic max-repos cap for an org (NULL/error = uncapped). */
+  async maxReposFor(organizationId: string): Promise<number | null> {
+    try {
+      const { rows } = await this.db.query<{ max_repos: number | null }>(
+        'SELECT max_repos FROM organizations WHERE id = $1',
+        [organizationId],
+      );
+      return rows[0]?.max_repos ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Whether this org already has telemetry for the given repo. */
+  async repoAlreadyTracked(organizationId: string, repo: string): Promise<boolean> {
+    try {
+      const rs = await this.client.query({
+        query: `SELECT 1 FROM github_pull_requests
+                WHERE organization_id = {organizationId:String}
+                  AND repo = {repo:String} LIMIT 1`,
+        query_params: { organizationId, repo },
+        format: 'JSONEachRow',
+      });
+      const rows = await rs.json<unknown>();
+      return rows.length > 0;
+    } catch {
+      // On any ClickHouse error fail open (don't block sync on telemetry hiccup)
+      return true;
+    }
+  }
+
+  /** Count of distinct repos this org has telemetry for (repo-cap unit). */
+  async countDistinctRepos(organizationId: string): Promise<number> {
+    try {
+      const rs = await this.client.query({
+        query: `SELECT uniqExact(repo) AS c FROM github_pull_requests
+                WHERE organization_id = {organizationId:String}`,
+        query_params: { organizationId },
+        format: 'JSONEachRow',
+      });
+      const rows = await rs.json<{ c: string | number }>();
+      return Number(rows[0]?.c ?? 0);
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Hard-prune telemetry past each capped org's retention window. Storage-cost
+   * enforcement for LTD workspaces (Step 3.2). OTEL tables carry a global 90d
+   * collector TTL, so the shorter LTD window (60d) must be deleted explicitly.
+   * Orgs with retention_days = NULL are uncapped and untouched.
+   */
+  async pruneExpiredTelemetry(): Promise<void> {
+    let orgs: Array<{ id: string; retention_days: number }>;
+    try {
+      const res = await this.db.query<{ id: string; retention_days: number }>(
+        'SELECT id, retention_days FROM organizations WHERE retention_days IS NOT NULL',
+      );
+      orgs = res.rows;
+    } catch (err) {
+      this.logger.warn(`Retention prune: failed to load capped orgs: ${err}`);
+      Sentry.captureException(err, { tags: { operation: 'retention-prune-query-orgs' } });
+      return;
+    }
+    if (orgs.length === 0) return;
+
+    // [table, timestamp column, org-id expression]
+    const targets: Array<[string, string, string]> = [
+      ['otel_traces', 'Timestamp', "ResourceAttributes['organization_id']"],
+      ['otel_logs', 'Timestamp', "ResourceAttributes['organization_id']"],
+      ['otel_metrics_sum', 'TimeUnix', "ResourceAttributes['organization_id']"],
+      ['github_pull_requests', 'merged_at', 'organization_id'],
+      ['github_pr_reviews', 'submitted_at', 'organization_id'],
+      ['github_deployments', 'created_at', 'organization_id'],
+      ['incidents', 'created_at', 'organization_id'],
+      ['memory_access_log', 'timestamp', 'organization_id'],
+    ];
+
+    for (const { id, retention_days } of orgs) {
+      for (const [table, tsCol, orgExpr] of targets) {
+        try {
+          // Sequential awaits + async mutation (mutations_sync default 0) keep
+          // ClickHouse mutation pressure low.
+          const rs = await this.client.query({
+            query: `ALTER TABLE ${table}
+                    DELETE WHERE ${orgExpr} = {orgId:String}
+                      AND ${tsCol} < now() - INTERVAL {days:UInt32} DAY`,
+            query_params: { orgId: id, days: retention_days },
+          });
+          await rs.text();
+        } catch (err) {
+          // Table may not exist yet (fresh boot before collector runs) — skip.
+          this.logger.warn(
+            `Retention prune: ${table} for org ${id} failed: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
+    }
+    this.logger.log(`Retention prune ran for ${orgs.length} capped org(s)`);
   }
 
   private async ensureSkipIndexes(): Promise<void> {
@@ -660,6 +797,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<AIvsManualRatio[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -726,6 +864,7 @@ export class TelemetryService implements OnModuleDestroy {
   }
 
   async getFrictionHeatmap(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<FrictionEvent[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -810,6 +949,12 @@ export class TelemetryService implements OnModuleDestroy {
   }
 
   async getTimesheets(query: TimesheetQuery): Promise<TimesheetEntry[]> {
+    query = {
+      ...query,
+      startDate:
+        (await this.clampStartToRetention(query.organizationId, query.startDate)) ??
+        query.startDate,
+    };
     try {
       // Query task_session spans for timesheet data
       // Use duration_seconds attribute instead of ClickHouse Duration to avoid
@@ -877,6 +1022,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<DeveloperStat[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -940,6 +1086,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<TaskVelocityEntry[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -997,6 +1144,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ filePath: string; changeCount: number; taskCount: number; developerCount: number }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1048,6 +1196,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ category: string; taskCount: number; totalHours: number }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1093,6 +1242,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ filePath: string; aiTouchCount: number }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1140,6 +1290,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ date: string; totalCost: number }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1183,6 +1334,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ userId: string; userName: string; totalCost: number; taskCount: number; aiLines: number; costPerLine: number | null }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1265,6 +1417,7 @@ export class TelemetryService implements OnModuleDestroy {
     endDate?: string,
     teamId?: string,
   ): Promise<Array<{ tokenType: string; model: string; totalTokens: number }>> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1308,6 +1461,7 @@ export class TelemetryService implements OnModuleDestroy {
    * Shows which tools the team uses, success rates, and avg duration.
    */
   async getToolUsageStats(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<ToolUsageStat[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1376,6 +1530,7 @@ export class TelemetryService implements OnModuleDestroy {
    * Failed tool calls grouped by file path — augments custom friction logs.
    */
   async getNativeFriction(organizationId: string, startDate?: string, endDate?: string, teamId?: string): Promise<FrictionEvent[]> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     try {
       const params: Record<string, string> = { organizationId };
       let dateFilter = '';
@@ -1559,6 +1714,7 @@ export class TelemetryService implements OnModuleDestroy {
     settings?: OrgSettings,
     teamId?: string,
   ): Promise<InsightsMetrics> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     const hourlyRate = settings?.developerHourlyRate ?? 75;
     const secsPerLine = settings?.aiLineTimeEstimateSeconds ?? 120;
     const currency = settings?.currency ?? 'USD';
@@ -2035,6 +2191,7 @@ export class TelemetryService implements OnModuleDestroy {
     } | null;
     dataSource: 'deployments' | 'pull_requests';
   }> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     const nullResult = {
       deploymentFrequency: null,
       leadTimeForChanges: null,
@@ -2488,6 +2645,7 @@ export class TelemetryService implements OnModuleDestroy {
     } | null;
     reviewerLoad: Array<{ reviewer: string; prsReviewed: number; medianTurnaroundHours: number }>;
   }> {
+    startDate = await this.clampStartToRetention(organizationId, startDate);
     const nullResult = {
       timeToFirstReview: null,
       timeToMerge: null,

--- a/packages/database/src/migrations/0013_ltd_billing.sql
+++ b/packages/database/src/migrations/0013_ltd_billing.sql
@@ -1,0 +1,13 @@
+-- Lifetime Deal (LTD) tiers + generic resource caps.
+-- OSS reads only the numeric caps (NULL = unlimited); the Platform billing
+-- layer is the only writer. New enum values are declared here but MUST NOT be
+-- referenced (no UPDATE) in this same migration file — the runner wraps each
+-- file in a single transaction.
+
+ALTER TYPE plan_tier ADD VALUE IF NOT EXISTS 'ltd_tier_1';
+ALTER TYPE plan_tier ADD VALUE IF NOT EXISTS 'ltd_tier_2';
+ALTER TYPE plan_tier ADD VALUE IF NOT EXISTS 'ltd_tier_3';
+
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS max_seats      INTEGER;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS max_repos      INTEGER;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS retention_days INTEGER;

--- a/packages/database/src/schema/organizations.ts
+++ b/packages/database/src/schema/organizations.ts
@@ -4,12 +4,16 @@ import {
   uuid,
   varchar,
   timestamp,
+  integer,
 } from "drizzle-orm/pg-core";
 
 export const planTierEnum = pgEnum("plan_tier", [
   "free",
   "pro",
   "enterprise",
+  "ltd_tier_1",
+  "ltd_tier_2",
+  "ltd_tier_3",
 ]);
 
 export const subscriptionStatusEnum = pgEnum("subscription_status", [
@@ -29,6 +33,11 @@ export const organizations = pgTable("organizations", {
   subscriptionStatus: subscriptionStatusEnum("subscription_status")
     .default("active")
     .notNull(),
+  // Generic resource caps. NULL = unlimited (OSS standalone-correct).
+  // Written only by the Platform Stripe webhook for LTD workspaces.
+  maxSeats: integer("max_seats"),
+  maxRepos: integer("max_repos"),
+  retentionDays: integer("retention_days"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/packages/types/src/billing.ts
+++ b/packages/types/src/billing.ts
@@ -2,6 +2,9 @@ export enum PlanTier {
   FREE = "FREE",
   PRO = "PRO",
   ENTERPRISE = "ENTERPRISE",
+  LTD_TIER_1 = "LTD_TIER_1",
+  LTD_TIER_2 = "LTD_TIER_2",
+  LTD_TIER_3 = "LTD_TIER_3",
 }
 
 export enum SubscriptionStatus {
@@ -31,6 +34,11 @@ export interface CheckoutSessionRequest {
   readonly planTier: PlanTier;
   readonly successUrl: string;
   readonly cancelUrl: string;
+  /**
+   * Set for one-time Lifetime Deal checkouts. When present the Platform
+   * creates a `mode: 'payment'` session instead of a recurring subscription.
+   */
+  readonly ltdTier?: PlanTier;
 }
 
 export interface CheckoutSessionResponse {

--- a/packages/types/src/org.ts
+++ b/packages/types/src/org.ts
@@ -15,6 +15,10 @@ export interface Organization {
   readonly planTier: PlanTier;
   readonly subscriptionStatus: SubscriptionStatus;
   readonly settings?: OrgSettings;
+  /** Generic resource caps. Undefined = unlimited. Set by Platform billing. */
+  readonly maxSeats?: number;
+  readonly maxRepos?: number;
+  readonly retentionDays?: number;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -50,6 +54,9 @@ export interface UpdateOrganizationDto {
   readonly stripeSubscriptionId?: string;
   readonly subscriptionStatus?: SubscriptionStatus;
   readonly settings?: Partial<OrgSettings>;
+  readonly maxSeats?: number;
+  readonly maxRepos?: number;
+  readonly retentionDays?: number;
 }
 
 export interface InviteMemberDto {


### PR DESCRIPTION
## Context

OSS half of the Lifetime Deal (LTD) feature. The Platform repo (`tandemu-platform`) owns Stripe + the LTD plan→limit mapping; this repo stays **billing-unaware** and only enforces generic numeric caps stored on `organizations` (`max_seats`, `max_repos`, `retention_days`). **NULL = unlimited**, so a bare OSS deploy behaves exactly as before.

Pairs with the Platform PR (raised separately). Merge order: this PR → bump `oss` submodule in Platform → Platform PR.

## Changes

- **Migration `0013_ltd_billing.sql`**: extend `plan_tier` enum with `ltd_tier_1/2/3` (via `ALTER TYPE ADD VALUE`, same proven pattern as `0012`); add nullable `max_seats` / `max_repos` / `retention_days`. Drizzle schema + `@tandemu/types` updated.
- **`organizations.service.ts`**: persist + expose the new cap columns (`update()` writer blocks, row types, `mapOrg()`).
- **`invites.service.ts` `accept()`**: canonical seat cap. `free` = hard 1 seat; NULL = unlimited; otherwise block at `max_seats` with an upgrade-to-$25/mo message. Defense-in-depth (covers acceptance, not just creation).
- **`github-sync.processor.ts`**: repo cap. Only *new* repos beyond `max_repos` are skipped (distinct-repo count from `github_pull_requests` telemetry); already-tracked repos keep syncing.
- **`telemetry.service.ts`**: `clampStartToRetention()` applied at the entry of all 16 dashboard read methods so capped orgs can't query beyond their window; `pruneExpiredTelemetry()` hard-deletes ClickHouse rows past retention for capped orgs (explicit `ALTER … DELETE` because the collector TTL is a global 90d).
- **`RetentionPruneScheduler`**: daily 03:30 repeatable job on the existing `telemetry` queue.

## Verification

- `tsc --noEmit` clean across `@tandemu/types`, `@tandemu/database`, `@tandemu/backend`.
- Migration: bring up stack, confirm `Migration applied: 0013_ltd_billing.sql`; `SELECT enum_range(NULL::plan_tier)` shows 3 new values; `\d organizations` shows 3 nullable int cols; existing rows `max_seats IS NULL` → unchanged behaviour.
- Seat: org with `max_seats=5`, accept 6th invite → 403 upgrade message. FREE org → blocked at 2nd member (note: this fixes a pre-existing dead-code bug — FREE seat enforcement was never active).
- Repo: org with `max_repos=N`, map N+1th repo → processor logs "Repo cap reached", row N+1 not synced, existing repos keep syncing.
- Retention: set `retention_days=60`, query 90d back → no data older than 60d; NULL → full history. Enqueue `retention-prune` → ClickHouse `min(Timestamp)` ≥ now−60d for capped org, NULL orgs untouched.

## Risk

Fixing the seat interceptor's latent case bug means FREE-plan seat enforcement becomes **active for the first time** — existing free orgs with >1 member will hit the cap on their next invite. Flagged for product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)