### PR TITLE
feat(pricing): model_prices table + token→USD conversion for Codex CLI

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { MemoryModule } from './memory/memory.module.js';
 import { SetupModule } from './setup/setup.module.js';
 import { QueueModule } from './queue/queue.module.js';
 import { EmailModule } from './email/email.module.js';
+import { PricingModule } from './pricing/pricing.module.js';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { EmailModule } from './email/email.module.js';
     SetupModule,
     QueueModule,
     EmailModule,
+    PricingModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/backend/src/organizations/organizations.service.ts
+++ b/apps/backend/src/organizations/organizations.service.ts
@@ -20,6 +20,7 @@ const DEFAULT_ORG_SETTINGS: Required<OrgSettings> = {
   currency: 'USD',
   draftRetentionDays: 30,
   monthlyAICostBudget: 0,
+  modelPriceOverrides: {},
 };
 
 @Injectable()

--- a/apps/backend/src/pricing/README.md
+++ b/apps/backend/src/pricing/README.md
@@ -1,0 +1,106 @@
+# Pricing
+
+Server-side USD cost computation for agents that emit raw token counts.
+
+## Why this exists
+
+Claude Code and OpenCode emit `claude_code.cost.usage` / `opencode.cost.usage`
+metrics pre-computed in USD client-side, so existing dashboards that read from
+the `otel_metrics_sum` table see real cost rows directly.
+
+Codex CLI does **not** emit a USD cost field. It emits raw token counts on
+`codex.sse_event` log events (input/output/cached/reasoning). To show Codex
+cost on the same per-day / per-developer / per-task dashboards, the backend
+has to derive USD = `tokens × $/1M-tokens` at query time. This module owns
+that calculation.
+
+## Resolution order
+
+For every cost query that needs to convert tokens → USD for a given model:
+
+1. **Per-org override.** `organizations.settings.modelPriceOverrides[modelName]`
+   (existing JSONB column, no schema change). Edited via the standard
+   `PATCH /api/organizations/:id` endpoint with `settings.modelPriceOverrides`
+   in the body. Useful for teams on enterprise contracts with custom rates.
+
+2. **Global default.** Row in the `model_prices` Postgres table seeded by
+   migration `0014_model_prices.sql`. Editable via the admin endpoint or
+   direct SQL.
+
+3. **No price found.** Returns `null` from `getModelPrice`. `computeCost`
+   returns `0` and logs a one-time warning per model name so missing rates
+   surface during testing.
+
+## Schema
+
+```sql
+CREATE TABLE model_prices (
+  model_name        TEXT PRIMARY KEY,
+  provider          TEXT NOT NULL,             -- anthropic | openai | google | ...
+  input_per_1m      NUMERIC(10, 4) NOT NULL,
+  output_per_1m     NUMERIC(10, 4) NOT NULL,
+  cached_per_1m     NUMERIC(10, 4),            -- nullable: not all models offer cache discount
+  reasoning_per_1m  NUMERIC(10, 4),            -- nullable: only reasoning models
+  currency          TEXT NOT NULL DEFAULT 'USD',
+  source            TEXT NOT NULL DEFAULT 'seed',  -- seed | admin | fetcher
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+## Seed accuracy
+
+The values shipped by `0014_model_prices.sql` are **approximate as of 2026-05**
+and flagged `source = 'seed'`. They will go out of date as providers adjust
+pricing. Run this check before relying on cost reports:
+
+```sql
+SELECT model_name, provider, input_per_1m, output_per_1m, updated_at
+FROM model_prices
+WHERE source = 'seed';
+```
+
+…and compare against the provider's pricing page. Update via:
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"inputPer1M": 6.00}' \
+  https://api.tandemu.dev/api/admin/model-prices/gpt-5
+```
+
+The PATCH endpoint marks the row `source = 'admin'` and invalidates the
+in-process cache so the new rate is visible on the next cost query.
+
+## Adding a new model
+
+1. Find the provider's published rates (input/output/cached/reasoning per 1M).
+2. Insert a row:
+
+   ```sql
+   INSERT INTO model_prices
+     (model_name, provider, input_per_1m, output_per_1m, cached_per_1m, reasoning_per_1m, source)
+   VALUES
+     ('new-model-name', 'openai', 3.00, 12.00, 0.30, NULL, 'admin');
+   ```
+
+   Or call `PATCH /api/admin/model-prices/new-model-name` after running an
+   `INSERT … ON CONFLICT DO NOTHING` migration for the seed.
+
+## Caching
+
+`PricingService` caches the global table in-process for 5 minutes. The TTL is
+fine for usage where rates rarely change. Admin `PATCH` calls invoke
+`invalidate()` synchronously so editors see their own changes immediately.
+
+## What's not in v0.7
+
+- **Historical pricing.** A rate change today applies retroactively to past
+  metric rows in cost queries. Rates effective from past dates require an
+  `effective_from` column + JOIN on `Timestamp` ranges; deferred.
+- **Frontend admin UI.** Use `PATCH /api/admin/model-prices/:modelName` or SQL.
+- **Automated fetcher.** A scheduled job that polls provider pricing pages
+  and updates rows automatically. Defer until the manual maintenance burden
+  becomes painful.
+- **Multi-currency.** Schema has a `currency` column but conversion logic
+  treats everything as USD. Adding FX rates is a separate feature.

--- a/apps/backend/src/pricing/pricing.controller.ts
+++ b/apps/backend/src/pricing/pricing.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { PricingService, type ModelPrice } from './pricing.service.js';
+import { JwtAuthGuard } from '../auth/auth.guard.js';
+import { RolesGuard } from '../auth/roles.guard.js';
+import { Roles } from '../auth/auth.decorator.js';
+import { MembershipRole } from '@tandemu/types';
+
+/**
+ * Admin endpoints for the global `model_prices` table. Owners and admins of
+ * any org can read and edit — instance-level superadmin gating is a v0.8
+ * concern. Per-org overrides go through `PATCH /api/organizations/:id`
+ * with `settings.modelPriceOverrides`, not here.
+ */
+@Controller('admin/model-prices')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(MembershipRole.OWNER, MembershipRole.ADMIN)
+export class PricingController {
+  constructor(private readonly pricingService: PricingService) {}
+
+  @Get()
+  async list(): Promise<ModelPrice[]> {
+    return this.pricingService.listGlobalPrices();
+  }
+
+  @Patch(':modelName')
+  async update(
+    @Param('modelName') modelName: string,
+    @Body() patch: Partial<{
+      provider: string;
+      inputPer1M: number;
+      outputPer1M: number;
+      cachedPer1M: number | null;
+      reasoningPer1M: number | null;
+      currency: string;
+    }>,
+  ): Promise<ModelPrice | null> {
+    return this.pricingService.updateGlobalPrice(modelName, patch);
+  }
+}

--- a/apps/backend/src/pricing/pricing.module.ts
+++ b/apps/backend/src/pricing/pricing.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PricingService } from './pricing.service.js';
+import { PricingController } from './pricing.controller.js';
+import { DatabaseModule } from '../database/database.module.js';
+import { AuthModule } from '../auth/auth.module.js';
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [PricingController],
+  providers: [PricingService],
+  exports: [PricingService],
+})
+export class PricingModule {}

--- a/apps/backend/src/pricing/pricing.service.ts
+++ b/apps/backend/src/pricing/pricing.service.ts
@@ -1,0 +1,279 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service.js';
+import type { OrgSettings, ModelPriceOverride } from '@tandemu/types';
+
+export interface ModelPrice {
+  readonly modelName: string;
+  readonly provider: string;
+  readonly inputPer1M: number;
+  readonly outputPer1M: number;
+  readonly cachedPer1M: number | null;
+  readonly reasoningPer1M: number | null;
+  readonly currency: string;
+  readonly source: string;
+  readonly updatedAt: Date;
+}
+
+export interface TokenCounts {
+  readonly input?: number;
+  readonly output?: number;
+  readonly cached?: number;
+  readonly reasoning?: number;
+}
+
+/**
+ * Looks up per-model USD rates and computes cost from token counts.
+ *
+ * Used by `TelemetryService` to convert Codex CLI token counts (the only data
+ * Codex emits; no native USD field) into per-day / per-developer / per-task
+ * cost figures that flow through the same dashboards as Claude Code and
+ * OpenCode (which both emit USD directly).
+ *
+ * Resolution order:
+ *  1. Per-org override at `organizations.settings.modelPriceOverrides[model]`
+ *  2. Global default row in the `model_prices` Postgres table
+ *  3. `null` (caller treats as $0 contribution and logs the missing model)
+ *
+ * Global rates are cached in-process for 5 minutes. Admin PATCH endpoints call
+ * `invalidate()` to drop the cache synchronously so an edit is visible on the
+ * next request.
+ */
+@Injectable()
+export class PricingService {
+  private readonly logger = new Logger(PricingService.name);
+  private readonly cacheTtlMs = 5 * 60 * 1000;
+  private globalCache: { rows: Map<string, ModelPrice>; expiresAt: number } | null = null;
+  private readonly missingModelWarned = new Set<string>();
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Get the effective price for a model, applying any per-org override on top
+   * of the global default. Returns null if no global row exists and no
+   * override is set.
+   */
+  async getModelPrice(modelName: string, orgId?: string): Promise<ModelPrice | null> {
+    if (!modelName) return null;
+
+    const base = await this.getGlobalPrice(modelName);
+    const override = orgId ? await this.getOrgOverride(orgId, modelName) : null;
+
+    if (!base && !override) {
+      if (!this.missingModelWarned.has(modelName)) {
+        this.missingModelWarned.add(modelName);
+        this.logger.warn(
+          `No price for model "${modelName}" (global or per-org). Cost contribution will be $0 until a row is added to model_prices or an override is set.`,
+        );
+      }
+      return null;
+    }
+
+    return this.merge(modelName, base, override);
+  }
+
+  /**
+   * Compute USD cost from token counts for the given model. Any token field
+   * that's missing OR has no corresponding rate contributes $0 — callers don't
+   * need to pre-check which rates exist for a model. Returns 0 when the model
+   * has no price at all.
+   */
+  async computeCost(
+    tokens: TokenCounts,
+    modelName: string,
+    orgId?: string,
+  ): Promise<number> {
+    const price = await this.getModelPrice(modelName, orgId);
+    if (!price) return 0;
+
+    let total = 0;
+    if (tokens.input && tokens.input > 0) {
+      total += (tokens.input * price.inputPer1M) / 1_000_000;
+    }
+    if (tokens.output && tokens.output > 0) {
+      total += (tokens.output * price.outputPer1M) / 1_000_000;
+    }
+    if (tokens.cached && tokens.cached > 0 && price.cachedPer1M !== null) {
+      total += (tokens.cached * price.cachedPer1M) / 1_000_000;
+    }
+    if (tokens.reasoning && tokens.reasoning > 0 && price.reasoningPer1M !== null) {
+      total += (tokens.reasoning * price.reasoningPer1M) / 1_000_000;
+    }
+    return total;
+  }
+
+  /**
+   * List every global model_prices row. Used by the admin endpoint.
+   */
+  async listGlobalPrices(): Promise<ModelPrice[]> {
+    const result = await this.db.query<{
+      model_name: string;
+      provider: string;
+      input_per_1m: string;
+      output_per_1m: string;
+      cached_per_1m: string | null;
+      reasoning_per_1m: string | null;
+      currency: string;
+      source: string;
+      updated_at: Date;
+    }>(
+      `SELECT model_name, provider, input_per_1m, output_per_1m,
+              cached_per_1m, reasoning_per_1m, currency, source, updated_at
+       FROM model_prices
+       ORDER BY provider, model_name`,
+    );
+    return result.rows.map((r) => this.rowToPrice(r));
+  }
+
+  /**
+   * Update a global model_prices row. Only fields present in `patch` are
+   * changed. Marks the row as `source = 'admin'` and invalidates the cache.
+   */
+  async updateGlobalPrice(
+    modelName: string,
+    patch: Partial<{
+      provider: string;
+      inputPer1M: number;
+      outputPer1M: number;
+      cachedPer1M: number | null;
+      reasoningPer1M: number | null;
+      currency: string;
+    }>,
+  ): Promise<ModelPrice | null> {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+    const push = (sql: string, val: unknown) => {
+      fields.push(`${sql} = $${i++}`);
+      values.push(val);
+    };
+
+    if (patch.provider !== undefined) push('provider', patch.provider);
+    if (patch.inputPer1M !== undefined) push('input_per_1m', patch.inputPer1M);
+    if (patch.outputPer1M !== undefined) push('output_per_1m', patch.outputPer1M);
+    if (patch.cachedPer1M !== undefined) push('cached_per_1m', patch.cachedPer1M);
+    if (patch.reasoningPer1M !== undefined) push('reasoning_per_1m', patch.reasoningPer1M);
+    if (patch.currency !== undefined) push('currency', patch.currency);
+
+    if (fields.length === 0) {
+      // No-op update; just return the current row.
+      return this.getGlobalPrice(modelName);
+    }
+
+    fields.push(`source = 'admin'`);
+    fields.push(`updated_at = NOW()`);
+    values.push(modelName);
+
+    const result = await this.db.query<{
+      model_name: string;
+      provider: string;
+      input_per_1m: string;
+      output_per_1m: string;
+      cached_per_1m: string | null;
+      reasoning_per_1m: string | null;
+      currency: string;
+      source: string;
+      updated_at: Date;
+    }>(
+      `UPDATE model_prices SET ${fields.join(', ')}
+       WHERE model_name = $${i}
+       RETURNING *`,
+      values,
+    );
+
+    this.invalidate();
+
+    if (result.rows.length === 0) return null;
+    return this.rowToPrice(result.rows[0]);
+  }
+
+  /**
+   * Drop the in-process cache. Called from admin PATCH so edits become
+   * visible without waiting for TTL expiry.
+   */
+  invalidate(): void {
+    this.globalCache = null;
+  }
+
+  // ── Internals ──
+
+  private async getGlobalPrice(modelName: string): Promise<ModelPrice | null> {
+    const cache = await this.loadGlobalCache();
+    return cache.get(modelName) ?? null;
+  }
+
+  private async getOrgOverride(
+    orgId: string,
+    modelName: string,
+  ): Promise<ModelPriceOverride | null> {
+    try {
+      const result = await this.db.query<{ settings: Record<string, unknown> | null }>(
+        `SELECT settings FROM organizations WHERE id = $1`,
+        [orgId],
+      );
+      const settings = (result.rows[0]?.settings ?? {}) as OrgSettings;
+      const overrides = settings.modelPriceOverrides;
+      if (!overrides) return null;
+      return overrides[modelName] ?? null;
+    } catch (err) {
+      this.logger.warn(`Failed to read org override for ${modelName}: ${err}`);
+      return null;
+    }
+  }
+
+  private async loadGlobalCache(): Promise<Map<string, ModelPrice>> {
+    const now = Date.now();
+    if (this.globalCache && this.globalCache.expiresAt > now) {
+      return this.globalCache.rows;
+    }
+
+    const rows = await this.listGlobalPrices();
+    const map = new Map<string, ModelPrice>();
+    for (const row of rows) {
+      map.set(row.modelName, row);
+    }
+    this.globalCache = { rows: map, expiresAt: now + this.cacheTtlMs };
+    return map;
+  }
+
+  private merge(
+    modelName: string,
+    base: ModelPrice | null,
+    override: ModelPriceOverride | null,
+  ): ModelPrice {
+    return {
+      modelName,
+      provider: base?.provider ?? 'unknown',
+      inputPer1M: override?.inputPer1M ?? base?.inputPer1M ?? 0,
+      outputPer1M: override?.outputPer1M ?? base?.outputPer1M ?? 0,
+      cachedPer1M: override?.cachedPer1M ?? base?.cachedPer1M ?? null,
+      reasoningPer1M: override?.reasoningPer1M ?? base?.reasoningPer1M ?? null,
+      currency: base?.currency ?? 'USD',
+      source: override ? 'override' : (base?.source ?? 'seed'),
+      updatedAt: base?.updatedAt ?? new Date(0),
+    };
+  }
+
+  private rowToPrice(row: {
+    model_name: string;
+    provider: string;
+    input_per_1m: string;
+    output_per_1m: string;
+    cached_per_1m: string | null;
+    reasoning_per_1m: string | null;
+    currency: string;
+    source: string;
+    updated_at: Date;
+  }): ModelPrice {
+    return {
+      modelName: row.model_name,
+      provider: row.provider,
+      inputPer1M: Number(row.input_per_1m),
+      outputPer1M: Number(row.output_per_1m),
+      cachedPer1M: row.cached_per_1m === null ? null : Number(row.cached_per_1m),
+      reasoningPer1M: row.reasoning_per_1m === null ? null : Number(row.reasoning_per_1m),
+      currency: row.currency,
+      source: row.source,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/apps/backend/src/telemetry/telemetry.module.ts
+++ b/apps/backend/src/telemetry/telemetry.module.ts
@@ -16,6 +16,7 @@ import { IncidentSyncProcessor } from '../queue/incident-sync.processor.js';
 import { IncidentSyncScheduler } from './incident-sync.scheduler.js';
 import { PagerDutyProviderService } from '../integrations/providers/pagerduty.service.js';
 import { OpsgenieProviderService } from '../integrations/providers/opsgenie.service.js';
+import { PricingModule } from '../pricing/pricing.module.js';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { OpsgenieProviderService } from '../integrations/providers/opsgenie.serv
     DatabaseModule,
     forwardRef(() => MemoryModule),
     forwardRef(() => IntegrationsModule),
+    PricingModule,
     BullModule.registerQueue({ name: 'telemetry' }),
     BullModule.registerQueue({ name: 'github-sync' }),
     BullModule.registerQueue({ name: 'incident-sync' }),

--- a/apps/backend/src/telemetry/telemetry.service.ts
+++ b/apps/backend/src/telemetry/telemetry.service.ts
@@ -12,6 +12,7 @@ import { DatabaseService } from '../database/database.service.js';
 import { GitHubGitService } from '../integrations/providers/github-git.service.js';
 import { IntegrationsService } from '../integrations/integrations.service.js';
 import type { TelemetryJobData } from '../queue/queue.types.js';
+import { PricingService } from '../pricing/pricing.service.js';
 import { COST_METRICS, TOKEN_METRICS, LINES_METRICS, sqlIn } from './metric-names.js';
 
 export interface TimesheetEntry {
@@ -81,6 +82,7 @@ export class TelemetryService implements OnModuleDestroy {
     @Inject(forwardRef(() => MemoryService)) private readonly memoryService: MemoryService,
     @Inject(forwardRef(() => GitHubGitService)) private readonly gitHubGitService: GitHubGitService,
     @Inject(forwardRef(() => IntegrationsService)) private readonly integrationsService: IntegrationsService,
+    private readonly pricingService: PricingService,
     @InjectQueue('telemetry') private readonly telemetryQueue: Queue<TelemetryJobData>,
   ) {
     const clickhouseUrl = this.configService.get<string>('clickhouse.url', 'http://localhost:8123');
@@ -532,8 +534,18 @@ export class TelemetryService implements OnModuleDestroy {
         }),
       ]);
       const costRows = await costResult.json<{ total_cost: number }>();
-      taskCost = Math.round(Number(costRows[0]?.total_cost ?? 0) * 100) / 100;
       const tokenRows = await tokenResult.json<{ total_tokens: number }>();
+      const baseCost = Number(costRows[0]?.total_cost ?? 0);
+
+      // Codex-derived cost in the same window. Returns 0 if no Codex sessions
+      // touched this task, so the Claude/OpenCode path is unchanged for them.
+      const codexCost = await this.getCodexCostInWindow(
+        organizationId,
+        input.startedAt,
+        now.toISOString(),
+      );
+
+      taskCost = Math.round((baseCost + codexCost) * 100) / 100;
       taskTokens = Number(tokenRows[0]?.total_tokens ?? 0);
     } catch (err) {
       this.logger.warn('Failed to query task cost/token data', err);
@@ -1284,6 +1296,99 @@ export class TelemetryService implements OnModuleDestroy {
     }
   }
 
+  /**
+   * Pull aggregated Codex token counts from `otel_logs` (`codex.sse_event`)
+   * grouped by `(date, user_id, model)` and convert each row to USD via the
+   * `PricingService`. Returned as a single flat array so callers can
+   * aggregate by date OR user OR both.
+   *
+   * Codex emits per-turn token counts only — no native USD field — so this
+   * helper is the only path that produces Codex cost rows. The same backend
+   * call returns the rows used by `getCostMetrics`, `getDeveloperCostBreakdown`,
+   * and `finishTask` (window variant below) so the price-lookup happens once.
+   */
+  private async getCodexCostRows(
+    organizationId: string,
+    startDate?: string,
+    endDate?: string,
+    teamId?: string,
+  ): Promise<Array<{ date: string; userId: string; cost: number }>> {
+    try {
+      const params: Record<string, string> = { organizationId };
+      let dateFilter = '';
+      if (startDate) { dateFilter += ` AND Timestamp >= {startDate: DateTime64(3)}`; params.startDate = TelemetryService.dt(startDate); }
+      if (endDate) { dateFilter += ` AND Timestamp <= {endDate: DateTime64(3)}`; params.endDate = TelemetryService.dtEnd(endDate); }
+      const teamFilter = teamId ? ` AND LogAttributes['team_id'] = {teamId: String}` : '';
+      if (teamId) params.teamId = teamId;
+
+      const resultSet = await this.client.query({
+        query: `
+          SELECT
+            toString(toDate(Timestamp)) AS date,
+            LogAttributes['user.account_uuid'] AS user_id,
+            LogAttributes['model'] AS model,
+            sum(toFloat64OrZero(LogAttributes['input_token_count'])) AS input_tokens,
+            sum(toFloat64OrZero(LogAttributes['output_token_count'])) AS output_tokens,
+            sum(toFloat64OrZero(LogAttributes['cached_token_count'])) AS cached_tokens,
+            sum(toFloat64OrZero(LogAttributes['reasoning_token_count'])) AS reasoning_tokens
+          FROM otel_logs
+          WHERE ResourceAttributes['organization_id'] = {organizationId: String}
+            AND LogAttributes['event.name'] = 'codex.sse_event'
+            ${dateFilter}
+            ${teamFilter}
+          GROUP BY date, user_id, model
+        `,
+        query_params: params,
+        format: 'JSONEachRow',
+      });
+
+      const rows = await resultSet.json<{
+        date: string;
+        user_id: string;
+        model: string;
+        input_tokens: number;
+        output_tokens: number;
+        cached_tokens: number;
+        reasoning_tokens: number;
+      }>();
+
+      const out: Array<{ date: string; userId: string; cost: number }> = [];
+      for (const r of rows) {
+        const cost = await this.pricingService.computeCost(
+          {
+            input: Number(r.input_tokens) || 0,
+            output: Number(r.output_tokens) || 0,
+            cached: Number(r.cached_tokens) || 0,
+            reasoning: Number(r.reasoning_tokens) || 0,
+          },
+          r.model,
+          organizationId,
+        );
+        if (cost > 0) {
+          out.push({ date: r.date, userId: r.user_id ?? '', cost });
+        }
+      }
+      return out;
+    } catch (err) {
+      this.logger.warn(`Failed to get Codex cost rows: ${err}`);
+      Sentry.captureException(err, { tags: { operation: 'telemetry-codex-cost-rows' } });
+      return [];
+    }
+  }
+
+  /**
+   * Sum of Codex-derived USD cost within a task time window. Used by
+   * `finishTask` to roll the Codex contribution into `taskCost`.
+   */
+  private async getCodexCostInWindow(
+    organizationId: string,
+    start: string,
+    end: string,
+  ): Promise<number> {
+    const rows = await this.getCodexCostRows(organizationId, start, end);
+    return rows.reduce((sum, r) => sum + r.cost, 0);
+  }
+
   async getCostMetrics(
     organizationId: string,
     startDate?: string,
@@ -1317,10 +1422,25 @@ export class TelemetryService implements OnModuleDestroy {
       });
 
       const rows = await resultSet.json<{ date: string; total_cost: number }>();
-      return rows.map((r) => ({
-        date: r.date,
-        totalCost: Math.round(Number(r.total_cost) * 100) / 100,
-      }));
+
+      // Merge in Codex-derived cost (tokens × pricing table). Empty when no
+      // Codex sessions are present, so no-op for existing Claude/OpenCode-only
+      // installs.
+      const codexRows = await this.getCodexCostRows(organizationId, startDate, endDate, teamId);
+      const byDate = new Map<string, number>();
+      for (const r of rows) {
+        byDate.set(r.date, Number(r.total_cost) || 0);
+      }
+      for (const r of codexRows) {
+        byDate.set(r.date, (byDate.get(r.date) ?? 0) + r.cost);
+      }
+
+      return [...byDate.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, totalCost]) => ({
+          date,
+          totalCost: Math.round(totalCost * 100) / 100,
+        }));
     } catch (err) {
       this.logger.warn(`Failed to get cost metrics: ${err}`);
       Sentry.captureException(err, { tags: { operation: 'telemetry-cost-metrics' } });
@@ -1385,15 +1505,31 @@ export class TelemetryService implements OnModuleDestroy {
       const costRows = await costResult.json<{ user_id: string; total_cost: number }>();
       const devRows = await devStatsResult.json<{ user_id: string; task_count: number; ai_lines: number }>();
 
+      // Codex-derived cost (tokens × pricing) per user, merged with native cost
+      // metrics so Codex users show up alongside Claude/OpenCode users without
+      // a separate code path.
+      const codexRows = await this.getCodexCostRows(organizationId, startDate, endDate, teamId);
+      const codexByUser = new Map<string, number>();
+      for (const r of codexRows) {
+        if (!r.userId) continue;
+        codexByUser.set(r.userId, (codexByUser.get(r.userId) ?? 0) + r.cost);
+      }
+
       // Build dev stats lookup
       const devMap = new Map(devRows.map((r) => [r.user_id, { taskCount: Number(r.task_count), aiLines: Number(r.ai_lines) }]));
 
-      // Merge: cost rows are the primary source, enrich with dev stats
-      const allUserIds = new Set([...costRows.map((r) => r.user_id), ...devRows.map((r) => r.user_id)]);
+      // Merge: cost rows are the primary source, enrich with dev stats + Codex
+      const allUserIds = new Set([
+        ...costRows.map((r) => r.user_id),
+        ...devRows.map((r) => r.user_id),
+        ...codexByUser.keys(),
+      ]);
       return [...allUserIds].map((userId) => {
         const cost = costRows.find((r) => r.user_id === userId);
         const dev = devMap.get(userId);
-        const totalCost = Math.round(Number(cost?.total_cost ?? 0) * 100) / 100;
+        const totalCost = Math.round(
+          (Number(cost?.total_cost ?? 0) + (codexByUser.get(userId) ?? 0)) * 100,
+        ) / 100;
         const aiLines = dev?.aiLines ?? 0;
         return {
           userId,

--- a/packages/database/src/migrations/0014_model_prices.sql
+++ b/packages/database/src/migrations/0014_model_prices.sql
@@ -1,0 +1,37 @@
+-- Model price table for agents that emit raw token counts (Codex CLI) but no
+-- native USD cost field. Backend computes `cost = tokens × rate / 1M` at query
+-- time, joining the agent's emitted `model` attribute against this table.
+-- Claude Code and OpenCode emit pre-computed USD via `*.cost.usage` metrics
+-- and bypass this table entirely; rows here are advisory for those agents.
+--
+-- Per-org overrides live in `organizations.settings.modelPriceOverrides` (the
+-- existing JSONB column). PricingService reads the override first, falls back
+-- to the row here.
+--
+-- Seeded rates are approximate as of 2026-05 and flagged `source = 'seed'`.
+-- Admins should verify against provider pricing pages and update via the
+-- `PATCH /api/admin/model-prices/:modelName` endpoint or direct SQL before
+-- relying on cost reports for billing-grade accuracy.
+
+CREATE TABLE IF NOT EXISTS model_prices (
+  model_name        TEXT PRIMARY KEY,
+  provider          TEXT NOT NULL,
+  input_per_1m      NUMERIC(10, 4) NOT NULL,
+  output_per_1m     NUMERIC(10, 4) NOT NULL,
+  cached_per_1m     NUMERIC(10, 4),
+  reasoning_per_1m  NUMERIC(10, 4),
+  currency          TEXT NOT NULL DEFAULT 'USD',
+  source            TEXT NOT NULL DEFAULT 'seed',
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_prices_provider ON model_prices (provider);
+
+INSERT INTO model_prices (model_name, provider, input_per_1m, output_per_1m, cached_per_1m, reasoning_per_1m) VALUES
+  ('claude-opus-4-7',   'anthropic', 15.00, 75.00, 1.50, NULL),
+  ('claude-sonnet-4-6', 'anthropic',  3.00, 15.00, 0.30, NULL),
+  ('claude-haiku-4-5',  'anthropic',  1.00,  5.00, 0.10, NULL),
+  ('gpt-5',             'openai',     5.00, 40.00, 0.50, 20.00),
+  ('gpt-5-codex',       'openai',     5.00, 40.00, 0.50, 20.00),
+  ('gpt-4o',            'openai',     2.50, 10.00, 0.25, NULL)
+ON CONFLICT (model_name) DO NOTHING;

--- a/packages/types/src/org.ts
+++ b/packages/types/src/org.ts
@@ -65,6 +65,17 @@ export interface InviteMemberDto {
   readonly role: MembershipRole;
 }
 
+export interface ModelPriceOverride {
+  /** USD per 1M input tokens. Overrides the global model_prices row. */
+  readonly inputPer1M?: number;
+  /** USD per 1M output tokens. */
+  readonly outputPer1M?: number;
+  /** USD per 1M cache-hit tokens. Optional — not all models have a cache discount. */
+  readonly cachedPer1M?: number;
+  /** USD per 1M reasoning tokens. Optional — only emitted by reasoning models. */
+  readonly reasoningPer1M?: number;
+}
+
 export interface OrgSettings {
   /** Fully-loaded hourly cost of one developer in USD. Default: 75 */
   readonly developerHourlyRate?: number;
@@ -76,6 +87,13 @@ export interface OrgSettings {
   readonly draftRetentionDays?: number;
   /** Optional monthly AI cost budget in the org's currency. Null = no budget. */
   readonly monthlyAICostBudget?: number;
+  /**
+   * Per-model price overrides for agents that emit raw token counts (e.g. Codex
+   * CLI). Keyed by model name. Falls back to the global `model_prices` table
+   * when not set. Each field is optional so admins can override one rate
+   * (e.g. just the input rate) without re-specifying the rest.
+   */
+  readonly modelPriceOverrides?: Record<string, ModelPriceOverride>;
 }
 
 export interface TeamSettings {


### PR DESCRIPTION
## Summary

Completes the deferred half of v0.6 (#88). Codex CLI emits raw token counts on `codex.sse_event` log events but no native USD field. Claude Code and OpenCode emit `*.cost.usage` metrics pre-computed in USD. To show Codex on the same cost dashboards, the backend now converts `tokens × $/1M-tokens = USD` at query time via a Postgres pricing table.

## What's new

| Layer | Change |
|---|---|
| Migration | `packages/database/src/migrations/0014_model_prices.sql` — schema + seeded rates (approximate 2026-05) for 6 common models |
| Types | `OrgSettings.modelPriceOverrides?: Record<string, ModelPriceOverride>` (per-org rate override in existing JSONB) |
| Backend module | `apps/backend/src/pricing/` — `PricingService` + admin controller, 5-min in-process cache |
| Telemetry queries | `getCostMetrics`, `getDeveloperCostBreakdown`, `finishTask` now UNION Codex token-derived cost with the existing native cost metrics |

Resolution order in `PricingService.getModelPrice(model, orgId?)`:
1. Per-org override from `organizations.settings.modelPriceOverrides[model]`
2. Global default from `model_prices` Postgres row
3. `null` → cost contribution is `$0`, missing-model warning logged once

Admin endpoints at `GET / PATCH /api/admin/model-prices` (auth-gated to OWNER/ADMIN). PATCH invalidates the cache synchronously so edits land immediately.

## Why it's not "just hardcode the prices"

- Provider rates change. Hardcoded values mean a deploy for every adjustment. SQL-editable + admin PATCH endpoint = no redeploy.
- Per-org overrides for teams on custom enterprise contracts.
- Future tokens-only agents (Gemini CLI, etc.) slot in by adding one row.

## What's NOT in this PR (v0.8 follow-up)

- Historical pricing (`effective_from` dates affecting past metric rows) — current rate retroactively applied, fine for estimate-grade reporting
- Frontend admin UI — use `PATCH` endpoint or SQL
- Automated fetcher polling provider pricing pages
- Multi-currency conversion (column exists, logic treats everything as USD)
- `agent` dimension tag at ingest + dashboard filter

## Dependency

This PR depends on #88 (Codex `[otel]` native OTLP) being merged for the Codex `codex.sse_event` log rows to actually exist in ClickHouse. Without #88, the Codex query returns empty and the merged cost is identical to today's Claude/OpenCode-only path. The two PRs can merge in either order — neither breaks the other.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] `packages/types` `tsc --noEmit` clean
- [x] Migration uses `CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING` so re-running is safe
- [ ] Apply migration on dev DB; `SELECT * FROM model_prices` shows seeded rows
- [ ] `GET /api/admin/model-prices` (as OWNER) returns the rows
- [ ] `PATCH /api/admin/model-prices/gpt-5` with `{ "inputPer1M": 6.00 }` updates the row, `source = 'admin'`
- [ ] After #88 merges + a Codex install fires `codex.sse_event` rows: `GET /api/telemetry/cost-metrics` includes Codex-derived cost in daily totals
- [ ] Same: `GET /api/telemetry/developer-cost` shows non-zero `totalCost` for a Codex-only user
- [ ] Same: `/finish` on a Codex task returns `taskCost > 0`
- [ ] Per-org override: `PATCH /api/organizations/:id` with `settings.modelPriceOverrides['gpt-5'] = { inputPer1M: 4.00 }` — that org's cost queries reflect the override, other orgs see the global rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)