### PR TITLE
feat(telemetry): Codex CLI native OTLP + OpenCode per-tool spans

### DIFF
--- a/apps/backend/src/telemetry/metric-names.ts
+++ b/apps/backend/src/telemetry/metric-names.ts
@@ -1,3 +1,7 @@
+// NOTE: Codex CLI emits cost only as derived (input_token_count + output_token_count
+// on `codex.sse_event` × server-side price table). It does NOT emit a native
+// USD cost metric, so cost queries should still treat it as missing here and
+// compute server-side. Token counts ARE first-class.
 export const COST_METRICS = [
   'claude_code.cost.usage',
   'opencode.cost.usage',
@@ -6,6 +10,8 @@ export const COST_METRICS = [
 export const TOKEN_METRICS = [
   'claude_code.token.usage',
   'opencode.token.usage',
+  // Codex CLI uses log events (`codex.sse_event` with token-count attributes)
+  // rather than a top-level metric; ingest handles it separately.
 ] as const;
 
 export const LINES_METRICS = [
@@ -17,9 +23,10 @@ export const LINES_METRICS = [
 export const TOOL_METRICS = [
   'claude_code.tool.usage',
   'opencode.tool.usage',
+  'codex.tool_result',
 ] as const;
 
-export const TANDEMU_SERVICE_NAMES = ['claude-code', 'opencode'] as const;
+export const TANDEMU_SERVICE_NAMES = ['claude-code', 'opencode', 'codex'] as const;
 
 export function sqlIn(values: readonly string[]): string {
   if (values.length === 0) throw new Error('sqlIn: empty list');

--- a/apps/opencode-plugin/src/hooks/otel.ts
+++ b/apps/opencode-plugin/src/hooks/otel.ts
@@ -7,8 +7,58 @@ import { record, flush } from "../lib/otlp.ts";
 
 const seenMessages = new Set<string>();
 
-export function recordToolUse(input: { tool: string }): void {
-  record("opencode.tool.usage", 1, { tool: input.tool });
+// Per-call start timestamps, keyed by callID, written by recordToolStart
+// (tool.execute.before) and consumed by recordToolUse (tool.execute.after).
+// Lets us emit duration_ms per tool call instead of just an aggregate counter.
+const toolStarts = new Map<string, number>();
+
+export function recordToolStart(input: { tool: string; callID: string }): void {
+  toolStarts.set(input.callID, Date.now());
+}
+
+export function recordToolUse(input: {
+  tool: string;
+  callID?: string;
+  output?: { output?: string; metadata?: unknown };
+}): void {
+  const startedAt = input.callID ? toolStarts.get(input.callID) : undefined;
+  const durationMs = startedAt ? Date.now() - startedAt : 0;
+  if (input.callID) toolStarts.delete(input.callID);
+
+  // Best-effort success detection from output / metadata. OpenCode doesn't
+  // expose a structured success flag, so we look for error markers and fall
+  // back to "true" otherwise. Worth keeping coarse rather than missing — the
+  // friction-heatmap reads success=false, so we want to surface failures.
+  const success = detectSuccess(input.output);
+
+  record("opencode.tool.usage", 1, {
+    tool: input.tool,
+    success: success ? "true" : "false",
+    ...(durationMs > 0 ? { duration_ms: durationMs } : {}),
+  });
+
+  if (durationMs > 0) {
+    record("opencode.tool.duration_ms", durationMs, {
+      tool: input.tool,
+      success: success ? "true" : "false",
+    });
+  }
+}
+
+function detectSuccess(output: { output?: string; metadata?: unknown } | undefined): boolean {
+  if (!output) return true;
+  const md = output.metadata as Record<string, unknown> | undefined;
+  if (md && typeof md === "object") {
+    if (md.error || md.success === false) return false;
+  }
+  const text = output.output ?? "";
+  if (typeof text === "string" && text.length > 0) {
+    // Heuristic: bash failure prints "exit code N" / "Error:" / "command failed"
+    if (/\bexit code\s+[1-9]/i.test(text)) return false;
+    if (/^\s*Error:/m.test(text)) return false;
+    if (/\bcommand failed\b/i.test(text)) return false;
+  }
+  return true;
 }
 
 export function recordMessage(message: AssistantMessage): void {

--- a/apps/opencode-plugin/src/index.ts
+++ b/apps/opencode-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import { sessionStart } from "./hooks/session-start.ts";
-import { dispatchEvent, recordToolUse } from "./hooks/otel.ts";
+import { dispatchEvent, recordToolStart, recordToolUse } from "./hooks/otel.ts";
 import { shellEnv } from "./hooks/shell-env.ts";
 
 export const TandemuPlugin: Plugin = async ({ client, $ }) => {
@@ -10,8 +10,11 @@ export const TandemuPlugin: Plugin = async ({ client, $ }) => {
     event: async ({ event }) => {
       await dispatchEvent(event, $, () => onSessionCreated(event));
     },
-    "tool.execute.after": async (input) => {
-      recordToolUse({ tool: input.tool });
+    "tool.execute.before": async (input) => {
+      recordToolStart({ tool: input.tool, callID: input.callID });
+    },
+    "tool.execute.after": async (input, output) => {
+      recordToolUse({ tool: input.tool, callID: input.callID, output });
     },
     "shell.env": async (input, output) => {
       shellEnv(input, output);

--- a/install.sh
+++ b/install.sh
@@ -352,8 +352,15 @@ import os, re
 f = os.path.expanduser("~/.codex/config.toml")
 try:
     text = open(f).read()
+    # Strip tandemu MCP block + the [otel] block we installed for telemetry.
     text = re.sub(
         r"\n?\[mcp_servers\.tandemu(\.[^\]]+)?\][^\[]*",
+        "",
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"\n?\[otel\][^\[]*",
         "",
         text,
         flags=re.DOTALL,
@@ -365,7 +372,7 @@ try:
 except FileNotFoundError:
     pass
 PYEOF
-    ok "Codex MCP cleaned"
+    ok "Codex MCP + OTLP cleaned"
   fi
   if [ -f "$CODEX_DIR/AGENTS.md" ]; then
     if grep -q "Tandemu AI Teammate" "$CODEX_DIR/AGENTS.md" 2>/dev/null; then
@@ -1067,6 +1074,26 @@ install_skills_to() {
   done
 }
 
+# Resolve OTEL ingest endpoint + per-org ingestion key from the backend.
+# Sets $TANDEMU_OTLP_ENDPOINT and $TANDEMU_INGESTION_KEY. Both are empty if
+# the call fails — callers should treat empty as "skip OTEL config".
+fetch_setup_config() {
+  local cfg
+  cfg=$(curl -sf -H "Authorization: Bearer ${TOKEN}" "${API_URL}/api/setup/config" 2>/dev/null || true)
+  TANDEMU_OTLP_ENDPOINT=""
+  TANDEMU_INGESTION_KEY=""
+  if [ -n "$cfg" ]; then
+    TANDEMU_OTLP_ENDPOINT=$(echo "$cfg" | python3 -c "import json,sys
+d=json.load(sys.stdin)
+d=d.get('data',d) if isinstance(d,dict) and 'data' in d else d
+print(d.get('otel',{}).get('endpoint',''))" 2>/dev/null) || TANDEMU_OTLP_ENDPOINT=""
+    TANDEMU_INGESTION_KEY=$(echo "$cfg" | python3 -c "import json,sys
+d=json.load(sys.stdin)
+d=d.get('data',d) if isinstance(d,dict) and 'data' in d else d
+print(d.get('otel',{}).get('ingestionKey',''))" 2>/dev/null) || TANDEMU_INGESTION_KEY=""
+  fi
+}
+
 # Resolve the combined Tandemu MCP URL from the backend (handles SaaS/self-host).
 # Sets $TANDEMU_MCP_URL. Falls back to ${API_URL}/api/memory/mcp on error.
 fetch_mcp_url() {
@@ -1206,6 +1233,64 @@ with open(cfg_file, "w") as f:
     f.write(text)
 PYEOF
   ok "MCP: enabled (→ ${TANDEMU_MCP_URL})"
+
+  # ── Native OTLP telemetry ──
+  # Codex CLI's native [otel] block (PR #2103) emits codex.tool_result,
+  # codex.api_request, codex.sse_event spans/logs. Same backend proxy
+  # Claude Code uses — auth via per-org ingestion_key, not user JWT.
+  step "Configuring native OTLP telemetry (Codex CLI)..."
+  fetch_setup_config
+  if [ -n "$TANDEMU_OTLP_ENDPOINT" ] && [ -n "$TANDEMU_INGESTION_KEY" ]; then
+    TANDEMU_OTLP_ENDPOINT="$TANDEMU_OTLP_ENDPOINT" \
+    TANDEMU_INGESTION_KEY="$TANDEMU_INGESTION_KEY" \
+    TANDEMU_ORG_ID="$ORG_ID" \
+    python3 << 'PYEOF'
+import os, re
+
+cfg_file = os.path.expanduser("~/.codex/config.toml")
+endpoint = os.environ["TANDEMU_OTLP_ENDPOINT"]
+key = os.environ["TANDEMU_INGESTION_KEY"]
+org_id = os.environ.get("TANDEMU_ORG_ID", "")
+
+# Per Codex docs: exporter is a single inline table with the otlp-http key.
+# Resource attributes propagate via OTEL_RESOURCE_ATTRIBUTES, but Codex's
+# own backend proxy stamps organization_id from the ingestion_key for
+# defense-in-depth, so we don't strictly need to send it from the client.
+block = (
+    "\n[otel]\n"
+    'environment = "prod"\n'
+    'log_user_prompt = false\n'
+    "exporter = { otlp-http = { "
+    f'endpoint = "{endpoint}/v1/logs", '
+    'protocol = "json", '
+    "headers = { "
+    f'"Authorization" = "Bearer {key}"'
+    " } } }\n"
+)
+
+text = ""
+if os.path.exists(cfg_file):
+    with open(cfg_file) as f:
+        text = f.read()
+
+# Strip any prior [otel] section so re-running stays idempotent. Match the
+# section header through the next [section] or EOF.
+text = re.sub(
+    r"\n?\[otel\][^\[]*",
+    "",
+    text,
+    flags=re.DOTALL,
+).rstrip()
+
+text = (text + "\n" + block) if text else block.lstrip()
+
+with open(cfg_file, "w") as f:
+    f.write(text)
+PYEOF
+    ok "OTLP: enabled (→ ${TANDEMU_OTLP_ENDPOINT})"
+  else
+    warn "Could not fetch OTLP endpoint/ingestion key — per-tool telemetry not configured"
+  fi
 }
 
 install_assets_codex() {


### PR DESCRIPTION
## Summary

Brings Codex CLI and OpenCode closer to Claude Code's "full telemetry" behavior using each agent's documented extension points. No hacks — no env-var injection into user shell rc, no output scraping, no patched binaries.

| Agent | Lines / AI ratio / session | Cost / token | Per-tool spans (success, duration) |
|---|---|---|---|
| Claude Code | ✅ existing | ✅ existing native | ✅ existing native |
| OpenCode | ✅ existing | ✅ existing plugin | **✅ new in this PR** (was aggregate-only) |
| Codex CLI | ✅ existing | ⚠️ tokens emitted, USD conversion deferred to v0.7 | **✅ new in this PR** via native `codex.tool_result` |
| Cursor | ✅ existing | ❌ no plugin runtime / no hooks | ❌ no plugin runtime / no hooks |

## Codex CLI — native OTLP via `[otel]` block

Codex shipped native OTLP in [openai/codex#2103](https://github.com/openai/codex/pull/2103), emitting `codex.tool_result`, `codex.api_request`, `codex.sse_event` with full per-call fields (`tool_name`, `call_id`, `duration_ms`, `success`, token counts). Wiring is a TOML block in `~/.codex/config.toml`.

- `install.sh` adds `fetch_setup_config` helper that calls `GET /api/setup/config` for the org's OTLP endpoint + `ingestion_key` (same source the Claude setup uses).
- `configure_codex` writes a re-runnable `[otel]` block alongside the existing `[mcp_servers.tandemu]` block, baking the ingestion key into exporter headers.
- Uninstall sweeps the `[otel]` block too.
- `apps/backend/src/telemetry/metric-names.ts`: adds `codex.tool_result` to `TOOL_METRICS` and `'codex'` to `TANDEMU_SERVICE_NAMES`.

## OpenCode — per-tool spans

Plugin previously emitted only an aggregate counter (`opencode.tool.usage += 1`, attribute `tool`). Friction-heatmap and tool-success queries need per-call data.

- `recordToolStart()` captures `Date.now()` keyed by `callID` from the new `tool.execute.before` hook.
- `recordToolUse()` reads start, computes `duration_ms`, emits two metrics: `opencode.tool.usage` (with `tool` / `success` / `duration_ms` attrs) and `opencode.tool.duration_ms` (so backend can avg/percentile).
- `detectSuccess()` reads `output.metadata.error` / `output.metadata.success` first, falls back to text heuristics on `output.output` for bash failures (`exit code N`, `^Error:`, `command failed`). Coarse on purpose — the friction-heatmap reads `success=false` rows.

## Deferred to v0.7

- Server-side token×price-table cost conversion for Codex (Codex emits token counts but no native USD).
- `agent` dimension tag at ingest + filter on dashboards.
- `.codex-plugin/` bundle with `PreToolUse`/`PostToolUse` hooks for `codex exec` CI coverage ([codex#12913](https://github.com/openai/codex/issues/12913) — exec emits traces+logs but not metrics).
- Cursor: still no plugin runtime / no documented hooks. Stays Tier 3.
- Docs in `tandemu-website` (changelog, `connecting-codex.mdx`, `connecting-opencode.mdx` telemetry sections) — follow-up commit in that repo.

## Test plan

- [x] `apps/backend` `tsc --noEmit` clean
- [x] `apps/opencode-plugin` `tsc --noEmit` clean
- [x] `bash -n install.sh` clean
- [ ] End-to-end: install Codex target on a test org, run `codex` REPL, fire a few Bash tools, verify `codex.tool_result` rows in ClickHouse
- [ ] End-to-end: same on OpenCode, verify per-call `opencode.tool.usage` rows with `success` / `duration_ms` attributes
- [ ] Friction-heatmap query returns OpenCode rows with `success=false` after a deliberate failed Bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)