### PR TITLE
feat(frontend): gate AppSumo redeem UI behind a feature flag

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -19,6 +19,9 @@ COPY apps/frontend/ apps/frontend/
 # Build
 ARG APP_VERSION=0.0.0-dev
 ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION
+# AppSumo redeem UI flag — off unless explicitly built with 'true'.
+ARG NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED=false
+ENV NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED=$NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter @tandemu/types build && \
     pnpm --filter @tandemu/frontend build

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -474,8 +474,13 @@ function SettingsPageContent() {
         </Card>
       )}
 
-      {/* Redeem an AppSumo / marketplace license code */}
-      {org && process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' && (
+      {/* Redeem an AppSumo / marketplace license code.
+          Gated by a second flag so the code can ship before the AppSumo
+          listing is live; flip NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED to 'true'
+          to surface it. */}
+      {org &&
+        process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true' &&
+        process.env.NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED === 'true' && (
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Context

Marketplace code can merge now, but the AppSumo listing process is still in progress — the redeem UI must stay hidden until then.

## Change

- Redeem card on `/settings` now requires **both** `NEXT_PUBLIC_BILLING_ENABLED === 'true'` **and** the new `NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED === 'true'`.
- `apps/frontend/Dockerfile`: declares `ARG NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED=false` + `ENV`, so the flag is deterministic at build and flippable when AppSumo goes live (the existing billing flag has no ARG; this one does).

Default = hidden (unset/false). Flip the build arg to `true` when the AppSumo listing is live. Backend marketplace endpoints are unaffected (already merged behind their own env config).

## Verification

- `tsc --noEmit` clean for `@tandemu/frontend`.
- Unset / `false` → card hidden. `NEXT_PUBLIC_APPSUMO_REDEEM_ENABLED=true` (with billing on) → card shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)